### PR TITLE
chore: fix README screenshot layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ The frontend for [3D Print Log](https://3dprintlog.com) — a web application fo
 
 **Live app:** https://3dprintlog.com
 
-<p align="center">
-  <img src="src/assets/Homepage_PrinterList_fd6e7f73bf3f.png" alt="Print log" height="400" />
-  <img src="src/assets/Homepage_Filament_34b0aa09478611.png" alt="Materials" height="400" />
-  <img src="src/assets/Homepage_Analytics_56744e5428bda.png" alt="Analytics" height="400" />
-</p>
+<table align="center"><tr>
+  <td><img src="src/assets/Homepage_PrinterList_fd6e7f73bf3f.png" alt="Print log" height="300" /></td>
+  <td><img src="src/assets/Homepage_Filament_34b0aa09478611.png" alt="Materials" height="300" /></td>
+  <td><img src="src/assets/Homepage_Analytics_56744e5428bda.png" alt="Analytics" height="300" /></td>
+</tr></table>
 
 ## Features
 


### PR DESCRIPTION
## Summary

Fixes the three homepage screenshots wrapping across two rows. Switches from inline images (which wrap based on available width) to a single-row HTML table, and reduces height from 400px to 300px so they don't dominate the page.

## Test plan

- [ ] Verify all three screenshots appear on a single row on the GitHub repo page