### PR TITLE
Release 1.41.0 - Multi-Color Materials

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,7 @@ Thumbs.db
 cypress.env.json
 
 # Internal planning and design docs — keep local, not for the public repo
-docs/
+/docs/
 
 # Git worktrees
 .worktrees/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "print-log-ui",
-  "version": "1.40.0",
+  "version": "1.41.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --ssl --host 0.0.0.0 ",

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -28,6 +28,31 @@ export class VersionReleaseNoteDialogService {
   private readonly LOCAL_STORAGE_KEY = 'LastLoggedInVersion';
 
   private releaseNotes: ReleaseNoteHistory = {
+    '1.41.0': {
+      title: '1.41.0 - Multi-Color Materials',
+      body: `<p>
+<strong>Multi-Color Material Support</strong> is here! Materials now support color patterns (solid, multi, gradient, and rainbow), finish types (standard, silk, and matte), and special effects (sparkle, glow-in-the-dark, translucent, carbon fiber, wood fill, metal fill, fluorescent, and glass fiber). Swatches throughout the app now render as rich gradient previews that reflect your filament's actual appearance, including the materials list, print list, printer list, and print detail pages.
+</p>
+<p>
+  <strong>Support development of 3D Print Log:</strong><br />
+  <a href="/subscription">Subscribe to Pro</a> for an ad-free experience and extra cloud storage,
+  buy me a coffee by <a
+    href="https://paypal.me/hoffmanengineering"
+    rel="noreferrer noopener"
+    target="_blank"
+    >donating via PayPal</a
+  >, or by becoming a
+  <a
+    href="https://www.patreon.com/HoffmanEngineering"
+    rel="noreferrer noopener"
+    target="_blank"
+  >
+    Patron of Hoffman Engineering</a
+  >
+  on Patreon.com
+  </p><p>Share <strong>3D Print Log</strong> with a friend, and Happy Printing!
+</p>`,
+    },
     '1.40.0': {
       title: '1.40.0 - Open Source',
       body: `<p>

--- a/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
+++ b/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
@@ -2,6 +2,55 @@
   <h2>Release Notes</h2>
   <hr />
 
+  <h3 id="v1.41.0">1.41.0 - Multi-Color Materials</h3>
+  <p>
+    This release brings <strong>Multi-Color Material Support</strong> to 3D Print Log! Materials
+    now support color patterns (solid, multi, gradient, and rainbow), finish types (standard, silk,
+    and matte), and special effects (sparkle, glow-in-the-dark, translucent, carbon fiber, wood
+    fill, metal fill, fluorescent, and glass fiber). Filament swatches throughout the app in the
+    materials list, print list, print detail, and printer pages now render as rich gradient
+    previews that reflect your filament's actual appearance.
+  </p>
+  <h4>Full List of Changes:</h4>
+  <ul>
+    <li>
+      <strong>Multi-Color Material Support</strong> - Materials now support color patterns (solid,
+      multi, gradient, rainbow), finish types (standard, silk, matte), and special effects
+      (sparkle, glow-in-the-dark, translucent, carbon fiber, wood fill, metal fill, fluorescent,
+      glass fiber). Set these on the <a routerLink="/materials">Materials</a> page when adding or
+      editing a filament.
+      (<a href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/32" rel="noreferrer noopener" target="_blank">PR #32</a>)
+    </li>
+    <li>
+      <strong>Gradient Swatches</strong> - Color swatches throughout the app (materials list,
+      print list, printer list, print detail) now render as gradient previews for multi-color
+      filaments, giving you an accurate visual representation of your filament.
+      (<a href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/32" rel="noreferrer noopener" target="_blank">PR #32</a>)
+    </li>
+    <li>
+      <strong>Color and Appearance Filters</strong> - The materials page now supports filtering
+      by color pattern, finish type, and effects to help you find the right filament quickly.
+      (<a href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/32" rel="noreferrer noopener" target="_blank">PR #32</a>)
+    </li>
+    <li>
+      <strong>Material Icon Updates</strong> - The filament spool and resin bottle icons now
+      render multi-color patterns and effect overlays to visually represent your filament's
+      appearance.
+      (<a href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/32" rel="noreferrer noopener" target="_blank">PR #32</a>)
+    </li>
+    <li>
+      <strong>Bug Fix: Project Selector</strong> - Fixed a bug where editing a print with an
+      existing project assigned would not correctly display the selected project in the project
+      selector.
+      (<a href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/31" rel="noreferrer noopener" target="_blank">PR #31</a>)
+    </li>
+    <li>
+      <strong>Angular 21 Upgrade</strong> - Upgraded to Angular 21, which includes various
+      performance improvements and security enhancements.
+      (<a href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/29" rel="noreferrer noopener" target="_blank">PR #29</a>)
+    </li>
+  </ul>
+
   <h3 id="v1.40.0">1.40.0 - Open Source</h3>
   <p>
     <strong>3D Print Log is now open source!</strong> After years of requests,


### PR DESCRIPTION
## Summary

- Bumps version to 1.41.0
- Adds release notes for multi-color material support (color patterns, finish types, effects), gradient swatches, color & appearance filters, material icon updates, project selector bug fix, and Angular 21 upgrade
- Fixes `.gitignore` to anchor `docs/` rule to repo root so new files under `src/app/documentation/docs/` are not silently ignored

## Test plan

- [ ] Verify release notes page shows the 1.41.0 section with correct content and PR links
- [ ] Verify the release note dialog appears for users on first login after upgrade with the multi-color materials blurb
- [ ] Confirm `package.json` version is `1.41.0`