### PR TITLE
feat: release v1.40.0 - Open Source

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "print-log-ui",
-  "version": "1.39.0",
+  "version": "1.40.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --ssl --host 0.0.0.0 ",

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -28,6 +28,34 @@ export class VersionReleaseNoteDialogService {
   private readonly LOCAL_STORAGE_KEY = 'LastLoggedInVersion';
 
   private releaseNotes: ReleaseNoteHistory = {
+    '1.40.0': {
+      title: '1.40.0 - Open Source',
+      body: `<p>
+<strong>3D Print Log is now open source!</strong> After years of requests, the full source code for both the UI and API are publicly available on GitHub. Whether you want to self-host, contribute a feature, or just explore how it works — you're warmly invited.
+</p>
+<p>
+  Find the code at <a href="https://github.com/HoffmanEngineering/3d-print-log-ui" rel="noreferrer noopener" target="_blank">3d-print-log-ui</a> and <a href="https://github.com/HoffmanEngineering/3d-print-log-api" rel="noreferrer noopener" target="_blank">3d-print-log-api</a> on GitHub. Issues, feature requests, and pull requests are all welcome!
+</p>
+<p>
+  <strong>Support development of 3D Print Log:</strong><br />
+  <a href="/subscription">Subscribe to Pro</a> for an ad-free experience and extra cloud storage,
+  buy me a coffee by <a
+    href="https://paypal.me/hoffmanengineering"
+    rel="noreferrer noopener"
+    target="_blank"
+    >donating via PayPal</a
+  >, or by becoming a
+  <a
+    href="https://www.patreon.com/HoffmanEngineering"
+    rel="noreferrer noopener"
+    target="_blank"
+  >
+    Patron of Hoffman Engineering</a
+  >
+  on Patreon.com
+  </p><p>Share <strong>3D Print Log</strong> with a friend, and Happy Printing!
+</p>`,
+    },
     '1.39.0': {
       title: '1.39.0 - Electricity Cost Tracking',
       body: `<p>

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -31,7 +31,7 @@ export class VersionReleaseNoteDialogService {
     '1.40.0': {
       title: '1.40.0 - Open Source',
       body: `<p>
-<strong>3D Print Log is now open source!</strong> After years of requests, the full source code for both the UI and API are publicly available on GitHub. Whether you want to self-host, contribute a feature, or just explore how it works — you're warmly invited.
+<strong>3D Print Log is now open source!</strong> After years of requests, the full source code for both the UI and API are publicly available on GitHub. Whether you want to self-host, contribute a feature, or just explore how it works, the community is open to everyone.
 </p>
 <p>
   Find the code at <a href="https://github.com/HoffmanEngineering/3d-print-log-ui" rel="noreferrer noopener" target="_blank">3d-print-log-ui</a> and <a href="https://github.com/HoffmanEngineering/3d-print-log-api" rel="noreferrer noopener" target="_blank">3d-print-log-api</a> on GitHub. Issues, feature requests, and pull requests are all welcome!

--- a/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
+++ b/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
@@ -2,6 +2,40 @@
   <h2>Release Notes</h2>
   <hr />
 
+  <h3 id="v1.40.0">1.40.0 - Open Source</h3>
+  <p>
+    <strong>3D Print Log is now open source!</strong> After years of requests,
+    the full source code for both the UI and API are publicly available on
+    GitHub. Whether you want to self-host, contribute a feature, report a bug,
+    or simply explore how it all works — you're warmly invited to get involved.
+  </p>
+  <h4>Full List of Changes:</h4>
+  <ul>
+    <li>
+      <strong>UI Repository</strong> - The Angular frontend is available at
+      <a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui"
+        rel="noreferrer noopener"
+        target="_blank"
+        >github.com/HoffmanEngineering/3d-print-log-ui</a
+      >. Contributions, bug reports, and feature requests are welcome!
+    </li>
+    <li>
+      <strong>API Repository</strong> - The backend API is available at
+      <a
+        href="https://github.com/HoffmanEngineering/3d-print-log-api"
+        rel="noreferrer noopener"
+        target="_blank"
+        >github.com/HoffmanEngineering/3d-print-log-api</a
+      >. Pull requests and issues are open to the community.
+    </li>
+    <li>
+      <strong>How to Contribute</strong> - Open an issue to discuss a feature or
+      bug, then submit a pull request. All skill levels are welcome — from
+      typo fixes to full features.
+    </li>
+  </ul>
+
   <h3 id="v1.39.0">1.39.0 - Electricity Cost Tracking</h3>
   <p>
     This release adds <strong>Electricity Cost Tracking</strong>! Set your


### PR DESCRIPTION
## Summary
- Bumps version to 1.40.0
- Adds release notes announcing the open-source launch of both the UI and API repos
- Adds version dialog entry that will display to users on first login after the update

## Test plan
- [ ] Release notes page shows the 1.40.0 section at the top with correct links to both repos
- [ ] Login dialog shows the open-source announcement with correct repo links
- [ ] Version bumped to 1.40.0 in package.json