### PR TITLE
fix: show existing project and allow removal in print edit form

### DIFF
--- a/cypress/e2e/projects/projects.cy.ts
+++ b/cypress/e2e/projects/projects.cy.ts
@@ -103,6 +103,79 @@ describe('Projects', () => {
       });
   });
 
+  it('should show the assigned project name when re-entering the print edit page', () => {
+    const ts = new Date().getTime();
+    const projectName = 'Edit Display Test Project - ' + ts;
+
+    cy.intercept('POST', '/api/Projects').as('createProject');
+    cy.visit('/projects/new');
+    cy.get('[data-testid="name-input"]').type(projectName);
+    cy.get('[data-cy="project-save-btn"]').click();
+    cy.wait('@createProject');
+
+    cy.visit('/prints');
+    cy.get('[cy-print-row]')
+      .first()
+      .invoke('attr', 'cy-print-row')
+      .then((printId) => {
+        cy.visit(`/prints/${printId}`);
+        cy.get('button[data-cy-edit-btn]').click();
+
+        cy.intercept('PUT', '/api/Prints/*').as('assignPrint');
+        cy.get('[data-cy="project-selector-input"]').clear().type(projectName);
+        cy.get('mat-option').contains(projectName).click();
+        cy.get('#edit-print-submit-btn').click();
+        cy.wait('@assignPrint');
+
+        cy.visit(`/prints/${printId}`);
+        cy.get('button[data-cy-edit-btn]').click();
+
+        cy.get('[data-cy="project-selector-input"]').should(
+          'have.value',
+          projectName
+        );
+        cy.get('button[aria-label="Clear"]').should('be.visible');
+      });
+  });
+
+  it('should allow removing a print from a project via the clear button', () => {
+    const ts = new Date().getTime();
+    const projectName = 'Remove Test Project - ' + ts;
+
+    cy.intercept('POST', '/api/Projects').as('createProject');
+    cy.visit('/projects/new');
+    cy.get('[data-testid="name-input"]').type(projectName);
+    cy.get('[data-cy="project-save-btn"]').click();
+    cy.wait('@createProject');
+
+    cy.visit('/prints');
+    cy.get('[cy-print-row]')
+      .first()
+      .invoke('attr', 'cy-print-row')
+      .then((printId) => {
+        cy.visit(`/prints/${printId}`);
+        cy.get('button[data-cy-edit-btn]').click();
+
+        cy.intercept('PUT', '/api/Prints/*').as('assignPrint');
+        cy.get('[data-cy="project-selector-input"]').clear().type(projectName);
+        cy.get('mat-option').contains(projectName).click();
+        cy.get('#edit-print-submit-btn').click();
+        cy.wait('@assignPrint');
+
+        cy.visit(`/prints/${printId}`);
+        cy.get('button[data-cy-edit-btn]').click();
+
+        cy.intercept('PUT', '/api/Prints/*').as('removePrint');
+        cy.get('button[aria-label="Clear"]').click();
+        cy.get('#edit-print-submit-btn').click();
+        cy.wait('@removePrint');
+
+        cy.get(`[cy-print-row="${printId}"]`).within(() => {
+          cy.get('[data-cy="project-chip"]').should('not.exist');
+        });
+      });
+  });
+
   it('should display the project in Grouped View', () => {
     const projectName = 'Grouped Test Project - ' + new Date().getTime();
 

--- a/src/app/shared/project-selector/project-selector.component.spec.ts
+++ b/src/app/shared/project-selector/project-selector.component.spec.ts
@@ -8,6 +8,7 @@ import { ProjectSelectorComponent } from './project-selector.component';
 import {
   ProjectService,
   ProjectSummaryDto,
+  ProjectDetailDto,
   ProjectStatus,
   ProjectViewStatus,
 } from 'src/app/core/services/project.service';
@@ -37,13 +38,20 @@ describe('ProjectSelectorComponent', () => {
   beforeEach(async () => {
     mockProjectService = jasmine.createSpyObj<ProjectService>(
       'ProjectService',
-      ['getProjectSummaries']
+      ['getProjectSummaries', 'getProjectById']
     );
     mockProjectService.getProjectSummaries.and.returnValue(
       of({
         items: mockProjects,
         paging: { totalCount: 1, currentPage: 1, pageSize: 25, totalPages: 1 },
       })
+    );
+    mockProjectService.getProjectById.and.returnValue(
+      of({
+        id: 'abc',
+        name: 'Voron Build',
+        status: ProjectStatus.InProgress,
+      } as ProjectDetailDto)
     );
 
     await TestBed.configureTestingModule({
@@ -109,6 +117,69 @@ describe('ProjectSelectorComponent', () => {
     );
     fixture.componentInstance.clearProject();
     tick(250); // debounce from setValue('')
+    expect(emitted[0]).toBeNull();
+  }));
+
+  it('should initialize selectedProject signal when initial project inputs are provided', fakeAsync(() => {
+    fixture.componentRef.setInput('initialProjectId', 'abc');
+    fixture.componentRef.setInput('initialProjectName', 'Voron Build');
+    fixture.detectChanges();
+    tick(250);
+
+    const selected = fixture.componentInstance.selectedProject();
+    expect(selected).not.toBeNull();
+    expect(selected?.type).toBe('existing');
+    if (selected?.type === 'existing') {
+      expect(selected.projectId).toBe('abc');
+      expect(selected.projectName).toBe('Voron Build');
+    }
+    expect(fixture.componentInstance.searchControl.value).toBe('Voron Build');
+  }));
+
+  it('should show clear button when initial project is provided', fakeAsync(() => {
+    fixture.componentRef.setInput('initialProjectId', 'abc');
+    fixture.componentRef.setInput('initialProjectName', 'Voron Build');
+    fixture.detectChanges();
+    tick(250);
+    fixture.detectChanges();
+
+    const clearButton = fixture.nativeElement.querySelector(
+      'button[aria-label="Clear"]'
+    );
+    expect(clearButton).not.toBeNull();
+  }));
+
+  it('should fetch project by id and initialize when only initialProjectId is provided', fakeAsync(() => {
+    fixture.componentRef.setInput('initialProjectId', 'abc');
+    fixture.detectChanges();
+    tick(250);
+    fixture.detectChanges();
+
+    expect(mockProjectService.getProjectById).toHaveBeenCalledWith('abc');
+    const selected = fixture.componentInstance.selectedProject();
+    expect(selected).not.toBeNull();
+    expect(selected?.type).toBe('existing');
+    if (selected?.type === 'existing') {
+      expect(selected.projectId).toBe('abc');
+      expect(selected.projectName).toBe('Voron Build');
+    }
+    expect(fixture.componentInstance.searchControl.value).toBe('Voron Build');
+  }));
+
+  it('should clear selectedProject and emit null when clear button clicked after initial project', fakeAsync(() => {
+    fixture.componentRef.setInput('initialProjectId', 'abc');
+    fixture.componentRef.setInput('initialProjectName', 'Voron Build');
+    fixture.detectChanges();
+    tick(250);
+
+    const emitted: any[] = [];
+    fixture.componentInstance.projectSelected.subscribe((v: any) =>
+      emitted.push(v)
+    );
+    fixture.componentInstance.clearProject();
+    tick(250);
+
+    expect(fixture.componentInstance.selectedProject()).toBeNull();
     expect(emitted[0]).toBeNull();
   }));
 });

--- a/src/app/shared/project-selector/project-selector.component.ts
+++ b/src/app/shared/project-selector/project-selector.component.ts
@@ -69,10 +69,20 @@ export class ProjectSelectorComponent implements OnInit {
   isDefaultView = signal(true);
 
   ngOnInit(): void {
-    if (this.initialProjectId() && this.initialProjectName()) {
-      this.searchControl.setValue(this.initialProjectName()!, {
-        emitEvent: false,
-      });
+    if (this.initialProjectId()) {
+      if (this.initialProjectName()) {
+        this.applyInitialProject(
+          this.initialProjectId()!,
+          this.initialProjectName()!
+        );
+      } else {
+        this.projectService
+          .getProjectById(this.initialProjectId()!)
+          .pipe(takeUntilDestroyed(this.destroyRef))
+          .subscribe((project) => {
+            this.applyInitialProject(project.id, project.name, project.status);
+          });
+      }
     }
 
     this.searchControl.valueChanges
@@ -101,6 +111,21 @@ export class ProjectSelectorComponent implements OnInit {
           q.length > 0 && !result.items.some((p) => p.name.toLowerCase() === q)
         );
       });
+  }
+
+  private applyInitialProject(
+    projectId: string,
+    projectName: string,
+    projectStatus?: ProjectStatus
+  ): void {
+    const initial: ProjectSelection = {
+      type: 'existing',
+      projectId,
+      projectName,
+      projectStatus,
+    };
+    this.selectedProject.set(initial);
+    this.searchControl.setValue(projectName, { emitEvent: false });
   }
 
   selectExistingProject(project: ProjectSummaryDto): void {


### PR DESCRIPTION
## Summary

Fixes #30

- **Bug 1 fixed:** When editing a print assigned to a project, the Project field now correctly displays the project name. The edit API endpoint returns `projectId` but not `projectName`, so the component now fetches the project by ID on init to resolve the name.
- **Bug 2 fixed:** The × clear button now appears next to the project name, allowing users to remove the project assignment. This button was always in the template but was guarded by `selectedProject()` signal, which was never initialized — fixed as a side-effect of Bug 1.

## Root Cause

`ProjectSelectorComponent.ngOnInit()` set the text input value but never initialized the `selectedProject` signal. With `selectedProject` always `null`, the clear button never rendered.

Additionally, the print edit API returns `projectId` but omits `projectName`, so the fast-path (both inputs present) would never have triggered. The component now falls back to `getProjectById()` when name is missing.

## Test plan

- [ ] Open a print that belongs to a project → Project field shows the project name
- [ ] The × button appears next to the project name
- [ ] Click × → field clears, project is removed on save
- [ ] Select a different project from the dropdown → saves correctly
- [ ] Prints with no project → field remains empty (no regression)
- [ ] All 497 unit tests pass