### PR TITLE
feat: preferred filament display unit setting

### DIFF
--- a/cypress/e2e/filament-usage/filament-usage.cy.ts
+++ b/cypress/e2e/filament-usage/filament-usage.cy.ts
@@ -38,6 +38,8 @@ describe('Filament Usage', () => {
     cy.wait('@getFilamentsModal');
     cy.get('[data-cy-filament-row]').should('have.length.greaterThan', 0);
     cy.get('[data-cy-filament-row]').first().click();
+    cy.get('#edit-print-actual-measure-type-0').click();
+    cy.contains('mat-option', 'Weight').click();
     cy.get('#edit-print-actual-filament-used-gram-0').clear().type('100');
     cy.intercept('PUT', '/api/Prints/*').as('updatePrint');
     cy.get('#edit-print-submit-btn').click();
@@ -69,6 +71,8 @@ describe('Filament Usage', () => {
     cy.wait('@getFilamentsModal1');
     cy.get('[data-cy-filament-row]').should('have.length.greaterThan', 0);
     cy.get('[data-cy-filament-row]').first().click();
+    cy.get('#edit-print-actual-measure-type-0').click();
+    cy.contains('mat-option', 'Weight').click();
     cy.get('#edit-print-actual-filament-used-gram-0').clear().type('50');
 
     cy.intercept('GET', '/api/Filaments*').as('getFilamentsModal2');
@@ -77,6 +81,8 @@ describe('Filament Usage', () => {
     cy.wait('@getFilamentsModal2');
     cy.get('[data-cy-filament-row]').should('have.length.greaterThan', 0);
     cy.get('[data-cy-filament-row]').first().click();
+    cy.get('#edit-print-actual-measure-type-1').click();
+    cy.contains('mat-option', 'Weight').click();
     cy.get('#edit-print-actual-filament-used-gram-1').clear().type('30');
 
     cy.intercept('PUT', '/api/Prints/*').as('updatePrint');

--- a/cypress/e2e/filament-usage/filament-usage.cy.ts
+++ b/cypress/e2e/filament-usage/filament-usage.cy.ts
@@ -3,6 +3,22 @@ describe('Filament Usage', () => {
     cy.login();
   });
 
+  // The new-print form may auto-fill filament entries from the printer's loaded filament,
+  // and legacy prints may produce an "Other" entry from old filamentType/filamentUsageMg
+  // fields. Both kinds have EMPTY_GUID ids (unsaved) so deleting them requires no dialog.
+  // Call this after navigating to the edit form to clear any pre-existing entries before
+  // adding test-specific ones.
+  const clearPrefilledFilamentEntries = () => {
+    // Wait for the form to finish rendering before counting entries.
+    cy.get('#add-new-filament-usage-btn').should('exist');
+    cy.get('body').then(($body) => {
+      const count = $body.find('[data-cy="delete-filament-btn"]').length;
+      for (let i = 0; i < count; i++) {
+        cy.get('[data-cy="delete-filament-btn"]').first().click();
+      }
+    });
+  };
+
   it('should track remaining weight when filament is used in a print', () => {
     const ts = new Date().getTime();
     const filamentName = 'Weight Test Filament - ' + ts;
@@ -28,8 +44,12 @@ describe('Filament Usage', () => {
 
     cy.createPrint(printTitle);
 
-    cy.contains('[cy-print-row]', printTitle).find('.mat-column-title').click();
-    cy.get('button[data-cy-edit-btn]').click();
+    cy.contains('[cy-print-row]', printTitle)
+      .invoke('attr', 'cy-print-row')
+      .then((printId) => {
+        cy.visit(`/prints/${printId}/edit`);
+      });
+    clearPrefilledFilamentEntries();
     cy.intercept('GET', '/api/Filaments*').as('getFilamentsModal');
     cy.get('#add-new-filament-usage-btn').click();
     cy.get('[data-cy="select-filament-btn"]').click();
@@ -63,8 +83,13 @@ describe('Filament Usage', () => {
 
     cy.createPrint(printTitle);
 
-    cy.contains('[cy-print-row]', printTitle).find('.mat-column-title').click();
-    cy.get('button[data-cy-edit-btn]').click();
+    cy.contains('[cy-print-row]', printTitle)
+      .invoke('attr', 'cy-print-row')
+      .then((printId) => {
+        cy.wrap(printId).as('printId');
+        cy.visit(`/prints/${printId}/edit`);
+      });
+    clearPrefilledFilamentEntries();
     cy.intercept('GET', '/api/Filaments*').as('getFilamentsModal1');
     cy.get('#add-new-filament-usage-btn').click();
     cy.get('[data-cy="select-filament-btn"]').first().click();
@@ -89,8 +114,9 @@ describe('Filament Usage', () => {
     cy.get('#edit-print-submit-btn').click();
     cy.wait('@updatePrint');
 
-    cy.contains('[cy-print-row]', printTitle).find('.mat-column-title').click();
-    cy.get('button[data-cy-edit-btn]').should('be.visible').click();
+    cy.get('@printId').then((printId) => {
+      cy.visit(`/prints/${printId}/edit`);
+    });
     cy.get('.filament-entry-card').should('have.length', 2);
   });
 
@@ -99,28 +125,37 @@ describe('Filament Usage', () => {
 
     cy.createPrint(printTitle);
 
-    cy.contains('[cy-print-row]', printTitle).find('.mat-column-title').click();
-    cy.get('button[data-cy-edit-btn]').click();
+    cy.contains('[cy-print-row]', printTitle)
+      .invoke('attr', 'cy-print-row')
+      .then((printId) => {
+        cy.wrap(printId).as('printId');
+        cy.visit(`/prints/${printId}/edit`);
+      });
+    clearPrefilledFilamentEntries();
     cy.intercept('GET', '/api/Filaments*').as('getFilamentsModal');
     cy.get('#add-new-filament-usage-btn').click();
     cy.get('[data-cy="select-filament-btn"]').click();
     cy.wait('@getFilamentsModal');
     cy.get('[data-cy-filament-row]').should('have.length.greaterThan', 0);
     cy.get('[data-cy-filament-row]').first().click();
+    cy.get('#edit-print-actual-measure-type-0').click();
+    cy.contains('mat-option', 'Weight').click();
     cy.get('#edit-print-actual-filament-used-gram-0').clear().type('50');
     cy.intercept('PUT', '/api/Prints/*').as('updatePrint');
     cy.get('#edit-print-submit-btn').click();
     cy.wait('@updatePrint');
 
-    cy.contains('[cy-print-row]', printTitle).find('.mat-column-title').click();
-    cy.get('button[data-cy-edit-btn]').should('be.visible').click();
+    cy.get('@printId').then((printId) => {
+      cy.visit(`/prints/${printId}/edit`);
+    });
     cy.get('#edit-print-actual-filament-used-gram-0').clear().type('75');
     cy.intercept('PUT', '/api/Prints/*').as('updatePrint2');
     cy.get('#edit-print-submit-btn').click();
     cy.wait('@updatePrint2');
 
-    cy.contains('[cy-print-row]', printTitle).find('.mat-column-title').click();
-    cy.get('button[data-cy-edit-btn]').should('be.visible').click();
+    cy.get('@printId').then((printId) => {
+      cy.visit(`/prints/${printId}/edit`);
+    });
     cy.get('#edit-print-actual-filament-used-gram-0').should(
       'have.value',
       '75'
@@ -132,21 +167,29 @@ describe('Filament Usage', () => {
 
     cy.createPrint(printTitle);
 
-    cy.contains('[cy-print-row]', printTitle).find('.mat-column-title').click();
-    cy.get('button[data-cy-edit-btn]').click();
+    cy.contains('[cy-print-row]', printTitle)
+      .invoke('attr', 'cy-print-row')
+      .then((printId) => {
+        cy.wrap(printId).as('printId');
+        cy.visit(`/prints/${printId}/edit`);
+      });
+    clearPrefilledFilamentEntries();
     cy.intercept('GET', '/api/Filaments*').as('getFilamentsModal');
     cy.get('#add-new-filament-usage-btn').click();
     cy.get('[data-cy="select-filament-btn"]').click();
     cy.wait('@getFilamentsModal');
     cy.get('[data-cy-filament-row]').should('have.length.greaterThan', 0);
     cy.get('[data-cy-filament-row]').first().click();
+    cy.get('#edit-print-actual-measure-type-0').click();
+    cy.contains('mat-option', 'Weight').click();
     cy.get('#edit-print-actual-filament-used-gram-0').clear().type('50');
     cy.intercept('PUT', '/api/Prints/*').as('updatePrint');
     cy.get('#edit-print-submit-btn').click();
     cy.wait('@updatePrint');
 
-    cy.contains('[cy-print-row]', printTitle).find('.mat-column-title').click();
-    cy.get('button[data-cy-edit-btn]').should('be.visible').click();
+    cy.get('@printId').then((printId) => {
+      cy.visit(`/prints/${printId}/edit`);
+    });
     cy.get('[data-cy="delete-filament-btn"]').click();
     cy.get('mat-dialog-container').contains('button', 'Delete').click();
     cy.get('.filament-entry-card').should('not.exist');
@@ -154,8 +197,9 @@ describe('Filament Usage', () => {
     cy.get('#edit-print-submit-btn').click();
     cy.wait('@updatePrint2');
 
-    cy.contains('[cy-print-row]', printTitle).find('.mat-column-title').click();
-    cy.get('button[data-cy-edit-btn]').should('be.visible').click();
+    cy.get('@printId').then((printId) => {
+      cy.visit(`/prints/${printId}/edit`);
+    });
     cy.get('.filament-entry-card').should('not.exist');
   });
 });

--- a/cypress/e2e/filaments/filament-appearance.cy.ts
+++ b/cypress/e2e/filaments/filament-appearance.cy.ts
@@ -576,7 +576,10 @@ describe('Cross-screen swatch rendering', () => {
 
     cy.createPrint(printTitle);
 
-    cy.contains('[cy-print-row]', printTitle).find('.mat-column-title').click();
+    cy.contains('[cy-print-row]', printTitle)
+      .find('.mat-column-title')
+      .first()
+      .click();
     cy.get('button[data-cy-edit-btn]').click();
 
     cy.intercept('GET', '/api/Filaments*').as('getFilaments');
@@ -628,7 +631,10 @@ describe('Cross-screen swatch rendering', () => {
 
     cy.createPrint(printTitle);
 
-    cy.contains('[cy-print-row]', printTitle).find('.mat-column-title').click();
+    cy.contains('[cy-print-row]', printTitle)
+      .find('.mat-column-title')
+      .first()
+      .click();
     cy.get('button[data-cy-edit-btn]').click();
 
     cy.intercept('GET', '/api/Filaments*').as('getFilaments');

--- a/cypress/e2e/prints/print-list-filters.cy.ts
+++ b/cypress/e2e/prints/print-list-filters.cy.ts
@@ -147,7 +147,10 @@ describe('Print List Filters', () => {
 
     cy.createPrint(printTitle);
 
-    cy.contains('[cy-print-row]', printTitle).find('.mat-column-title').click();
+    cy.contains('[cy-print-row]', printTitle)
+      .find('.mat-column-title')
+      .first()
+      .click();
     cy.get('button[data-cy-edit-btn]').click();
     cy.intercept('GET', '/api/Filaments*').as('getFilamentsModal');
     cy.get('#add-new-filament-usage-btn').click();

--- a/cypress/e2e/prints/print-list-filters.cy.ts
+++ b/cypress/e2e/prints/print-list-filters.cy.ts
@@ -156,6 +156,8 @@ describe('Print List Filters', () => {
     cy.get('#filament-list-search-input').clear().type(filamentName);
     cy.wait('@getFilamentsModal');
     cy.get('[data-cy-filament-row]').first().click();
+    cy.get('#edit-print-actual-measure-type-0').click();
+    cy.contains('mat-option', 'Weight').click();
     cy.get('#edit-print-actual-filament-used-gram-0').clear().type('50');
     cy.intercept('PUT', '/api/Prints/*').as('updatePrint');
     cy.get('#edit-print-submit-btn').click();

--- a/src/app/core/resolvers/preferred-filament-display-unit-setting-resolver.service.ts
+++ b/src/app/core/resolvers/preferred-filament-display-unit-setting-resolver.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import {
+  UserSettingService,
+  UserSettingType,
+} from 'src/app/core/services/user-setting.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PreferredFilamentDisplayUnitSettingResolverService {
+  constructor(private readonly userSettingService: UserSettingService) {}
+
+  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+    return this.userSettingService.getCurrentUsersSettingByType(
+      UserSettingType.Prints_PreferredFilamentDisplayUnit
+    );
+  }
+}

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -17,6 +17,7 @@ import { isCordova } from '../utils/platform';
 import { NotificationService } from './notification.service';
 import { SubscriptionService } from './subscription.service';
 import { ProfileViewStatus, UserDetailDto, UserService } from './user.service';
+import { UserSettingService } from './user-setting.service';
 const cordovaCallbackUri =
   'com.hoffmanengineering.printlog://cordova/com.hoffmanengineering.printlog/callback';
 
@@ -88,6 +89,7 @@ export class AuthService {
   loggedIn: boolean = null;
 
   private readonly subscriptionService = inject(SubscriptionService);
+  private readonly userSettingService = inject(UserSettingService);
 
   constructor(
     private router: Router,
@@ -270,6 +272,7 @@ export class AuthService {
     }
     // Stop notification polling
     this.notificationService.stopPolling();
+    this.userSettingService.clearCache();
 
     // Ensure Auth0 client instance exists
     this.auth0Client$.subscribe((client: Auth0Client) => {

--- a/src/app/core/services/print.service.ts
+++ b/src/app/core/services/print.service.ts
@@ -37,6 +37,7 @@ export enum PrintViewStatus {
 }
 
 export enum PrintFilamentSourceMeasurement {
+  AsRecorded = 0,
   Weight = 1,
   Length = 2,
   Volume = 3,

--- a/src/app/core/services/user-setting.service.spec.ts
+++ b/src/app/core/services/user-setting.service.spec.ts
@@ -1,27 +1,253 @@
 import { TestBed } from '@angular/core/testing';
-
-import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { UserSettingService } from './user-setting.service';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
 import {
   provideHttpClient,
   withInterceptorsFromDi,
 } from '@angular/common/http';
+import { lastValueFrom } from 'rxjs';
+import {
+  UserSettingService,
+  UserSettingType,
+  UserSettingDto,
+} from './user-setting.service';
+import { environment } from 'src/environments/environment';
+
+const apiUrl = `${environment.printLogApiUrl}/api/Users/me/user-settings`;
+
+function makeDto(overrides: Partial<UserSettingDto> = {}): UserSettingDto {
+  return {
+    id: 1,
+    userId: 10,
+    userSettingTypeId: UserSettingType.Currency_Name,
+    value: 'USD',
+    createdDate: '2024-01-01T00:00:00Z',
+    updatedDate: '2024-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
 
 describe('UserSettingService', () => {
   let service: UserSettingService;
+  let httpTesting: HttpTestingController;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [],
       providers: [
         provideHttpClient(withInterceptorsFromDi()),
         provideHttpClientTesting(),
       ],
     });
     service = TestBed.inject(UserSettingService);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('getCurrentUsersSettingByType', () => {
+    it('fetches settings on cache miss and returns matching setting', async () => {
+      const dto = makeDto({
+        userSettingTypeId: UserSettingType.Currency_Name,
+        value: 'USD',
+      });
+
+      const resultPromise = service.getCurrentUsersSettingByType(
+        UserSettingType.Currency_Name
+      );
+      httpTesting.expectOne(apiUrl).flush([dto]);
+      const result = await resultPromise;
+
+      expect(result).not.toBeNull();
+      expect(result!.userSettingTypeId).toBe(UserSettingType.Currency_Name);
+      expect(result!.value).toBe('USD');
+      expect(result!.createdDate).toBeInstanceOf(Date);
+    });
+
+    it('returns null when the requested setting type is not in the response', async () => {
+      const dto = makeDto({
+        userSettingTypeId: UserSettingType.Currency_Symbol,
+      });
+
+      const resultPromise = service.getCurrentUsersSettingByType(
+        UserSettingType.Currency_Name
+      );
+      httpTesting.expectOne(apiUrl).flush([dto]);
+      const result = await resultPromise;
+
+      expect(result).toBeNull();
+    });
+
+    it('uses the cache on subsequent calls without making additional HTTP requests', async () => {
+      const dto = makeDto();
+
+      const first = service.getCurrentUsersSettingByType(
+        UserSettingType.Currency_Name
+      );
+      httpTesting.expectOne(apiUrl).flush([dto]);
+      await first;
+
+      // Second call — no HTTP request should be made
+      await service.getCurrentUsersSettingByType(UserSettingType.Currency_Name);
+      httpTesting.expectNone(apiUrl);
+    });
+
+    it('deduplicates concurrent cache-miss requests into a single HTTP call', async () => {
+      const dtoA = makeDto({
+        id: 1,
+        userSettingTypeId: UserSettingType.Currency_Name,
+        value: 'USD',
+      });
+      const dtoB = makeDto({
+        id: 2,
+        userSettingTypeId: UserSettingType.Currency_Symbol,
+        value: '$',
+      });
+
+      // Start both calls before either resolves
+      const call1 = service.getCurrentUsersSettingByType(
+        UserSettingType.Currency_Name
+      );
+      const call2 = service.getCurrentUsersSettingByType(
+        UserSettingType.Currency_Symbol
+      );
+
+      // Only one HTTP request should exist
+      httpTesting.expectOne(apiUrl).flush([dtoA, dtoB]);
+
+      const [result1, result2] = await Promise.all([call1, call2]);
+      expect(result1!.value).toBe('USD');
+      expect(result2!.value).toBe('$');
+    });
+  });
+
+  describe('clearCache', () => {
+    it('causes the next call to fetch from the API again', async () => {
+      const dto = makeDto();
+
+      const first = service.getCurrentUsersSettingByType(
+        UserSettingType.Currency_Name
+      );
+      httpTesting.expectOne(apiUrl).flush([dto]);
+      await first;
+
+      service.clearCache();
+
+      const second = service.getCurrentUsersSettingByType(
+        UserSettingType.Currency_Name
+      );
+      httpTesting.expectOne(apiUrl).flush([dto]);
+      await second;
+    });
+  });
+
+  describe('updateUserSetting', () => {
+    it('replaces the matching setting in the cache', async () => {
+      const original = makeDto({ id: 5, value: 'USD' });
+      const prime = service.getCurrentUsersSettingByType(
+        UserSettingType.Currency_Name
+      );
+      httpTesting.expectOne(apiUrl).flush([original]);
+      await prime;
+
+      const updated = makeDto({ id: 5, value: 'EUR' });
+      const updatePromise = lastValueFrom(service.updateUserSetting(5, 'EUR'));
+      httpTesting.expectOne(apiUrl).flush(updated);
+      await updatePromise;
+
+      const result = await service.getCurrentUsersSettingByType(
+        UserSettingType.Currency_Name
+      );
+      expect(result!.value).toBe('EUR');
+    });
+
+    it('appends to the cache when the updated ID is not already present', async () => {
+      const prime = service.getCurrentUsersSettingByType(
+        UserSettingType.Currency_Name
+      );
+      httpTesting.expectOne(apiUrl).flush([]);
+      await prime;
+
+      const newSetting = makeDto({ id: 99, value: 'GBP' });
+      const updatePromise = lastValueFrom(service.updateUserSetting(99, 'GBP'));
+      httpTesting.expectOne(apiUrl).flush(newSetting);
+      await updatePromise;
+
+      const result = await service.getCurrentUsersSettingByType(
+        UserSettingType.Currency_Name
+      );
+      expect(result!.value).toBe('GBP');
+    });
+  });
+
+  describe('addUserSetting', () => {
+    it('appends a new setting to the cache', async () => {
+      const prime = service.getCurrentUsersSettingByType(
+        UserSettingType.Currency_Name
+      );
+      httpTesting.expectOne(apiUrl).flush([]);
+      await prime;
+
+      const newDto = makeDto({
+        id: 7,
+        userSettingTypeId: UserSettingType.Currency_Name,
+        value: 'CAD',
+      });
+      const addPromise = lastValueFrom(
+        service.addUserSetting(UserSettingType.Currency_Name, 'CAD')
+      );
+      httpTesting.expectOne(apiUrl).flush(newDto);
+      await addPromise;
+
+      const result = await service.getCurrentUsersSettingByType(
+        UserSettingType.Currency_Name
+      );
+      expect(result!.value).toBe('CAD');
+    });
+
+    it('replaces an existing cached setting with the same ID without corrupting other entries', async () => {
+      const existingA = makeDto({
+        id: 3,
+        userSettingTypeId: UserSettingType.Currency_Name,
+        value: 'USD',
+      });
+      const existingB = makeDto({
+        id: 4,
+        userSettingTypeId: UserSettingType.Currency_Symbol,
+        value: '$',
+      });
+      const prime = service.getCurrentUsersSettingByType(
+        UserSettingType.Currency_Name
+      );
+      httpTesting.expectOne(apiUrl).flush([existingA, existingB]);
+      await prime;
+
+      const updatedA = makeDto({
+        id: 3,
+        userSettingTypeId: UserSettingType.Currency_Name,
+        value: 'EUR',
+      });
+      const addPromise = lastValueFrom(
+        service.addUserSetting(UserSettingType.Currency_Name, 'EUR')
+      );
+      httpTesting.expectOne(apiUrl).flush(updatedA);
+      await addPromise;
+
+      const resultA = await service.getCurrentUsersSettingByType(
+        UserSettingType.Currency_Name
+      );
+      const resultB = await service.getCurrentUsersSettingByType(
+        UserSettingType.Currency_Symbol
+      );
+      expect(resultA!.value).toBe('EUR');
+      expect(resultB!.value).toBe('$');
+    });
   });
 });

--- a/src/app/core/services/user-setting.service.ts
+++ b/src/app/core/services/user-setting.service.ts
@@ -28,6 +28,7 @@ export enum UserSettingType {
   Prints_LastSelectedWireMeasureType = 11,
   Electricity_KwhRate = 12,
   Electricity_DefaultWattageW = 13,
+  Prints_PreferredFilamentDisplayUnit = 14,
 }
 
 export interface UserSetting {

--- a/src/app/core/services/user-setting.service.ts
+++ b/src/app/core/services/user-setting.service.ts
@@ -1,5 +1,5 @@
 import { HttpClient } from '@angular/common/http';
-import { Injectable } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { lastValueFrom } from 'rxjs';
 import { map, tap } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
@@ -62,38 +62,48 @@ export interface AddUserSettingDto {
   providedIn: 'root',
 })
 export class UserSettingService {
+  private readonly http = inject(HttpClient);
   private readonly baseApiUrl = `${environment.printLogApiUrl}/api/Users/me/user-settings`;
-  private userSettings: UserSetting[] = [];
-
-  constructor(private readonly http: HttpClient) {}
+  private settingsMap = new Map<UserSettingType, UserSetting>();
+  private loaded = false;
+  private loadingPromise: Promise<Map<UserSettingType, UserSetting>> | null =
+    null;
 
   public async getCurrentUsersSettingByType(
     userSettingTypeId: UserSettingType
   ): Promise<UserSetting | null> {
-    if (this.userSettings.length === 0) {
-      await lastValueFrom(this.getCurrentUsersSettings());
+    if (!this.loaded) {
+      if (!this.loadingPromise) {
+        this.loadingPromise = lastValueFrom(this.fetchSettings()).finally(
+          () => {
+            this.loadingPromise = null;
+          }
+        );
+      }
+      await this.loadingPromise;
     }
 
-    const existingSetting = this.userSettings.find(
-      (setting) => setting.userSettingTypeId === userSettingTypeId
-    );
-    return existingSetting ?? null;
+    return this.settingsMap.get(userSettingTypeId) ?? null;
   }
 
-  getCurrentUsersSettings() {
+  clearCache() {
+    this.settingsMap.clear();
+    this.loaded = false;
+    this.loadingPromise = null;
+  }
+
+  private fetchSettings() {
     return this.http.get<UserSettingDto[]>(this.baseApiUrl).pipe(
-      map((settingDto) => {
-        const newSettings: UserSetting[] = [];
-
-        for (const setting of settingDto) {
-          const newSetting: UserSetting = this.formatUserSettingDto(setting);
-
-          newSettings.push(newSetting);
+      map((dtos) => {
+        const result = new Map<UserSettingType, UserSetting>();
+        for (const dto of dtos) {
+          result.set(dto.userSettingTypeId, this.formatUserSettingDto(dto));
         }
-        return newSettings;
+        return result;
       }),
       tap((settings) => {
-        this.userSettings = settings;
+        this.settingsMap = settings;
+        this.loaded = true;
       })
     );
   }
@@ -110,23 +120,12 @@ export class UserSettingService {
   }
 
   updateUserSetting(id: number, newValue: string) {
-    const dto: UpdateUserSettingDto = {
-      id,
-      value: newValue,
-    };
+    const dto: UpdateUserSettingDto = { id, value: newValue };
 
     return this.http.put<UserSettingDto>(this.baseApiUrl, dto).pipe(
       map((settingDto) => this.formatUserSettingDto(settingDto)),
       tap((updatedSetting) => {
-        const existingSetting = this.userSettings.findIndex(
-          (u) => u.id === updatedSetting.id
-        );
-
-        if (existingSetting !== -1) {
-          this.userSettings[existingSetting] = updatedSetting;
-        } else {
-          this.userSettings.push(updatedSetting);
-        }
+        this.settingsMap.set(updatedSetting.userSettingTypeId, updatedSetting);
       })
     );
   }
@@ -139,16 +138,8 @@ export class UserSettingService {
 
     return this.http.post<UserSettingDto>(this.baseApiUrl, dto).pipe(
       map((settingDto) => this.formatUserSettingDto(settingDto)),
-      tap((updatedSetting) => {
-        const existingSetting = this.userSettings.findIndex(
-          (u) => (u.id = updatedSetting.id)
-        );
-
-        if (existingSetting !== -1) {
-          this.userSettings[existingSetting] = updatedSetting;
-        } else {
-          this.userSettings.push(updatedSetting);
-        }
+      tap((newSetting) => {
+        this.settingsMap.set(newSetting.userSettingTypeId, newSetting);
       })
     );
   }

--- a/src/app/print/edit-print-detail/edit-print-detail.component.html
+++ b/src/app/print/edit-print-detail/edit-print-detail.component.html
@@ -690,6 +690,9 @@
                             }
                           </mat-form-field>
                         }
+                        @if (getPreferredUnitSecondaryDisplay($any(printFilament), true); as secondary) {
+                          <span class="preferred-unit-hint">{{ secondary }}</span>
+                        }
                         <mat-form-field style="flex: 0 0 120px">
                           <mat-label>Measure</mat-label>
                           <mat-select
@@ -832,6 +835,9 @@
                               </mat-error>
                             }
                           </mat-form-field>
+                        }
+                        @if (getPreferredUnitSecondaryDisplay($any(printFilament), false); as secondary) {
+                          <span class="preferred-unit-hint">{{ secondary }}</span>
                         }
                         <mat-form-field style="flex: 0 0 120px">
                           <mat-label>Measure</mat-label>

--- a/src/app/print/edit-print-detail/edit-print-detail.component.html
+++ b/src/app/print/edit-print-detail/edit-print-detail.component.html
@@ -690,9 +690,6 @@
                             }
                           </mat-form-field>
                         }
-                        @if (getPreferredUnitSecondaryDisplay($any(printFilament), true); as secondary) {
-                          <span class="preferred-unit-hint">{{ secondary }}</span>
-                        }
                         <mat-form-field style="flex: 0 0 120px">
                           <mat-label>Measure</mat-label>
                           <mat-select
@@ -725,6 +722,9 @@
                           </mat-select>
                         </mat-form-field>
                       </div>
+                      @if (getPreferredUnitSecondaryDisplay($any(printFilament), true); as secondary) {
+                        <span class="preferred-unit-hint">{{ secondary }}</span>
+                      }
                       <div class="input-row">
                         @if (
                           printFilament.get('source').value ===
@@ -836,12 +836,14 @@
                             }
                           </mat-form-field>
                         }
-                        @if (getPreferredUnitSecondaryDisplay($any(printFilament), false); as secondary) {
-                          <span class="preferred-unit-hint">{{ secondary }}</span>
-                        }
                         <mat-form-field style="flex: 0 0 120px">
                           <mat-label>Measure</mat-label>
-                          <mat-select formControlName="source">
+                          <mat-select
+                            id="edit-print-actual-measure-type-{{
+                              printFilamentIndex
+                            }}"
+                            formControlName="source"
+                          >
                             <mat-option
                               [value]="
                                 printFilamentSourceMeasurementTypes.Weight
@@ -866,6 +868,9 @@
                           </mat-select>
                         </mat-form-field>
                       </div>
+                      @if (getPreferredUnitSecondaryDisplay($any(printFilament), false); as secondary) {
+                        <span class="preferred-unit-hint">{{ secondary }}</span>
+                      }
                       <mat-form-field>
                         <mat-label>
                           {{

--- a/src/app/print/edit-print-detail/edit-print-detail.component.scss
+++ b/src/app/print/edit-print-detail/edit-print-detail.component.scss
@@ -301,6 +301,14 @@ form > div {
   }
 }
 
+.preferred-unit-hint {
+  font-size: 0.75rem;
+  color: var(--mat-sys-outline);
+  display: block;
+  margin-top: -4px;
+  margin-bottom: 4px;
+}
+
 // Image drop zone styles
 .image-drop-zone {
   position: relative;

--- a/src/app/print/edit-print-detail/edit-print-detail.component.scss
+++ b/src/app/print/edit-print-detail/edit-print-detail.component.scss
@@ -305,8 +305,10 @@ form > div {
   font-size: 0.75rem;
   color: var(--mat-sys-outline);
   display: block;
-  margin-top: -4px;
-  margin-bottom: 4px;
+  // Pull hint up past mat-form-field's subscript area (~20px) and the column gap (8px)
+  margin-top: -24px;
+  margin-bottom: 8px;
+  padding-left: 16px;
 }
 
 // Image drop zone styles

--- a/src/app/print/edit-print-detail/edit-print-detail.component.spec.ts
+++ b/src/app/print/edit-print-detail/edit-print-detail.component.spec.ts
@@ -56,7 +56,10 @@ describe('EditPrintDetailComponent', () => {
 
     const mockUserSettingService = jasmine.createSpyObj<UserSettingService>(
       'UserSettingService',
-      ['updateUserSetting']
+      ['updateUserSetting', 'getCurrentUsersSettingByType']
+    );
+    mockUserSettingService.getCurrentUsersSettingByType.and.returnValue(
+      Promise.resolve(null)
     );
 
     const mockPrinterPromptService =

--- a/src/app/print/edit-print-detail/edit-print-detail.component.ts
+++ b/src/app/print/edit-print-detail/edit-print-detail.component.ts
@@ -165,7 +165,7 @@ export class EditPrintDetailComponent
   public isCordova = isCordova;
 
   public preferredFilamentUnit = signal<PrintFilamentSourceMeasurement>(
-    PrintFilamentSourceMeasurement.Weight
+    PrintFilamentSourceMeasurement.AsRecorded
   );
 
   public printDetail: PrintDetail | null = null;

--- a/src/app/print/edit-print-detail/edit-print-detail.component.ts
+++ b/src/app/print/edit-print-detail/edit-print-detail.component.ts
@@ -54,6 +54,7 @@ import {
   PrintViewStatus,
 } from '../../core/services/print.service';
 import { PrinterRedirectPromptService } from '../services/printer-redirect-prompt.service';
+import { convertFilamentValue } from 'src/app/shared/utils/filament-display.utils';
 import { ThumbnailImage } from 'src/app/shared/image-thumbnail-strip/image-thumbnail-strip.component';
 import {
   Currencies,
@@ -1921,29 +1922,44 @@ export class EditPrintDetailComponent
     const sourceField = isEstimated ? 'estimatedSource' : 'source';
     const source = formGroup.get(sourceField)
       ?.value as PrintFilamentSourceMeasurement;
+    const preferred = this.preferredFilamentUnit();
 
-    if (source === this.preferredFilamentUnit()) return null;
+    if (source === preferred) return null;
 
-    if (
-      this.preferredFilamentUnit() === PrintFilamentSourceMeasurement.Weight
-    ) {
-      const field = isEstimated ? 'estimatedAmountG' : 'amountG';
-      const v = formGroup.get(field)?.value as number | null;
-      return v != null && v > 0 ? `≈ ${v.toFixed(1)}g` : null;
+    // Get the source value in its native unit (weight stored as grams in form)
+    let sourceValueNative: number | null = null;
+    if (source === PrintFilamentSourceMeasurement.Weight) {
+      const v = formGroup.get(isEstimated ? 'estimatedAmountG' : 'amountG')
+        ?.value as number | null;
+      sourceValueNative = v != null && v > 0 ? v * 1000 : null; // g → mg
+    } else if (source === PrintFilamentSourceMeasurement.Length) {
+      const v = formGroup.get(isEstimated ? 'estimatedLengthInM' : 'lengthInM')
+        ?.value as number | null;
+      sourceValueNative = v != null && v > 0 ? v : null;
+    } else {
+      const v = formGroup.get(isEstimated ? 'estimatedVolumeMl' : 'volumeMl')
+        ?.value as number | null;
+      sourceValueNative = v != null && v > 0 ? v : null;
     }
 
-    if (
-      this.preferredFilamentUnit() === PrintFilamentSourceMeasurement.Length
-    ) {
-      const field = isEstimated ? 'estimatedLengthInM' : 'lengthInM';
-      const v = formGroup.get(field)?.value as number | null;
-      return v != null && v > 0 ? `≈ ${v.toFixed(1)}m` : null;
-    }
+    if (sourceValueNative === null) return null;
 
-    // Volume
-    const field = isEstimated ? 'estimatedVolumeMl' : 'volumeMl';
-    const v = formGroup.get(field)?.value as number | null;
-    return v != null && v > 0 ? `≈ ${v.toFixed(1)}ml` : null;
+    const filament = formGroup.get('filament')?.value as FilamentSummary | null;
+    const converted = convertFilamentValue(
+      sourceValueNative,
+      source,
+      preferred,
+      filament
+    );
+    if (converted === null) return null;
+
+    if (preferred === PrintFilamentSourceMeasurement.Weight) {
+      return `≈ ${(converted / 1000).toFixed(1)}g`;
+    }
+    if (preferred === PrintFilamentSourceMeasurement.Length) {
+      return `≈ ${converted.toFixed(1)}m`;
+    }
+    return `≈ ${converted.toFixed(1)}ml`;
   }
 
   public setStartDateToNow() {

--- a/src/app/print/edit-print-detail/edit-print-detail.component.ts
+++ b/src/app/print/edit-print-detail/edit-print-detail.component.ts
@@ -849,8 +849,10 @@ export class EditPrintDetailComponent
     }
 
     // Convert the old filamentType/FilamentUsage properties into the new Filament Usage format.
+    // Skip when modern filament usage records already exist to avoid duplicate entries.
     if (
       print &&
+      printFilamentUsageArray.length === 0 &&
       (!(print.filamentType === null || print.filamentType === '') ||
         print.filamentUsageMg > 0 ||
         print.estimatedFilamentUsageMg > 0)

--- a/src/app/print/edit-print-detail/edit-print-detail.component.ts
+++ b/src/app/print/edit-print-detail/edit-print-detail.component.ts
@@ -5,6 +5,7 @@ import {
   OnInit,
   inject,
   DestroyRef,
+  signal,
 } from '@angular/core';
 import {
   AbstractControl,
@@ -161,6 +162,10 @@ export class EditPrintDetailComponent
   };
 
   public isCordova = isCordova;
+
+  public preferredFilamentUnit = signal<PrintFilamentSourceMeasurement>(
+    PrintFilamentSourceMeasurement.Weight
+  );
 
   public printDetail: PrintDetail | null = null;
 
@@ -419,6 +424,18 @@ export class EditPrintDetailComponent
       this.getEstimatedCompletedDate();
       this.getActualCompletedDate();
     });
+
+    this.userSettingService
+      .getCurrentUsersSettingByType(
+        UserSettingType.Prints_PreferredFilamentDisplayUnit
+      )
+      .then((setting) => {
+        if (setting) {
+          this.preferredFilamentUnit.set(
+            +setting.value as PrintFilamentSourceMeasurement
+          );
+        }
+      });
 
     /**
      * Show the Add Printer prompt if needed.
@@ -1895,6 +1912,38 @@ export class EditPrintDetailComponent
     itemTwo: FilamentSummary
   ) {
     return itemOne && itemTwo && itemOne.id === itemTwo.id;
+  }
+
+  getPreferredUnitSecondaryDisplay(
+    formGroup: FilamentUsageFormGroup,
+    isEstimated: boolean
+  ): string | null {
+    const sourceField = isEstimated ? 'estimatedSource' : 'source';
+    const source = formGroup.get(sourceField)
+      ?.value as PrintFilamentSourceMeasurement;
+
+    if (source === this.preferredFilamentUnit()) return null;
+
+    if (
+      this.preferredFilamentUnit() === PrintFilamentSourceMeasurement.Weight
+    ) {
+      const field = isEstimated ? 'estimatedAmountG' : 'amountG';
+      const v = formGroup.get(field)?.value as number | null;
+      return v != null && v > 0 ? `≈ ${v.toFixed(1)}g` : null;
+    }
+
+    if (
+      this.preferredFilamentUnit() === PrintFilamentSourceMeasurement.Length
+    ) {
+      const field = isEstimated ? 'estimatedLengthInM' : 'lengthInM';
+      const v = formGroup.get(field)?.value as number | null;
+      return v != null && v > 0 ? `≈ ${v.toFixed(1)}m` : null;
+    }
+
+    // Volume
+    const field = isEstimated ? 'estimatedVolumeMl' : 'volumeMl';
+    const v = formGroup.get(field)?.value as number | null;
+    return v != null && v > 0 ? `≈ ${v.toFixed(1)}ml` : null;
   }
 
   public setStartDateToNow() {

--- a/src/app/print/print-card/print-card.component.html
+++ b/src/app/print/print-card/print-card.component.html
@@ -63,13 +63,14 @@
                       ></div>
                       <span class="material-name">
                         {{ fu.filament?.displayName }}
-                        @if (fu.amountMg !== null && fu.amountMg > 0) {
-                          ({{ fu.amountMg / 1000 | number: '1.0-1' }}g)
-                        } @else if (
-                          fu.estimatedAmountMg !== null &&
-                          fu.estimatedAmountMg > 0
-                        ) {
-                          ({{ fu.estimatedAmountMg / 1000 | number: '1.0-1' }}g*)
+                        @if (getPreferredDisplay(fu); as display) {
+                          <span
+                            [matTooltip]="display.isFallback
+                              ? display.fallbackTooltip
+                              : (display.isEstimated ? '* indicates Estimated Material Usage' : null)"
+                          >
+                            ({{ display.displayString }}@if (display.isEstimated) { * })
+                          </span>
                         }
                       </span>
                     } @else {

--- a/src/app/print/print-card/print-card.component.spec.ts
+++ b/src/app/print/print-card/print-card.component.spec.ts
@@ -6,7 +6,11 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MatDialog } from '@angular/material/dialog';
 import { By } from '@angular/platform-browser';
 import { PrintCardComponent } from './print-card.component';
-import { PrintSummary, PrintStatus } from 'src/app/core/services/print.service';
+import {
+  PrintSummary,
+  PrintStatus,
+  PrintFilamentSourceMeasurement,
+} from 'src/app/core/services/print.service';
 import { LoggingService } from 'src/app/core/services/logging.service';
 
 const mockPrint: PrintSummary = {
@@ -81,5 +85,108 @@ describe('PrintCardComponent', () => {
     component.statusChanged.subscribe(spy);
     component.onStatusChange(PrintStatus.Failed);
     expect(spy).toHaveBeenCalledWith({ id: 42, status: PrintStatus.Failed });
+  });
+});
+
+describe('PrintCardComponent — preferred unit', () => {
+  let component: PrintCardComponent;
+  let fixture: ComponentFixture<PrintCardComponent>;
+
+  function makeMinimalPrint(filamentOverrides: any = {}) {
+    return {
+      id: 1,
+      title: 'Test Print',
+      printer: {
+        id: 1,
+        name: 'Test Printer',
+        make: 'Make',
+        model: 'Model',
+      } as any,
+      startDate: new Date().toISOString(),
+      status: 1,
+      defaultPrintImageId: null,
+      createdByUserId: 1,
+      estimatedPrintTimeInSeconds: null,
+      printTimeInSeconds: null,
+      sumActualFilamentWeightMg: 0,
+      sumEstimatedFilamentWeightMg: 0,
+      totalFilamentWeightMg: 0,
+      commentCount: 0,
+      filamentUsage: [
+        {
+          id: 'fu1',
+          filament: {
+            id: 1,
+            displayName: 'PLA',
+            colorName: null,
+            colors: [],
+            colorPattern: null,
+            finishType: null,
+            effects: null,
+          },
+          amountMg: 15000,
+          lengthInM: 0,
+          volumeMl: 0,
+          estimatedAmountMg: 0,
+          estimatedLengthInM: 0,
+          estimatedVolumeMl: 0,
+          source: PrintFilamentSourceMeasurement.Weight,
+          estimatedSource: PrintFilamentSourceMeasurement.Weight,
+          notes: null,
+          ...filamentOverrides,
+        },
+      ],
+    } as any;
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PrintCardComponent, NoopAnimationsModule],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        {
+          provide: MatDialog,
+          useValue: jasmine.createSpyObj('MatDialog', ['open']),
+        },
+        {
+          provide: LoggingService,
+          useValue: jasmine.createSpyObj('LoggingService', ['logEvent']),
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PrintCardComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('shows weight when preferredUnit=Weight and amountMg is set', async () => {
+    fixture.componentRef.setInput('print', makeMinimalPrint());
+    fixture.componentRef.setInput(
+      'preferredUnit',
+      PrintFilamentSourceMeasurement.Weight
+    );
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(fixture.nativeElement.textContent).toContain('15.0g');
+  });
+
+  it('shows length when preferredUnit=Length and lengthInM is set', async () => {
+    fixture.componentRef.setInput(
+      'print',
+      makeMinimalPrint({
+        amountMg: 0,
+        lengthInM: 8.4,
+        source: PrintFilamentSourceMeasurement.Length,
+      })
+    );
+    fixture.componentRef.setInput(
+      'preferredUnit',
+      PrintFilamentSourceMeasurement.Length
+    );
+    fixture.detectChanges();
+    await fixture.whenStable();
+    expect(fixture.nativeElement.textContent).toContain('8.4m');
   });
 });

--- a/src/app/print/print-card/print-card.component.ts
+++ b/src/app/print/print-card/print-card.component.ts
@@ -7,12 +7,21 @@ import {
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { MatDialog } from '@angular/material/dialog';
-import { PrintSummary, PrintStatus } from 'src/app/core/services/print.service';
+import {
+  PrintSummary,
+  PrintStatus,
+  PrintFilamentSourceMeasurement,
+  PrintFilamentSummaryDto,
+} from 'src/app/core/services/print.service';
 import { PrinterSummary } from 'src/app/core/services/printer.service';
 import { LoggingService } from 'src/app/core/services/logging.service';
 import { SharedModule } from 'src/app/shared/shared.module';
 import { ProjectChipComponent } from 'src/app/shared/project-chip/project-chip.component';
 import { PrintShareDialogComponent } from 'src/app/print/print-share-dialog/print-share-dialog.component';
+import {
+  FilamentPreferredDisplayResult,
+  getFilamentPreferredDisplay,
+} from 'src/app/shared/utils/filament-display.utils';
 
 @Component({
   selector: 'app-print-card',
@@ -29,6 +38,15 @@ export class PrintCardComponent {
   readonly deleted = output<PrintSummary>();
   readonly statusChanged = output<{ id: number; status: PrintStatus }>();
   readonly printStatusTypes = PrintStatus;
+  readonly preferredUnit = input<PrintFilamentSourceMeasurement>(
+    PrintFilamentSourceMeasurement.Weight
+  );
+
+  getPreferredDisplay(
+    fu: PrintFilamentSummaryDto
+  ): FilamentPreferredDisplayResult | null {
+    return getFilamentPreferredDisplay(fu, this.preferredUnit());
+  }
 
   onDeleteClicked(): void {
     this.deleted.emit(this.print());

--- a/src/app/print/print-list/print-grouped-view/print-grouped-view.component.html
+++ b/src/app/print/print-list/print-grouped-view/print-grouped-view.component.html
@@ -785,18 +785,21 @@
             [filamentUsage]="row.item.filamentUsage ?? []"
             [defaultFilamentPrice]="defaultFilamentPriceSetting()?.value"
             [currencySymbol]="preferredCurrencySymbolSetting()?.value ?? '$'"
+            [preferredUnit]="preferredUnit()"
           />
         } @else if (row.kind === 'expanded-print') {
           <app-filament-usage-summary
             [filamentUsage]="row.print.filamentUsage ?? []"
             [defaultFilamentPrice]="defaultFilamentPriceSetting()?.value"
             [currencySymbol]="preferredCurrencySymbolSetting()?.value ?? '$'"
+            [preferredUnit]="preferredUnit()"
           />
         } @else if (row.kind === 'print') {
           <app-filament-usage-summary
             [filamentUsage]="row.item.print?.filamentUsage ?? []"
             [defaultFilamentPrice]="defaultFilamentPriceSetting()?.value"
             [currencySymbol]="preferredCurrencySymbolSetting()?.value ?? '$'"
+            [preferredUnit]="preferredUnit()"
           />
         }
       </td>

--- a/src/app/print/print-list/print-grouped-view/print-grouped-view.component.ts
+++ b/src/app/print/print-list/print-grouped-view/print-grouped-view.component.ts
@@ -27,6 +27,7 @@ import {
   ElectricityCostValid,
   FilamentPriceValid,
   PrintFilamentSummaryDto,
+  PrintFilamentSourceMeasurement,
   PrintService,
   PrintStatus,
   PrintSummary,
@@ -88,6 +89,9 @@ export class PrintGroupedViewComponent implements OnInit {
   preferredCurrencySymbolSetting = input<UserSetting | null>(null);
   defaultElectricityKwhRateSetting = input<UserSetting | null>(null);
   defaultElectricityWattageSetting = input<UserSetting | null>(null);
+  preferredUnit = input<PrintFilamentSourceMeasurement>(
+    PrintFilamentSourceMeasurement.Weight
+  );
 
   // ---- Internal state ----
   feed = signal<PagedList<GroupedFeedItemDto> | null>(null);

--- a/src/app/print/print-list/print-list.component.html
+++ b/src/app/print/print-list/print-list.component.html
@@ -168,6 +168,7 @@
       [preferredCurrencySymbolSetting]="preferredCurrencySymbolSetting"
       [defaultElectricityKwhRateSetting]="defaultElectricityKwhRateSetting"
       [defaultElectricityWattageSetting]="defaultElectricityWattageSetting"
+      [preferredUnit]="preferredFilamentUnit()"
     />
   }
 
@@ -180,6 +181,7 @@
           [print]="print"
           (deleted)="deletePrint($event)"
           (statusChanged)="changeStatus($event.id, $event.status)"
+          [preferredUnit]="preferredFilamentUnit()"
         />
       }
       @if (totalCount === 0) {

--- a/src/app/print/print-list/print-list.component.spec.ts
+++ b/src/app/print/print-list/print-list.component.spec.ts
@@ -14,6 +14,7 @@ import {
   PrintStatus,
   PrintSummary,
 } from 'src/app/core/services/print.service';
+import { UserSettingService } from 'src/app/core/services/user-setting.service';
 import { PagedList } from 'src/app/core/types/paging';
 import { DurationPipe } from 'src/app/shared/pipes/duration.pipe';
 import { LocaleDatePipe } from 'src/app/shared/pipes/locale-date.pipe';
@@ -74,6 +75,14 @@ describe('PrintListComponent', () => {
       of(mockPrintPagedResult)
     );
 
+    const mockUserSettingService = jasmine.createSpyObj<UserSettingService>(
+      'UserSettingService',
+      ['getCurrentUsersSettingByType']
+    );
+    mockUserSettingService.getCurrentUsersSettingByType.and.returnValue(
+      Promise.resolve(null)
+    );
+
     TestBed.configureTestingModule({
       declarations: [PrintListComponent, DurationPipe, LocaleDatePipe],
       imports: [
@@ -92,6 +101,7 @@ describe('PrintListComponent', () => {
         { provide: Title, useValue: mockTitleService },
         { provide: ToastrService, useValue: mockToastrService },
         { provide: PrintService, useValue: mockPrintService },
+        { provide: UserSettingService, useValue: mockUserSettingService },
       ],
       schemas: [NO_ERRORS_SCHEMA],
     }).compileComponents();

--- a/src/app/print/print-list/print-list.component.ts
+++ b/src/app/print/print-list/print-list.component.ts
@@ -1,5 +1,12 @@
 import { MediaMatcher } from '@angular/cdk/layout';
-import { Component, OnDestroy, OnInit, computed, signal } from '@angular/core';
+import {
+  Component,
+  OnDestroy,
+  OnInit,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { PageEvent } from '@angular/material/paginator';
 import { Sort } from '@angular/material/sort';
@@ -13,7 +20,11 @@ import { FilamentSummary } from 'src/app/core/services/filament.service';
 import { GcodeFileParserService } from 'src/app/core/services/gcode-file-parser.service';
 import { LoggingService } from 'src/app/core/services/logging.service';
 import { PrinterSummary } from 'src/app/core/services/printer.service';
-import { UserSetting } from 'src/app/core/services/user-setting.service';
+import {
+  UserSetting,
+  UserSettingService,
+  UserSettingType,
+} from 'src/app/core/services/user-setting.service';
 import { NewPrintStoreService } from 'src/app/core/stores/new-print-store.service';
 import { PagedList } from 'src/app/core/types/paging';
 import { SortDirection } from 'src/app/core/types/sort-request';
@@ -227,6 +238,11 @@ export class PrintListComponent implements OnInit, OnDestroy {
   private readonly PRINT_TABLE_DISPLAYED_COLUMNS =
     'print_table_displayed_columns';
 
+  public preferredFilamentUnit = signal<PrintFilamentSourceMeasurement>(
+    PrintFilamentSourceMeasurement.Weight
+  );
+  private readonly userSettingService = inject(UserSettingService);
+
   public defaultFilamentPriceSetting: UserSetting | null = null;
 
   public preferredCurrencySymbolSetting: UserSetting | null = null;
@@ -405,6 +421,18 @@ export class PrintListComponent implements OnInit, OnDestroy {
         JSON.stringify(this.displayedColumns)
       );
     }
+
+    this.userSettingService
+      .getCurrentUsersSettingByType(
+        UserSettingType.Prints_PreferredFilamentDisplayUnit
+      )
+      .then((setting) => {
+        if (setting) {
+          this.preferredFilamentUnit.set(
+            +setting.value as PrintFilamentSourceMeasurement
+          );
+        }
+      });
   }
 
   public pageChange(pageEvent: PageEvent) {

--- a/src/app/print/print-list/print-list.component.ts
+++ b/src/app/print/print-list/print-list.component.ts
@@ -239,7 +239,7 @@ export class PrintListComponent implements OnInit, OnDestroy {
     'print_table_displayed_columns';
 
   public preferredFilamentUnit = signal<PrintFilamentSourceMeasurement>(
-    PrintFilamentSourceMeasurement.Weight
+    PrintFilamentSourceMeasurement.AsRecorded
   );
   private readonly userSettingService = inject(UserSettingService);
 

--- a/src/app/print/view-print-detail/view-print-detail.component.html
+++ b/src/app/print/view-print-detail/view-print-detail.component.html
@@ -140,6 +140,7 @@
                 <hr />
               }
             }
+            <!-- Legacy weight-only fields: displayed in grams regardless of preferred unit (no length/volume data available) -->
             @if (
               (print.filamentUsageMg !== null && print.filamentUsageMg > 0) ||
               (print.estimatedFilamentUsageMg !== null &&

--- a/src/app/print/view-print-detail/view-print-detail.component.html
+++ b/src/app/print/view-print-detail/view-print-detail.component.html
@@ -102,7 +102,7 @@
                       actual.isFallback ? actual.fallbackTooltip : null
                     "
                   >
-                    {{ actual.displayString }}
+                    {{ actual.displayString }}@if (actual.isFallback) { * }
                   </p>
                 }
               }
@@ -132,7 +132,7 @@
                       actual.isFallback ? actual.fallbackTooltip : null
                     "
                   >
-                    {{ actual.displayString }}
+                    {{ actual.displayString }}@if (actual.isFallback) { * }
                   </p>
                 }
               }

--- a/src/app/print/view-print-detail/view-print-detail.component.html
+++ b/src/app/print/view-print-detail/view-print-detail.component.html
@@ -85,46 +85,25 @@
               @if (printFilament.filament === null) {
                 <h3>Filament:</h3>
                 <p>{{ printFilament.notes }}</p>
-                @if (
-                  printFilament.estimatedSource ===
-                  printFilamentSourceMeasurementTypes.Length
-                ) {
-                  @if (printFilament.estimatedLengthInM > 0) {
-                    <h3>Estimated:</h3>
-                    <p>
-                      {{ printFilament.estimatedLengthInM | number: '1.0-1' }}
-                      meters
-                    </p>
-                  }
+                @if (getPreferredEstimatedDisplay(printFilament); as estimated) {
+                  <h3>Estimated:</h3>
+                  <p
+                    [matTooltip]="
+                      estimated.isFallback ? estimated.fallbackTooltip : null
+                    "
+                  >
+                    {{ estimated.displayString }}@if (estimated.isFallback) { * }
+                  </p>
                 }
-                @if (
-                  printFilament.estimatedSource ===
-                  printFilamentSourceMeasurementTypes.Weight
-                ) {
-                  @if (printFilament.estimatedAmountMg > 0) {
-                    <h3>Estimated:</h3>
-                    <p>{{ printFilament.estimatedAmountMg / 1000 }} grams</p>
-                  }
-                }
-                @if (
-                  printFilament.source ===
-                  printFilamentSourceMeasurementTypes.Length
-                ) {
-                  @if (printFilament.lengthInM > 0) {
-                    <h3>Actual:</h3>
-                    <p>
-                      {{ printFilament.lengthInM | number: '1.0-1' }} meters
-                    </p>
-                  }
-                }
-                @if (
-                  printFilament.source ===
-                  printFilamentSourceMeasurementTypes.Weight
-                ) {
-                  @if (printFilament.amountMg > 0) {
-                    <h3>Actual:</h3>
-                    <p>{{ printFilament.amountMg / 1000 }} grams</p>
-                  }
+                @if (getPreferredActualDisplay(printFilament); as actual) {
+                  <h3>Actual:</h3>
+                  <p
+                    [matTooltip]="
+                      actual.isFallback ? actual.fallbackTooltip : null
+                    "
+                  >
+                    {{ actual.displayString }}
+                  </p>
                 }
               }
               @if (printFilament.filament !== null) {
@@ -136,46 +115,25 @@
                   ></span>
                   {{ printFilament.filament.displayName }}
                 </p>
-                @if (
-                  printFilament.estimatedSource ===
-                  printFilamentSourceMeasurementTypes.Length
-                ) {
-                  @if (printFilament.estimatedLengthInM > 0) {
-                    <h3>Estimated:</h3>
-                    <p>
-                      {{ printFilament.estimatedLengthInM | number: '1.0-1' }}
-                      meters
-                    </p>
-                  }
+                @if (getPreferredEstimatedDisplay(printFilament); as estimated) {
+                  <h3>Estimated:</h3>
+                  <p
+                    [matTooltip]="
+                      estimated.isFallback ? estimated.fallbackTooltip : null
+                    "
+                  >
+                    {{ estimated.displayString }}@if (estimated.isFallback) { * }
+                  </p>
                 }
-                @if (
-                  printFilament.estimatedSource ===
-                  printFilamentSourceMeasurementTypes.Weight
-                ) {
-                  @if (printFilament.estimatedAmountMg > 0) {
-                    <h3>Estimated:</h3>
-                    <p>{{ printFilament.estimatedAmountMg / 1000 }} grams</p>
-                  }
-                }
-                @if (
-                  printFilament.source ===
-                  printFilamentSourceMeasurementTypes.Length
-                ) {
-                  @if (printFilament.lengthInM > 0) {
-                    <h3>Actual:</h3>
-                    <p>
-                      {{ printFilament.lengthInM | number: '1.0-1' }} meters
-                    </p>
-                  }
-                }
-                @if (
-                  printFilament.source ===
-                  printFilamentSourceMeasurementTypes.Weight
-                ) {
-                  @if (printFilament.amountMg > 0) {
-                    <h3>Actual:</h3>
-                    <p>{{ printFilament.amountMg / 1000 }} grams</p>
-                  }
+                @if (getPreferredActualDisplay(printFilament); as actual) {
+                  <h3>Actual:</h3>
+                  <p
+                    [matTooltip]="
+                      actual.isFallback ? actual.fallbackTooltip : null
+                    "
+                  >
+                    {{ actual.displayString }}
+                  </p>
                 }
               }
               @if (!last) {

--- a/src/app/print/view-print-detail/view-print-detail.component.spec.ts
+++ b/src/app/print/view-print-detail/view-print-detail.component.spec.ts
@@ -9,6 +9,7 @@ import { ViewPrintDetailComponent } from './view-print-detail.component';
 import { PrintService } from 'src/app/core/services/print.service';
 import { AuthService } from 'src/app/core/services/auth.service';
 import { MetaTagService } from 'src/app/core/services/meta-tag.service';
+import { UserSettingService } from 'src/app/core/services/user-setting.service';
 import { DurationPipe } from 'src/app/shared/pipes/duration.pipe';
 import { FilamentColorSwatchStylePipe } from 'src/app/shared/pipes/filament-color-swatch-style.pipe';
 import { LocaleDatePipe } from 'src/app/shared/pipes/locale-date.pipe';
@@ -63,6 +64,14 @@ describe('ViewPrintDetailComponent', () => {
       ['setTitle', 'setSocialMediaTags']
     );
 
+    const mockUserSettingService = jasmine.createSpyObj<UserSettingService>(
+      'UserSettingService',
+      ['getCurrentUsersSettingByType']
+    );
+    mockUserSettingService.getCurrentUsersSettingByType.and.returnValue(
+      Promise.resolve(null)
+    );
+
     TestBed.configureTestingModule({
       declarations: [ViewPrintDetailComponent, DurationPipe, LocaleDatePipe],
       imports: [RouterTestingModule, FilamentColorSwatchStylePipe],
@@ -70,6 +79,7 @@ describe('ViewPrintDetailComponent', () => {
         { provide: PrintService, useValue: mockPrintService },
         { provide: AuthService, useValue: mockAuthService },
         { provide: MetaTagService, useValue: mockMetaService },
+        { provide: UserSettingService, useValue: mockUserSettingService },
         {
           provide: ActivatedRoute,
           useValue: {

--- a/src/app/print/view-print-detail/view-print-detail.component.ts
+++ b/src/app/print/view-print-detail/view-print-detail.component.ts
@@ -77,7 +77,7 @@ export class ViewPrintDetailComponent implements OnInit, OnDestroy {
   public defaultElectricityWattageSetting: UserSetting | null = null;
 
   public preferredFilamentUnit = signal<PrintFilamentSourceMeasurement>(
-    PrintFilamentSourceMeasurement.Weight
+    PrintFilamentSourceMeasurement.AsRecorded
   );
   private readonly userSettingService = inject(UserSettingService);
 

--- a/src/app/print/view-print-detail/view-print-detail.component.ts
+++ b/src/app/print/view-print-detail/view-print-detail.component.ts
@@ -23,6 +23,7 @@ import {
   ElectricityCost,
   PrintDetail,
   PrintFilamentSourceMeasurement,
+  PrintFilamentSummaryDto,
   PrintService,
   PrintStatus,
 } from '../../core/services/print.service';
@@ -31,6 +32,7 @@ import {
   UserSettingService,
   UserSettingType,
 } from 'src/app/core/services/user-setting.service';
+import { FilamentPreferredDisplayResult } from 'src/app/shared/utils/filament-display.utils';
 
 export interface PrintImageValue {
   id?: number;
@@ -217,5 +219,153 @@ export class ViewPrintDetailComponent implements OnInit, OnDestroy {
       defaultWattageW: this.defaultElectricityWattageSetting?.value,
       currencySymbol: this.preferredCurrencySymbolSetting?.value ?? '$',
     });
+  }
+
+  getPreferredActualDisplay(
+    fu: PrintFilamentSummaryDto
+  ): FilamentPreferredDisplayResult | null {
+    const preferred = this.preferredFilamentUnit();
+    if (
+      preferred === PrintFilamentSourceMeasurement.Weight &&
+      (fu.amountMg ?? 0) > 0
+    ) {
+      return {
+        displayString: `${(fu.amountMg / 1000).toFixed(1)} grams`,
+        isEstimated: false,
+        isFallback: false,
+        fallbackTooltip: null,
+      };
+    }
+    if (
+      preferred === PrintFilamentSourceMeasurement.Length &&
+      (fu.lengthInM ?? 0) > 0
+    ) {
+      return {
+        displayString: `${fu.lengthInM.toFixed(1)} meters`,
+        isEstimated: false,
+        isFallback: false,
+        fallbackTooltip: null,
+      };
+    }
+    if (
+      preferred === PrintFilamentSourceMeasurement.Volume &&
+      (fu.volumeMl ?? 0) > 0
+    ) {
+      return {
+        displayString: `${fu.volumeMl.toFixed(1)} ml`,
+        isEstimated: false,
+        isFallback: false,
+        fallbackTooltip: null,
+      };
+    }
+    // Fallback to source actual value
+    if (
+      fu.source === PrintFilamentSourceMeasurement.Weight &&
+      (fu.amountMg ?? 0) > 0
+    ) {
+      return {
+        displayString: `${(fu.amountMg / 1000).toFixed(1)} grams`,
+        isEstimated: false,
+        isFallback: true,
+        fallbackTooltip: 'Preferred unit unavailable — showing source unit',
+      };
+    }
+    if (
+      fu.source === PrintFilamentSourceMeasurement.Length &&
+      (fu.lengthInM ?? 0) > 0
+    ) {
+      return {
+        displayString: `${fu.lengthInM.toFixed(1)} meters`,
+        isEstimated: false,
+        isFallback: true,
+        fallbackTooltip: 'Preferred unit unavailable — showing source unit',
+      };
+    }
+    if (
+      fu.source === PrintFilamentSourceMeasurement.Volume &&
+      (fu.volumeMl ?? 0) > 0
+    ) {
+      return {
+        displayString: `${fu.volumeMl.toFixed(1)} ml`,
+        isEstimated: false,
+        isFallback: true,
+        fallbackTooltip: 'Preferred unit unavailable — showing source unit',
+      };
+    }
+    return null;
+  }
+
+  getPreferredEstimatedDisplay(
+    fu: PrintFilamentSummaryDto
+  ): FilamentPreferredDisplayResult | null {
+    const preferred = this.preferredFilamentUnit();
+    if (
+      preferred === PrintFilamentSourceMeasurement.Weight &&
+      (fu.estimatedAmountMg ?? 0) > 0
+    ) {
+      return {
+        displayString: `${(fu.estimatedAmountMg / 1000).toFixed(1)} grams`,
+        isEstimated: true,
+        isFallback: false,
+        fallbackTooltip: null,
+      };
+    }
+    if (
+      preferred === PrintFilamentSourceMeasurement.Length &&
+      (fu.estimatedLengthInM ?? 0) > 0
+    ) {
+      return {
+        displayString: `${fu.estimatedLengthInM.toFixed(1)} meters`,
+        isEstimated: true,
+        isFallback: false,
+        fallbackTooltip: null,
+      };
+    }
+    if (
+      preferred === PrintFilamentSourceMeasurement.Volume &&
+      (fu.estimatedVolumeMl ?? 0) > 0
+    ) {
+      return {
+        displayString: `${fu.estimatedVolumeMl.toFixed(1)} ml`,
+        isEstimated: true,
+        isFallback: false,
+        fallbackTooltip: null,
+      };
+    }
+    // Fallback to estimated source value
+    if (
+      fu.estimatedSource === PrintFilamentSourceMeasurement.Weight &&
+      (fu.estimatedAmountMg ?? 0) > 0
+    ) {
+      return {
+        displayString: `${(fu.estimatedAmountMg / 1000).toFixed(1)} grams`,
+        isEstimated: true,
+        isFallback: true,
+        fallbackTooltip: 'Preferred unit unavailable — showing source unit',
+      };
+    }
+    if (
+      fu.estimatedSource === PrintFilamentSourceMeasurement.Length &&
+      (fu.estimatedLengthInM ?? 0) > 0
+    ) {
+      return {
+        displayString: `${fu.estimatedLengthInM.toFixed(1)} meters`,
+        isEstimated: true,
+        isFallback: true,
+        fallbackTooltip: 'Preferred unit unavailable — showing source unit',
+      };
+    }
+    if (
+      fu.estimatedSource === PrintFilamentSourceMeasurement.Volume &&
+      (fu.estimatedVolumeMl ?? 0) > 0
+    ) {
+      return {
+        displayString: `${fu.estimatedVolumeMl.toFixed(1)} ml`,
+        isEstimated: true,
+        isFallback: true,
+        fallbackTooltip: 'Preferred unit unavailable — showing source unit',
+      };
+    }
+    return null;
   }
 }

--- a/src/app/print/view-print-detail/view-print-detail.component.ts
+++ b/src/app/print/view-print-detail/view-print-detail.component.ts
@@ -32,7 +32,11 @@ import {
   UserSettingService,
   UserSettingType,
 } from 'src/app/core/services/user-setting.service';
-import { FilamentPreferredDisplayResult } from 'src/app/shared/utils/filament-display.utils';
+import {
+  FilamentPreferredDisplayResult,
+  getActualPreferredDisplay,
+  getEstimatedPreferredDisplay,
+} from 'src/app/shared/utils/filament-display.utils';
 
 export interface PrintImageValue {
   id?: number;
@@ -224,148 +228,12 @@ export class ViewPrintDetailComponent implements OnInit, OnDestroy {
   getPreferredActualDisplay(
     fu: PrintFilamentSummaryDto
   ): FilamentPreferredDisplayResult | null {
-    const preferred = this.preferredFilamentUnit();
-    if (
-      preferred === PrintFilamentSourceMeasurement.Weight &&
-      (fu.amountMg ?? 0) > 0
-    ) {
-      return {
-        displayString: `${(fu.amountMg / 1000).toFixed(1)} grams`,
-        isEstimated: false,
-        isFallback: false,
-        fallbackTooltip: null,
-      };
-    }
-    if (
-      preferred === PrintFilamentSourceMeasurement.Length &&
-      (fu.lengthInM ?? 0) > 0
-    ) {
-      return {
-        displayString: `${fu.lengthInM.toFixed(1)} meters`,
-        isEstimated: false,
-        isFallback: false,
-        fallbackTooltip: null,
-      };
-    }
-    if (
-      preferred === PrintFilamentSourceMeasurement.Volume &&
-      (fu.volumeMl ?? 0) > 0
-    ) {
-      return {
-        displayString: `${fu.volumeMl.toFixed(1)} ml`,
-        isEstimated: false,
-        isFallback: false,
-        fallbackTooltip: null,
-      };
-    }
-    // Fallback to source actual value
-    if (
-      fu.source === PrintFilamentSourceMeasurement.Weight &&
-      (fu.amountMg ?? 0) > 0
-    ) {
-      return {
-        displayString: `${(fu.amountMg / 1000).toFixed(1)} grams`,
-        isEstimated: false,
-        isFallback: true,
-        fallbackTooltip: 'Preferred unit unavailable — showing source unit',
-      };
-    }
-    if (
-      fu.source === PrintFilamentSourceMeasurement.Length &&
-      (fu.lengthInM ?? 0) > 0
-    ) {
-      return {
-        displayString: `${fu.lengthInM.toFixed(1)} meters`,
-        isEstimated: false,
-        isFallback: true,
-        fallbackTooltip: 'Preferred unit unavailable — showing source unit',
-      };
-    }
-    if (
-      fu.source === PrintFilamentSourceMeasurement.Volume &&
-      (fu.volumeMl ?? 0) > 0
-    ) {
-      return {
-        displayString: `${fu.volumeMl.toFixed(1)} ml`,
-        isEstimated: false,
-        isFallback: true,
-        fallbackTooltip: 'Preferred unit unavailable — showing source unit',
-      };
-    }
-    return null;
+    return getActualPreferredDisplay(fu, this.preferredFilamentUnit());
   }
 
   getPreferredEstimatedDisplay(
     fu: PrintFilamentSummaryDto
   ): FilamentPreferredDisplayResult | null {
-    const preferred = this.preferredFilamentUnit();
-    if (
-      preferred === PrintFilamentSourceMeasurement.Weight &&
-      (fu.estimatedAmountMg ?? 0) > 0
-    ) {
-      return {
-        displayString: `${(fu.estimatedAmountMg / 1000).toFixed(1)} grams`,
-        isEstimated: true,
-        isFallback: false,
-        fallbackTooltip: null,
-      };
-    }
-    if (
-      preferred === PrintFilamentSourceMeasurement.Length &&
-      (fu.estimatedLengthInM ?? 0) > 0
-    ) {
-      return {
-        displayString: `${fu.estimatedLengthInM.toFixed(1)} meters`,
-        isEstimated: true,
-        isFallback: false,
-        fallbackTooltip: null,
-      };
-    }
-    if (
-      preferred === PrintFilamentSourceMeasurement.Volume &&
-      (fu.estimatedVolumeMl ?? 0) > 0
-    ) {
-      return {
-        displayString: `${fu.estimatedVolumeMl.toFixed(1)} ml`,
-        isEstimated: true,
-        isFallback: false,
-        fallbackTooltip: null,
-      };
-    }
-    // Fallback to estimated source value
-    if (
-      fu.estimatedSource === PrintFilamentSourceMeasurement.Weight &&
-      (fu.estimatedAmountMg ?? 0) > 0
-    ) {
-      return {
-        displayString: `${(fu.estimatedAmountMg / 1000).toFixed(1)} grams`,
-        isEstimated: true,
-        isFallback: true,
-        fallbackTooltip: 'Preferred unit unavailable — showing source unit',
-      };
-    }
-    if (
-      fu.estimatedSource === PrintFilamentSourceMeasurement.Length &&
-      (fu.estimatedLengthInM ?? 0) > 0
-    ) {
-      return {
-        displayString: `${fu.estimatedLengthInM.toFixed(1)} meters`,
-        isEstimated: true,
-        isFallback: true,
-        fallbackTooltip: 'Preferred unit unavailable — showing source unit',
-      };
-    }
-    if (
-      fu.estimatedSource === PrintFilamentSourceMeasurement.Volume &&
-      (fu.estimatedVolumeMl ?? 0) > 0
-    ) {
-      return {
-        displayString: `${fu.estimatedVolumeMl.toFixed(1)} ml`,
-        isEstimated: true,
-        isFallback: true,
-        fallbackTooltip: 'Preferred unit unavailable — showing source unit',
-      };
-    }
-    return null;
+    return getEstimatedPreferredDisplay(fu, this.preferredFilamentUnit());
   }
 }

--- a/src/app/print/view-print-detail/view-print-detail.component.ts
+++ b/src/app/print/view-print-detail/view-print-detail.component.ts
@@ -1,5 +1,13 @@
 import { Location } from '@angular/common';
-import { Component, Inject, OnDestroy, OnInit, DOCUMENT } from '@angular/core';
+import {
+  Component,
+  Inject,
+  OnDestroy,
+  OnInit,
+  DOCUMENT,
+  inject,
+  signal,
+} from '@angular/core';
 import { UntypedFormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs';
@@ -18,7 +26,11 @@ import {
   PrintService,
   PrintStatus,
 } from '../../core/services/print.service';
-import { UserSetting } from 'src/app/core/services/user-setting.service';
+import {
+  UserSetting,
+  UserSettingService,
+  UserSettingType,
+} from 'src/app/core/services/user-setting.service';
 
 export interface PrintImageValue {
   id?: number;
@@ -57,6 +69,11 @@ export class ViewPrintDetailComponent implements OnInit, OnDestroy {
   public preferredCurrencySymbolSetting: UserSetting | null = null;
   public defaultElectricityKwhRateSetting: UserSetting | null = null;
   public defaultElectricityWattageSetting: UserSetting | null = null;
+
+  public preferredFilamentUnit = signal<PrintFilamentSourceMeasurement>(
+    PrintFilamentSourceMeasurement.Weight
+  );
+  private readonly userSettingService = inject(UserSettingService);
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -112,6 +129,18 @@ export class ViewPrintDetailComponent implements OnInit, OnDestroy {
 
       this.setMetaTags();
     });
+
+    this.userSettingService
+      .getCurrentUsersSettingByType(
+        UserSettingType.Prints_PreferredFilamentDisplayUnit
+      )
+      .then((setting) => {
+        if (setting) {
+          this.preferredFilamentUnit.set(
+            +setting.value as PrintFilamentSourceMeasurement
+          );
+        }
+      });
   }
 
   setMetaTags() {

--- a/src/app/settings/settings-routing.module.ts
+++ b/src/app/settings/settings-routing.module.ts
@@ -11,6 +11,7 @@ import { DefaultFilamentDiameterSettingResolverService } from '../core/resolvers
 import { DefaultFilamentPriceSettingResolverService } from '../core/resolvers/default-filament-price-setting-resolver.service';
 import { DefaultElectricityKwhRateSettingResolverService } from '../core/resolvers/default-electricity-kwh-rate-setting-resolver.service';
 import { DefaultElectricityWattageSettingResolverService } from '../core/resolvers/default-electricity-wattage-setting-resolver.service';
+import { PreferredFilamentDisplayUnitSettingResolverService } from '../core/resolvers/preferred-filament-display-unit-setting-resolver.service';
 
 const routes: Routes = [
   {
@@ -30,6 +31,8 @@ const routes: Routes = [
         DefaultElectricityKwhRateSettingResolverService,
       defaultElectricityWattageSetting:
         DefaultElectricityWattageSettingResolverService,
+      preferredFilamentDisplayUnitSetting:
+        PreferredFilamentDisplayUnitSettingResolverService,
     },
   },
 ];

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -358,7 +358,7 @@
         <div>
           <label
             style="margin-right: 10px"
-            matTooltip="The unit used to display filament usage on prints."
+            matTooltip="The unit used to display filament usage on prints. 'As Recorded' shows each value in the unit it was originally entered."
             matTooltipPosition="right"
           >
             Preferred Filament Display Unit
@@ -368,6 +368,11 @@
             [(ngModel)]="preferredFilamentDisplayUnit"
             aria-label="Preferred filament display unit"
           >
+            <mat-button-toggle
+              [value]="printFilamentSourceMeasurementTypes.AsRecorded"
+            >
+              As Recorded
+            </mat-button-toggle>
             <mat-button-toggle
               [value]="printFilamentSourceMeasurementTypes.Weight"
             >

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -343,6 +343,82 @@
           </div>
         }
       </div>
+      <div
+        fxFlex="grow"
+        fxFlexFill
+        [class.mat-elevation-z5]="
+          preferredFilamentDisplayUnit?.toString() !==
+          this.preferredFilamentDisplayUnitSettingOnLoad?.value?.toString()
+        "
+        [class.editing-card]="
+          preferredFilamentDisplayUnit?.toString() !==
+          this.preferredFilamentDisplayUnitSettingOnLoad?.value?.toString()
+        "
+      >
+        <div>
+          <label
+            style="margin-right: 10px"
+            matTooltip="The unit used to display filament usage on prints."
+            matTooltipPosition="right"
+          >
+            Preferred Filament Display Unit
+            <mat-icon inline>info</mat-icon>:
+          </label>
+          <mat-button-toggle-group
+            [(ngModel)]="preferredFilamentDisplayUnit"
+            aria-label="Preferred filament display unit"
+          >
+            <mat-button-toggle
+              [value]="printFilamentSourceMeasurementTypes.Weight"
+            >
+              Weight (g)
+            </mat-button-toggle>
+            <mat-button-toggle
+              [value]="printFilamentSourceMeasurementTypes.Length"
+            >
+              Length (m)
+            </mat-button-toggle>
+            <mat-button-toggle
+              [value]="printFilamentSourceMeasurementTypes.Volume"
+            >
+              Volume (ml)
+            </mat-button-toggle>
+          </mat-button-toggle-group>
+        </div>
+        @if (
+          preferredFilamentDisplayUnit?.toString() !==
+          this.preferredFilamentDisplayUnitSettingOnLoad?.value?.toString()
+        ) {
+          <div>
+            <div
+              style="margin-top: 10px"
+              fxLayout
+              fxLayoutAlign="center center"
+              fxLayoutGap="15px"
+            >
+              <button
+                mat-raised-button
+                type="submit"
+                color="primary"
+                (click)="
+                  savePreferredFilamentDisplayUnit(preferredFilamentDisplayUnit)
+                "
+              >
+                Save Preferred Filament Display Unit
+              </button>
+              <button
+                mat-raised-button
+                type="button"
+                class="close"
+                (click)="cancelPreferredFilamentDisplayUnit()"
+                color="warn"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        }
+      </div>
       <div fxFlex="grow" fxFlexFill>
         <label
           for="theme-mode"

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -4,7 +4,11 @@ import { ActivatedRoute } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
 import { AuthService } from '../core/services/auth.service';
 import { MetaTagService } from '../core/services/meta-tag.service';
-import { PrintService, PrintViewStatus } from '../core/services/print.service';
+import {
+  PrintFilamentSourceMeasurement,
+  PrintService,
+  PrintViewStatus,
+} from '../core/services/print.service';
 import {
   UserSetting,
   UserSettingService,
@@ -43,6 +47,10 @@ export class SettingsComponent implements OnInit {
   public defaultFilamentPriceSettingOnLoad: UserSetting | null = null;
   public defaultElectricityKwhRateSettingOnLoad: UserSetting | null = null;
   public defaultElectricityWattageSettingOnLoad: UserSetting | null = null;
+  public preferredFilamentDisplayUnitSettingOnLoad: UserSetting | null = null;
+  public preferredFilamentDisplayUnit: PrintFilamentSourceMeasurement =
+    PrintFilamentSourceMeasurement.Weight;
+  public printFilamentSourceMeasurementTypes = PrintFilamentSourceMeasurement;
 
   public deactivateHasBeenClicked = false;
 
@@ -152,6 +160,14 @@ export class SettingsComponent implements OnInit {
         this.defaultElectricityKwhRateSettingOnLoad?.value ?? null;
       this.defaultElectricityWattageW =
         this.defaultElectricityWattageSettingOnLoad?.value ?? null;
+
+      this.preferredFilamentDisplayUnitSettingOnLoad =
+        data.preferredFilamentDisplayUnitSetting;
+      this.preferredFilamentDisplayUnit = this
+        .preferredFilamentDisplayUnitSettingOnLoad
+        ? (+this.preferredFilamentDisplayUnitSettingOnLoad
+            .value as PrintFilamentSourceMeasurement)
+        : PrintFilamentSourceMeasurement.Weight;
     });
 
     this.authService.userProfile$.subscribe((user) => {
@@ -317,6 +333,44 @@ export class SettingsComponent implements OnInit {
     this.defaultFilamentPrice = this.defaultFilamentPriceSettingOnLoad
       ? this.defaultFilamentPriceSettingOnLoad.value
       : null;
+  }
+
+  savePreferredFilamentDisplayUnit(newUnit: PrintFilamentSourceMeasurement) {
+    if (this.preferredFilamentDisplayUnitSettingOnLoad) {
+      this.userSettingService
+        .updateUserSetting(
+          this.preferredFilamentDisplayUnitSettingOnLoad.id,
+          newUnit.toString()
+        )
+        .subscribe((setting) => {
+          this.preferredFilamentDisplayUnitSettingOnLoad = setting;
+          this.loggingService.logEvent(
+            'Settings_PreferredFilamentDisplayUnitChanged',
+            { unit: newUnit }
+          );
+        });
+    } else {
+      this.userSettingService
+        .addUserSetting(
+          UserSettingType.Prints_PreferredFilamentDisplayUnit,
+          newUnit.toString()
+        )
+        .subscribe((setting) => {
+          this.preferredFilamentDisplayUnitSettingOnLoad = setting;
+          this.loggingService.logEvent(
+            'Settings_PreferredFilamentDisplayUnitChanged',
+            { unit: newUnit }
+          );
+        });
+    }
+  }
+
+  cancelPreferredFilamentDisplayUnit() {
+    this.preferredFilamentDisplayUnit = this
+      .preferredFilamentDisplayUnitSettingOnLoad
+      ? (+this.preferredFilamentDisplayUnitSettingOnLoad
+          .value as PrintFilamentSourceMeasurement)
+      : PrintFilamentSourceMeasurement.Weight;
   }
 
   saveDefaultElectricityKwhRate(newRate: string) {

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -48,8 +48,8 @@ export class SettingsComponent implements OnInit {
   public defaultElectricityKwhRateSettingOnLoad: UserSetting | null = null;
   public defaultElectricityWattageSettingOnLoad: UserSetting | null = null;
   public preferredFilamentDisplayUnitSettingOnLoad: UserSetting | null = null;
-  public preferredFilamentDisplayUnit: PrintFilamentSourceMeasurement =
-    PrintFilamentSourceMeasurement.Weight;
+  public preferredFilamentDisplayUnit: PrintFilamentSourceMeasurement | null =
+    null;
   public printFilamentSourceMeasurementTypes = PrintFilamentSourceMeasurement;
 
   public deactivateHasBeenClicked = false;
@@ -167,7 +167,7 @@ export class SettingsComponent implements OnInit {
         .preferredFilamentDisplayUnitSettingOnLoad
         ? (+this.preferredFilamentDisplayUnitSettingOnLoad
             .value as PrintFilamentSourceMeasurement)
-        : PrintFilamentSourceMeasurement.Weight;
+        : null;
     });
 
     this.authService.userProfile$.subscribe((user) => {
@@ -370,7 +370,7 @@ export class SettingsComponent implements OnInit {
       .preferredFilamentDisplayUnitSettingOnLoad
       ? (+this.preferredFilamentDisplayUnitSettingOnLoad
           .value as PrintFilamentSourceMeasurement)
-      : PrintFilamentSourceMeasurement.Weight;
+      : null;
   }
 
   saveDefaultElectricityKwhRate(newRate: string) {

--- a/src/app/shared/filament-usage-summary/filament-usage-summary.component.html
+++ b/src/app/shared/filament-usage-summary/filament-usage-summary.component.html
@@ -23,11 +23,13 @@
       }
     </div>
     <div>
-      @if (fu.amountMg !== null && fu.amountMg > 0) {
-        {{ fu.amountMg / 1000 | number: '1.0-1' }} g
-      } @else {
-        <div matTooltip="* indicates Estimated Material Usage">
-          {{ fu.estimatedAmountMg / 1000 | number: '1.0-1' }} g *
+      @if (getPreferredDisplay(fu); as display) {
+        <div
+          [matTooltip]="display.isFallback
+            ? display.fallbackTooltip
+            : (display.isEstimated ? '* indicates Estimated Material Usage' : null)"
+        >
+          {{ display.displayString }}@if (display.isEstimated) { * }
         </div>
       }
     </div>

--- a/src/app/shared/filament-usage-summary/filament-usage-summary.component.spec.ts
+++ b/src/app/shared/filament-usage-summary/filament-usage-summary.component.spec.ts
@@ -1,0 +1,103 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import currency from 'currency.js';
+import { FilamentUsageSummaryComponent } from './filament-usage-summary.component';
+import {
+  PrintFilamentSourceMeasurement,
+  PrintFilamentSummaryDto,
+  PrintService,
+} from 'src/app/core/services/print.service';
+
+describe('FilamentUsageSummaryComponent', () => {
+  let fixture: ComponentFixture<FilamentUsageSummaryComponent>;
+
+  beforeEach(async () => {
+    const mockPrintService = jasmine.createSpyObj<PrintService>(
+      'PrintService',
+      ['calculatePrintCost']
+    );
+    mockPrintService.calculatePrintCost.and.returnValue({
+      valid: true,
+      price: currency(0),
+      formattedPrice: '$0.00',
+      symbol: '$',
+      usesDefaultPrice: false,
+    });
+
+    await TestBed.configureTestingModule({
+      imports: [FilamentUsageSummaryComponent, NoopAnimationsModule],
+      providers: [{ provide: PrintService, useValue: mockPrintService }],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FilamentUsageSummaryComponent);
+  });
+
+  it('should create', () => {
+    fixture.detectChanges();
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  describe('FilamentUsageSummaryComponent — preferred unit', () => {
+    function makeFu(
+      overrides: Partial<PrintFilamentSummaryDto> = {}
+    ): PrintFilamentSummaryDto {
+      return {
+        id: 'abc',
+        filament: null,
+        amountMg: 0,
+        lengthInM: 0,
+        volumeMl: 0,
+        estimatedAmountMg: 0,
+        estimatedLengthInM: 0,
+        estimatedVolumeMl: 0,
+        source: PrintFilamentSourceMeasurement.Weight,
+        estimatedSource: PrintFilamentSourceMeasurement.Weight,
+        notes: '',
+        ...overrides,
+      };
+    }
+
+    it('displays weight when preferredUnit=Weight and amountMg is set', async () => {
+      fixture.componentRef.setInput('filamentUsage', [
+        makeFu({ amountMg: 25300 }),
+      ]);
+      fixture.componentRef.setInput(
+        'preferredUnit',
+        PrintFilamentSourceMeasurement.Weight
+      );
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(fixture.nativeElement.textContent).toContain('25.3g');
+    });
+
+    it('displays length when preferredUnit=Length and lengthInM is set', async () => {
+      fixture.componentRef.setInput('filamentUsage', [
+        makeFu({
+          lengthInM: 5.2,
+          source: PrintFilamentSourceMeasurement.Length,
+        }),
+      ]);
+      fixture.componentRef.setInput(
+        'preferredUnit',
+        PrintFilamentSourceMeasurement.Length
+      );
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(fixture.nativeElement.textContent).toContain('5.2m');
+    });
+
+    it('displays source unit with * when weight is estimated', async () => {
+      fixture.componentRef.setInput('filamentUsage', [
+        makeFu({ estimatedAmountMg: 8000 }),
+      ]);
+      fixture.componentRef.setInput(
+        'preferredUnit',
+        PrintFilamentSourceMeasurement.Weight
+      );
+      fixture.detectChanges();
+      await fixture.whenStable();
+      expect(fixture.nativeElement.textContent).toContain('8.0g');
+      expect(fixture.nativeElement.textContent).toContain('*');
+    });
+  });
+});

--- a/src/app/shared/filament-usage-summary/filament-usage-summary.component.ts
+++ b/src/app/shared/filament-usage-summary/filament-usage-summary.component.ts
@@ -10,10 +10,15 @@ import { CommonModule } from '@angular/common';
 import {
   FilamentPrice,
   FilamentPriceInvalid,
+  PrintFilamentSourceMeasurement,
   PrintFilamentSummaryDto,
   PrintService,
 } from 'src/app/core/services/print.service';
 import { FilamentColorSwatchStylePipe } from 'src/app/shared/pipes/filament-color-swatch-style.pipe';
+import {
+  FilamentPreferredDisplayResult,
+  getFilamentPreferredDisplay,
+} from 'src/app/shared/utils/filament-display.utils';
 
 @Component({
   selector: 'app-filament-usage-summary',
@@ -33,6 +38,9 @@ export class FilamentUsageSummaryComponent {
   filamentUsage = input<PrintFilamentSummaryDto[]>([]);
   defaultFilamentPrice = input<string | null | undefined>(null);
   currencySymbol = input<string>('$');
+  preferredUnit = input<PrintFilamentSourceMeasurement>(
+    PrintFilamentSourceMeasurement.Weight
+  );
 
   getActualPrice(fu: PrintFilamentSummaryDto): string {
     return this.formatFilamentPrice(
@@ -68,5 +76,11 @@ export class FilamentUsageSummaryComponent {
       return price.formattedPrice + (price.usesDefaultPrice ? '*' : '');
     }
     return (price as FilamentPriceInvalid).message;
+  }
+
+  getPreferredDisplay(
+    fu: PrintFilamentSummaryDto
+  ): FilamentPreferredDisplayResult | null {
+    return getFilamentPreferredDisplay(fu, this.preferredUnit());
   }
 }

--- a/src/app/shared/utils/filament-display.utils.spec.ts
+++ b/src/app/shared/utils/filament-display.utils.spec.ts
@@ -1,0 +1,137 @@
+import {
+  PrintFilamentSourceMeasurement,
+  PrintFilamentSummaryDto,
+} from 'src/app/core/services/print.service';
+import {
+  FilamentPreferredDisplayResult,
+  getFilamentPreferredDisplay,
+} from './filament-display.utils';
+
+function makeFu(
+  overrides: Partial<PrintFilamentSummaryDto> = {}
+): PrintFilamentSummaryDto {
+  return {
+    id: 'test-id',
+    filament: null,
+    amountMg: 0,
+    lengthInM: 0,
+    volumeMl: 0,
+    estimatedAmountMg: 0,
+    estimatedLengthInM: 0,
+    estimatedVolumeMl: 0,
+    source: PrintFilamentSourceMeasurement.Weight,
+    estimatedSource: PrintFilamentSourceMeasurement.Weight,
+    ...overrides,
+  };
+}
+
+describe('getFilamentPreferredDisplay', () => {
+  describe('preferred unit matches actual data', () => {
+    it('returns weight when preferred=Weight and amountMg is set', () => {
+      const fu = makeFu({
+        amountMg: 25300,
+        source: PrintFilamentSourceMeasurement.Weight,
+      });
+      const result = getFilamentPreferredDisplay(
+        fu,
+        PrintFilamentSourceMeasurement.Weight
+      )!;
+      expect(result.displayString).toBe('25.3g');
+      expect(result.isEstimated).toBeFalse();
+      expect(result.isFallback).toBeFalse();
+      expect(result.fallbackTooltip).toBeNull();
+    });
+
+    it('returns length when preferred=Length and lengthInM is set', () => {
+      const fu = makeFu({
+        lengthInM: 5.2,
+        source: PrintFilamentSourceMeasurement.Length,
+      });
+      const result = getFilamentPreferredDisplay(
+        fu,
+        PrintFilamentSourceMeasurement.Length
+      )!;
+      expect(result.displayString).toBe('5.2m');
+      expect(result.isEstimated).toBeFalse();
+    });
+
+    it('returns volume when preferred=Volume and volumeMl is set', () => {
+      const fu = makeFu({
+        volumeMl: 12.1,
+        source: PrintFilamentSourceMeasurement.Volume,
+      });
+      const result = getFilamentPreferredDisplay(
+        fu,
+        PrintFilamentSourceMeasurement.Volume
+      )!;
+      expect(result.displayString).toBe('12.1ml');
+    });
+  });
+
+  describe('preferred unit matches estimated data (no actual)', () => {
+    it('returns estimated weight with isEstimated=true when only estimatedAmountMg is set', () => {
+      const fu = makeFu({
+        amountMg: 0,
+        estimatedAmountMg: 10500,
+        estimatedSource: PrintFilamentSourceMeasurement.Weight,
+      });
+      const result = getFilamentPreferredDisplay(
+        fu,
+        PrintFilamentSourceMeasurement.Weight
+      )!;
+      expect(result.displayString).toBe('10.5g');
+      expect(result.isEstimated).toBeTrue();
+      expect(result.isFallback).toBeFalse();
+    });
+  });
+
+  describe('preferred unit unavailable — fallback to source', () => {
+    it('falls back to actual source length when preferred=Weight and no weight data', () => {
+      const fu = makeFu({
+        amountMg: 0,
+        estimatedAmountMg: 0,
+        lengthInM: 5.2,
+        source: PrintFilamentSourceMeasurement.Length,
+      });
+      const result = getFilamentPreferredDisplay(
+        fu,
+        PrintFilamentSourceMeasurement.Weight
+      )!;
+      expect(result.displayString).toBe('5.2m');
+      expect(result.isFallback).toBeTrue();
+      expect(result.isEstimated).toBeFalse();
+      expect(result.fallbackTooltip).toBe(
+        'Weight unavailable — showing source unit (length)'
+      );
+    });
+
+    it('falls back to estimated source length when preferred=Weight and no actual data', () => {
+      const fu = makeFu({
+        amountMg: 0,
+        estimatedAmountMg: 0,
+        lengthInM: 0,
+        estimatedLengthInM: 3.1,
+        source: PrintFilamentSourceMeasurement.Length,
+        estimatedSource: PrintFilamentSourceMeasurement.Length,
+      });
+      const result = getFilamentPreferredDisplay(
+        fu,
+        PrintFilamentSourceMeasurement.Weight
+      )!;
+      expect(result.displayString).toBe('3.1m');
+      expect(result.isFallback).toBeTrue();
+      expect(result.isEstimated).toBeTrue();
+    });
+  });
+
+  describe('no data at all', () => {
+    it('returns null when all values are zero', () => {
+      const fu = makeFu();
+      const result = getFilamentPreferredDisplay(
+        fu,
+        PrintFilamentSourceMeasurement.Weight
+      );
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/app/shared/utils/filament-display.utils.spec.ts
+++ b/src/app/shared/utils/filament-display.utils.spec.ts
@@ -4,8 +4,17 @@ import {
 } from 'src/app/core/services/print.service';
 import {
   FilamentPreferredDisplayResult,
+  buildConversionFallbackTooltip,
+  convertFilamentValue,
+  getActualPreferredDisplay,
+  getEstimatedPreferredDisplay,
   getFilamentPreferredDisplay,
 } from './filament-display.utils';
+
+const STANDARD_FILAMENT = {
+  materialDensityGramPerCubicCm: 1.24,
+  diameterMm: 1.75,
+};
 
 function makeFu(
   overrides: Partial<PrintFilamentSummaryDto> = {}
@@ -85,8 +94,44 @@ describe('getFilamentPreferredDisplay', () => {
     });
   });
 
-  describe('preferred unit unavailable — fallback to source', () => {
-    it('falls back to actual source length when preferred=Weight and no weight data', () => {
+  describe('unit conversion when filament has density and diameter', () => {
+    it('converts actual length to weight when preferred=Weight and filament data is available', () => {
+      const fu = makeFu({
+        amountMg: 0,
+        estimatedAmountMg: 0,
+        lengthInM: 10,
+        source: PrintFilamentSourceMeasurement.Length,
+        filament: STANDARD_FILAMENT as any,
+      });
+      const result = getFilamentPreferredDisplay(
+        fu,
+        PrintFilamentSourceMeasurement.Weight
+      )!;
+      expect(result.isFallback).toBeFalse();
+      expect(result.isEstimated).toBeFalse();
+      // 10m of 1.75mm PLA at 1.24 g/cm³ ≈ 29.8g = 29800mg
+      const weightG = parseFloat(result.displayString);
+      expect(weightG).toBeGreaterThan(29);
+      expect(weightG).toBeLessThan(31);
+    });
+
+    it('converts estimated length to weight when preferred=Weight and filament data is available', () => {
+      const fu = makeFu({
+        estimatedLengthInM: 5,
+        estimatedSource: PrintFilamentSourceMeasurement.Length,
+        filament: STANDARD_FILAMENT as any,
+      });
+      const result = getFilamentPreferredDisplay(
+        fu,
+        PrintFilamentSourceMeasurement.Weight
+      )!;
+      expect(result.isFallback).toBeFalse();
+      expect(result.isEstimated).toBeTrue();
+    });
+  });
+
+  describe('preferred unit unavailable — fallback to source (no filament data)', () => {
+    it('falls back to actual source length when preferred=Weight and no weight data and no filament', () => {
       const fu = makeFu({
         amountMg: 0,
         estimatedAmountMg: 0,
@@ -105,7 +150,29 @@ describe('getFilamentPreferredDisplay', () => {
       );
     });
 
-    it('falls back to estimated source length when preferred=Weight and no actual data', () => {
+    it('falls back with a specific tooltip when filament has density but no diameter', () => {
+      const fu = makeFu({
+        amountMg: 0,
+        estimatedAmountMg: 0,
+        lengthInM: 5.2,
+        source: PrintFilamentSourceMeasurement.Length,
+        filament: {
+          materialDensityGramPerCubicCm: 1.24,
+          diameterMm: null,
+        } as any,
+      });
+      const result = getFilamentPreferredDisplay(
+        fu,
+        PrintFilamentSourceMeasurement.Weight
+      )!;
+      expect(result.displayString).toBe('5.2m');
+      expect(result.isFallback).toBeTrue();
+      expect(result.fallbackTooltip).toBe(
+        'Cannot convert to weight — set filament diameter'
+      );
+    });
+
+    it('falls back to estimated source length when preferred=Weight and no actual data and no filament', () => {
       const fu = makeFu({
         amountMg: 0,
         estimatedAmountMg: 0,
@@ -124,6 +191,84 @@ describe('getFilamentPreferredDisplay', () => {
     });
   });
 
+  describe('buildConversionFallbackTooltip', () => {
+    it('returns generic message when filament is null', () => {
+      expect(
+        buildConversionFallbackTooltip(
+          PrintFilamentSourceMeasurement.Weight,
+          PrintFilamentSourceMeasurement.Length,
+          null
+        )
+      ).toBe('Weight unavailable — showing source unit (length)');
+    });
+
+    it('returns diameter-specific message when filament has density but no diameter', () => {
+      expect(
+        buildConversionFallbackTooltip(
+          PrintFilamentSourceMeasurement.Weight,
+          PrintFilamentSourceMeasurement.Length,
+          { materialDensityGramPerCubicCm: 1.24, diameterMm: null }
+        )
+      ).toBe('Cannot convert to weight — set filament diameter');
+    });
+
+    it('returns density-specific message when filament has diameter but no density', () => {
+      expect(
+        buildConversionFallbackTooltip(
+          PrintFilamentSourceMeasurement.Weight,
+          PrintFilamentSourceMeasurement.Volume,
+          { materialDensityGramPerCubicCm: null, diameterMm: 1.75 }
+        )
+      ).toBe('Cannot convert to weight — set filament density');
+    });
+  });
+
+  describe('convertFilamentValue', () => {
+    it('returns null when filament is null', () => {
+      expect(
+        convertFilamentValue(
+          10,
+          PrintFilamentSourceMeasurement.Length,
+          PrintFilamentSourceMeasurement.Weight,
+          null
+        )
+      ).toBeNull();
+    });
+
+    it('returns the value unchanged when fromUnit === toUnit', () => {
+      expect(
+        convertFilamentValue(
+          5000,
+          PrintFilamentSourceMeasurement.Weight,
+          PrintFilamentSourceMeasurement.Weight,
+          STANDARD_FILAMENT
+        )
+      ).toBe(5000);
+    });
+
+    it('converts length to weight (mg)', () => {
+      const mg = convertFilamentValue(
+        10,
+        PrintFilamentSourceMeasurement.Length,
+        PrintFilamentSourceMeasurement.Weight,
+        STANDARD_FILAMENT
+      )!;
+      // 10m × π×(0.0875cm)² × 1.24 g/cm³ × 1000 ≈ 29826 mg
+      expect(mg).toBeGreaterThan(29000);
+      expect(mg).toBeLessThan(31000);
+    });
+
+    it('converts weight to length (m)', () => {
+      const m = convertFilamentValue(
+        29826,
+        PrintFilamentSourceMeasurement.Weight,
+        PrintFilamentSourceMeasurement.Length,
+        STANDARD_FILAMENT
+      )!;
+      expect(m).toBeCloseTo(10, 0);
+    });
+  });
+
   describe('no data at all', () => {
     it('returns null when all values are zero', () => {
       const fu = makeFu();
@@ -132,6 +277,111 @@ describe('getFilamentPreferredDisplay', () => {
         PrintFilamentSourceMeasurement.Weight
       );
       expect(result).toBeNull();
+    });
+  });
+
+  describe('buildConversionFallbackTooltip — preferred equals source', () => {
+    it('returns a non-self-referential message when preferred === source', () => {
+      const tooltip = buildConversionFallbackTooltip(
+        PrintFilamentSourceMeasurement.Volume,
+        PrintFilamentSourceMeasurement.Volume,
+        null
+      );
+      expect(tooltip).toBe('Volume data unavailable');
+      expect(tooltip).not.toContain('showing source unit (volume)');
+    });
+  });
+
+  describe('getActualPreferredDisplay', () => {
+    it('returns direct actual match', () => {
+      const fu = makeFu({
+        amountMg: 25000,
+        source: PrintFilamentSourceMeasurement.Weight,
+      });
+      const result = getActualPreferredDisplay(
+        fu,
+        PrintFilamentSourceMeasurement.Weight
+      )!;
+      expect(result.displayString).toBe('25.0g');
+      expect(result.isFallback).toBeFalse();
+      expect(result.isEstimated).toBeFalse();
+    });
+
+    it('converts actual source to preferred unit', () => {
+      const fu = makeFu({
+        lengthInM: 10,
+        source: PrintFilamentSourceMeasurement.Length,
+        filament: STANDARD_FILAMENT as any,
+      });
+      const result = getActualPreferredDisplay(
+        fu,
+        PrintFilamentSourceMeasurement.Weight
+      )!;
+      expect(result.isFallback).toBeFalse();
+      expect(parseFloat(result.displayString)).toBeGreaterThan(29);
+    });
+
+    it('falls back when conversion is not possible', () => {
+      const fu = makeFu({
+        lengthInM: 5,
+        source: PrintFilamentSourceMeasurement.Length,
+      });
+      const result = getActualPreferredDisplay(
+        fu,
+        PrintFilamentSourceMeasurement.Weight
+      )!;
+      expect(result.displayString).toBe('5.0m');
+      expect(result.isFallback).toBeTrue();
+    });
+
+    it('returns null when no actual data', () => {
+      const fu = makeFu({
+        estimatedAmountMg: 10000,
+        estimatedSource: PrintFilamentSourceMeasurement.Weight,
+      });
+      expect(
+        getActualPreferredDisplay(fu, PrintFilamentSourceMeasurement.Weight)
+      ).toBeNull();
+    });
+  });
+
+  describe('getEstimatedPreferredDisplay', () => {
+    it('returns direct estimated match', () => {
+      const fu = makeFu({
+        estimatedAmountMg: 15000,
+        estimatedSource: PrintFilamentSourceMeasurement.Weight,
+      });
+      const result = getEstimatedPreferredDisplay(
+        fu,
+        PrintFilamentSourceMeasurement.Weight
+      )!;
+      expect(result.displayString).toBe('15.0g');
+      expect(result.isEstimated).toBeTrue();
+      expect(result.isFallback).toBeFalse();
+    });
+
+    it('converts estimated source to preferred unit', () => {
+      const fu = makeFu({
+        estimatedLengthInM: 5,
+        estimatedSource: PrintFilamentSourceMeasurement.Length,
+        filament: STANDARD_FILAMENT as any,
+      });
+      const result = getEstimatedPreferredDisplay(
+        fu,
+        PrintFilamentSourceMeasurement.Weight
+      )!;
+      expect(result.isEstimated).toBeTrue();
+      expect(result.isFallback).toBeFalse();
+    });
+
+    it('returns null when no estimated data', () => {
+      const fu = makeFu({
+        amountMg: 10000,
+        source: PrintFilamentSourceMeasurement.Weight,
+      });
+      expect(
+        getEstimatedPreferredDisplay(fu, PrintFilamentSourceMeasurement.Weight)
+      ).toBeNull();
     });
   });
 });

--- a/src/app/shared/utils/filament-display.utils.ts
+++ b/src/app/shared/utils/filament-display.utils.ts
@@ -11,6 +11,7 @@ export interface FilamentPreferredDisplayResult {
 }
 
 const UNIT_LABELS: Record<PrintFilamentSourceMeasurement, string> = {
+  [PrintFilamentSourceMeasurement.AsRecorded]: 'source',
   [PrintFilamentSourceMeasurement.Weight]: 'weight',
   [PrintFilamentSourceMeasurement.Length]: 'length',
   [PrintFilamentSourceMeasurement.Volume]: 'volume',
@@ -154,6 +155,17 @@ export function getActualPreferredDisplay(
   fu: PrintFilamentSummaryDto,
   preferredUnit: PrintFilamentSourceMeasurement
 ): FilamentPreferredDisplayResult | null {
+  if (preferredUnit === PrintFilamentSourceMeasurement.AsRecorded) {
+    const srcActual = actualValue(fu, fu.source);
+    if (srcActual === null) return null;
+    return {
+      displayString: formatValue(srcActual, fu.source),
+      isEstimated: false,
+      isFallback: false,
+      fallbackTooltip: null,
+    };
+  }
+
   const direct = actualValue(fu, preferredUnit);
   if (direct !== null) {
     return {
@@ -200,6 +212,17 @@ export function getEstimatedPreferredDisplay(
   fu: PrintFilamentSummaryDto,
   preferredUnit: PrintFilamentSourceMeasurement
 ): FilamentPreferredDisplayResult | null {
+  if (preferredUnit === PrintFilamentSourceMeasurement.AsRecorded) {
+    const srcEst = estimatedValue(fu, fu.estimatedSource);
+    if (srcEst === null) return null;
+    return {
+      displayString: formatValue(srcEst, fu.estimatedSource),
+      isEstimated: true,
+      isFallback: false,
+      fallbackTooltip: null,
+    };
+  }
+
   const direct = estimatedValue(fu, preferredUnit);
   if (direct !== null) {
     return {
@@ -245,6 +268,28 @@ export function getFilamentPreferredDisplay(
   fu: PrintFilamentSummaryDto,
   preferredUnit: PrintFilamentSourceMeasurement
 ): FilamentPreferredDisplayResult | null {
+  if (preferredUnit === PrintFilamentSourceMeasurement.AsRecorded) {
+    const srcActual = actualValue(fu, fu.source);
+    if (srcActual !== null) {
+      return {
+        displayString: formatValue(srcActual, fu.source),
+        isEstimated: false,
+        isFallback: false,
+        fallbackTooltip: null,
+      };
+    }
+    const srcEst = estimatedValue(fu, fu.estimatedSource);
+    if (srcEst !== null) {
+      return {
+        displayString: formatValue(srcEst, fu.estimatedSource),
+        isEstimated: true,
+        isFallback: false,
+        fallbackTooltip: null,
+      };
+    }
+    return null;
+  }
+
   // Direct match in actual data
   const preferred = actualValue(fu, preferredUnit);
   if (preferred !== null) {

--- a/src/app/shared/utils/filament-display.utils.ts
+++ b/src/app/shared/utils/filament-display.utils.ts
@@ -49,10 +49,203 @@ function estimatedValue(
   return (fu.estimatedVolumeMl ?? 0) > 0 ? fu.estimatedVolumeMl : null;
 }
 
+/**
+ * Converts a filament quantity from one unit to another.
+ * Input/output values use each unit's native representation:
+ *   Weight → milligrams, Length → meters, Volume → millilitres.
+ *
+ * Density is required whenever Weight is involved.
+ * Diameter is required whenever Length is involved.
+ * Returns null when the required properties are missing on the filament.
+ */
+export function convertFilamentValue(
+  value: number,
+  fromUnit: PrintFilamentSourceMeasurement,
+  toUnit: PrintFilamentSourceMeasurement,
+  filament:
+    | { materialDensityGramPerCubicCm?: number; diameterMm?: number }
+    | null
+    | undefined
+): number | null {
+  if (fromUnit === toUnit) return value;
+
+  const density = filament?.materialDensityGramPerCubicCm;
+  const diameterMm = filament?.diameterMm;
+
+  const involvesLength =
+    fromUnit === PrintFilamentSourceMeasurement.Length ||
+    toUnit === PrintFilamentSourceMeasurement.Length;
+  const involvesWeight =
+    fromUnit === PrintFilamentSourceMeasurement.Weight ||
+    toUnit === PrintFilamentSourceMeasurement.Weight;
+
+  if (involvesWeight && !density) return null;
+  if (involvesLength && !diameterMm) return null;
+
+  const radiusCm = diameterMm ? diameterMm / 2 / 10 : 0;
+  const crossSectionCm2 = diameterMm ? Math.PI * radiusCm * radiusCm : 0;
+
+  // Normalise to volume in cm³ (= ml)
+  let volumeCm3: number;
+  if (fromUnit === PrintFilamentSourceMeasurement.Weight) {
+    volumeCm3 = value / 1000 / density!; // mg → g → cm³
+  } else if (fromUnit === PrintFilamentSourceMeasurement.Length) {
+    volumeCm3 = crossSectionCm2 * (value * 100); // m → cm, cm × cm² = cm³
+  } else {
+    volumeCm3 = value; // ml = cm³
+  }
+
+  if (toUnit === PrintFilamentSourceMeasurement.Weight) {
+    return volumeCm3 * density! * 1000; // cm³ → g → mg
+  } else if (toUnit === PrintFilamentSourceMeasurement.Length) {
+    return volumeCm3 / crossSectionCm2 / 100; // cm³ → cm → m
+  } else {
+    return volumeCm3; // ml
+  }
+}
+
+/** Generates the fallback tooltip explaining why the preferred unit cannot be shown. */
+export function buildConversionFallbackTooltip(
+  preferredUnit: PrintFilamentSourceMeasurement,
+  sourceUnit: PrintFilamentSourceMeasurement,
+  filament:
+    | { materialDensityGramPerCubicCm?: number; diameterMm?: number }
+    | null
+    | undefined
+): string {
+  const preferredLabel = UNIT_LABELS[preferredUnit];
+  const sourceLabel = UNIT_LABELS[sourceUnit];
+
+  if (preferredUnit === sourceUnit) {
+    const cap =
+      preferredLabel.charAt(0).toUpperCase() + preferredLabel.slice(1);
+    return `${cap} data unavailable`;
+  }
+
+  if (filament) {
+    const needsDensity =
+      preferredUnit === PrintFilamentSourceMeasurement.Weight ||
+      sourceUnit === PrintFilamentSourceMeasurement.Weight;
+    const needsDiameter =
+      preferredUnit === PrintFilamentSourceMeasurement.Length ||
+      sourceUnit === PrintFilamentSourceMeasurement.Length;
+
+    const missingDensity =
+      needsDensity && !filament.materialDensityGramPerCubicCm;
+    const missingDiameter = needsDiameter && !filament.diameterMm;
+
+    if (missingDensity && missingDiameter) {
+      return `Cannot convert to ${preferredLabel} — set filament density and diameter`;
+    }
+    if (missingDensity) {
+      return `Cannot convert to ${preferredLabel} — set filament density`;
+    }
+    if (missingDiameter) {
+      return `Cannot convert to ${preferredLabel} — set filament diameter`;
+    }
+  }
+
+  const cap = preferredLabel.charAt(0).toUpperCase() + preferredLabel.slice(1);
+  return `${cap} unavailable — showing source unit (${sourceLabel})`;
+}
+
+/** Preferred-unit display for the actual (non-estimated) filament data only. */
+export function getActualPreferredDisplay(
+  fu: PrintFilamentSummaryDto,
+  preferredUnit: PrintFilamentSourceMeasurement
+): FilamentPreferredDisplayResult | null {
+  const direct = actualValue(fu, preferredUnit);
+  if (direct !== null) {
+    return {
+      displayString: formatValue(direct, preferredUnit),
+      isEstimated: false,
+      isFallback: false,
+      fallbackTooltip: null,
+    };
+  }
+
+  const srcActual = actualValue(fu, fu.source);
+  if (srcActual !== null) {
+    const converted = convertFilamentValue(
+      srcActual,
+      fu.source,
+      preferredUnit,
+      fu.filament
+    );
+    if (converted !== null) {
+      return {
+        displayString: formatValue(converted, preferredUnit),
+        isEstimated: false,
+        isFallback: false,
+        fallbackTooltip: null,
+      };
+    }
+    return {
+      displayString: formatValue(srcActual, fu.source),
+      isEstimated: false,
+      isFallback: true,
+      fallbackTooltip: buildConversionFallbackTooltip(
+        preferredUnit,
+        fu.source,
+        fu.filament
+      ),
+    };
+  }
+
+  return null;
+}
+
+/** Preferred-unit display for the estimated filament data only. */
+export function getEstimatedPreferredDisplay(
+  fu: PrintFilamentSummaryDto,
+  preferredUnit: PrintFilamentSourceMeasurement
+): FilamentPreferredDisplayResult | null {
+  const direct = estimatedValue(fu, preferredUnit);
+  if (direct !== null) {
+    return {
+      displayString: formatValue(direct, preferredUnit),
+      isEstimated: true,
+      isFallback: false,
+      fallbackTooltip: null,
+    };
+  }
+
+  const srcEst = estimatedValue(fu, fu.estimatedSource);
+  if (srcEst !== null) {
+    const converted = convertFilamentValue(
+      srcEst,
+      fu.estimatedSource,
+      preferredUnit,
+      fu.filament
+    );
+    if (converted !== null) {
+      return {
+        displayString: formatValue(converted, preferredUnit),
+        isEstimated: true,
+        isFallback: false,
+        fallbackTooltip: null,
+      };
+    }
+    return {
+      displayString: formatValue(srcEst, fu.estimatedSource),
+      isEstimated: true,
+      isFallback: true,
+      fallbackTooltip: buildConversionFallbackTooltip(
+        preferredUnit,
+        fu.estimatedSource,
+        fu.filament
+      ),
+    };
+  }
+
+  return null;
+}
+
 export function getFilamentPreferredDisplay(
   fu: PrintFilamentSummaryDto,
   preferredUnit: PrintFilamentSourceMeasurement
 ): FilamentPreferredDisplayResult | null {
+  // Direct match in actual data
   const preferred = actualValue(fu, preferredUnit);
   if (preferred !== null) {
     return {
@@ -63,6 +256,7 @@ export function getFilamentPreferredDisplay(
     };
   }
 
+  // Direct match in estimated data
   const preferredEst = estimatedValue(fu, preferredUnit);
   if (preferredEst !== null) {
     return {
@@ -73,27 +267,70 @@ export function getFilamentPreferredDisplay(
     };
   }
 
+  // Pre-compute source values for conversion attempts and fallback
   const srcActual = actualValue(fu, fu.source);
+  const srcEst = estimatedValue(fu, fu.estimatedSource);
+
+  // Try converting actual source value to preferred unit
   if (srcActual !== null) {
-    const preferredLabel = UNIT_LABELS[preferredUnit];
-    const sourceLabel = UNIT_LABELS[fu.source];
+    const converted = convertFilamentValue(
+      srcActual,
+      fu.source,
+      preferredUnit,
+      fu.filament
+    );
+    if (converted !== null) {
+      return {
+        displayString: formatValue(converted, preferredUnit),
+        isEstimated: false,
+        isFallback: false,
+        fallbackTooltip: null,
+      };
+    }
+  }
+
+  // Try converting estimated source value to preferred unit
+  if (srcEst !== null) {
+    const converted = convertFilamentValue(
+      srcEst,
+      fu.estimatedSource,
+      preferredUnit,
+      fu.filament
+    );
+    if (converted !== null) {
+      return {
+        displayString: formatValue(converted, preferredUnit),
+        isEstimated: true,
+        isFallback: false,
+        fallbackTooltip: null,
+      };
+    }
+  }
+
+  // Fallback: show source unit as-is with an informative tooltip
+  if (srcActual !== null) {
     return {
       displayString: formatValue(srcActual, fu.source),
       isEstimated: false,
       isFallback: true,
-      fallbackTooltip: `${preferredLabel.charAt(0).toUpperCase()}${preferredLabel.slice(1)} unavailable — showing source unit (${sourceLabel})`,
+      fallbackTooltip: buildConversionFallbackTooltip(
+        preferredUnit,
+        fu.source,
+        fu.filament
+      ),
     };
   }
 
-  const srcEst = estimatedValue(fu, fu.estimatedSource);
   if (srcEst !== null) {
-    const preferredLabel = UNIT_LABELS[preferredUnit];
-    const sourceLabel = UNIT_LABELS[fu.estimatedSource];
     return {
       displayString: formatValue(srcEst, fu.estimatedSource),
       isEstimated: true,
       isFallback: true,
-      fallbackTooltip: `${preferredLabel.charAt(0).toUpperCase()}${preferredLabel.slice(1)} unavailable — showing source unit (${sourceLabel})`,
+      fallbackTooltip: buildConversionFallbackTooltip(
+        preferredUnit,
+        fu.estimatedSource,
+        fu.filament
+      ),
     };
   }
 

--- a/src/app/shared/utils/filament-display.utils.ts
+++ b/src/app/shared/utils/filament-display.utils.ts
@@ -1,0 +1,101 @@
+import {
+  PrintFilamentSourceMeasurement,
+  PrintFilamentSummaryDto,
+} from 'src/app/core/services/print.service';
+
+export interface FilamentPreferredDisplayResult {
+  displayString: string;
+  isEstimated: boolean;
+  isFallback: boolean;
+  fallbackTooltip: string | null;
+}
+
+const UNIT_LABELS: Record<PrintFilamentSourceMeasurement, string> = {
+  [PrintFilamentSourceMeasurement.Weight]: 'weight',
+  [PrintFilamentSourceMeasurement.Length]: 'length',
+  [PrintFilamentSourceMeasurement.Volume]: 'volume',
+};
+
+function formatValue(
+  value: number,
+  unit: PrintFilamentSourceMeasurement
+): string {
+  if (unit === PrintFilamentSourceMeasurement.Weight)
+    return `${(value / 1000).toFixed(1)}g`;
+  if (unit === PrintFilamentSourceMeasurement.Length)
+    return `${value.toFixed(1)}m`;
+  return `${value.toFixed(1)}ml`;
+}
+
+function actualValue(
+  fu: PrintFilamentSummaryDto,
+  unit: PrintFilamentSourceMeasurement
+): number | null {
+  if (unit === PrintFilamentSourceMeasurement.Weight)
+    return (fu.amountMg ?? 0) > 0 ? fu.amountMg : null;
+  if (unit === PrintFilamentSourceMeasurement.Length)
+    return (fu.lengthInM ?? 0) > 0 ? fu.lengthInM : null;
+  return (fu.volumeMl ?? 0) > 0 ? fu.volumeMl : null;
+}
+
+function estimatedValue(
+  fu: PrintFilamentSummaryDto,
+  unit: PrintFilamentSourceMeasurement
+): number | null {
+  if (unit === PrintFilamentSourceMeasurement.Weight)
+    return (fu.estimatedAmountMg ?? 0) > 0 ? fu.estimatedAmountMg : null;
+  if (unit === PrintFilamentSourceMeasurement.Length)
+    return (fu.estimatedLengthInM ?? 0) > 0 ? fu.estimatedLengthInM : null;
+  return (fu.estimatedVolumeMl ?? 0) > 0 ? fu.estimatedVolumeMl : null;
+}
+
+export function getFilamentPreferredDisplay(
+  fu: PrintFilamentSummaryDto,
+  preferredUnit: PrintFilamentSourceMeasurement
+): FilamentPreferredDisplayResult | null {
+  const preferred = actualValue(fu, preferredUnit);
+  if (preferred !== null) {
+    return {
+      displayString: formatValue(preferred, preferredUnit),
+      isEstimated: false,
+      isFallback: false,
+      fallbackTooltip: null,
+    };
+  }
+
+  const preferredEst = estimatedValue(fu, preferredUnit);
+  if (preferredEst !== null) {
+    return {
+      displayString: formatValue(preferredEst, preferredUnit),
+      isEstimated: true,
+      isFallback: false,
+      fallbackTooltip: null,
+    };
+  }
+
+  const srcActual = actualValue(fu, fu.source);
+  if (srcActual !== null) {
+    const preferredLabel = UNIT_LABELS[preferredUnit];
+    const sourceLabel = UNIT_LABELS[fu.source];
+    return {
+      displayString: formatValue(srcActual, fu.source),
+      isEstimated: false,
+      isFallback: true,
+      fallbackTooltip: `${preferredLabel.charAt(0).toUpperCase()}${preferredLabel.slice(1)} unavailable — showing source unit (${sourceLabel})`,
+    };
+  }
+
+  const srcEst = estimatedValue(fu, fu.estimatedSource);
+  if (srcEst !== null) {
+    const preferredLabel = UNIT_LABELS[preferredUnit];
+    const sourceLabel = UNIT_LABELS[fu.estimatedSource];
+    return {
+      displayString: formatValue(srcEst, fu.estimatedSource),
+      isEstimated: true,
+      isFallback: true,
+      fallbackTooltip: `${preferredLabel.charAt(0).toUpperCase()}${preferredLabel.slice(1)} unavailable — showing source unit (${sourceLabel})`,
+    };
+  }
+
+  return null;
+}


### PR DESCRIPTION
Closes #35

## Summary

- Adds a **Preferred Filament Display Unit** setting to the Settings page, letting users choose how filament usage is displayed across prints (Weight, Length, Volume, or As Recorded)
- **As Recorded** (the default) shows each value in the unit it was originally entered — preserving existing app behavior for all users
- When a specific unit is selected, the app converts and displays all filament quantities in that unit, falling back to the source unit with an explanatory tooltip when conversion isn't possible (e.g. missing filament density or diameter)
- Secondary display in the edit-print-detail form shows the preferred unit alongside the entry fields
- Includes unit conversion utility (`convertFilamentValue`) supporting weight ↔ length ↔ volume using filament density and diameter

## Changes

- `PrintFilamentSourceMeasurement` enum gains `AsRecorded = 0`
- `filament-display.utils.ts` — new conversion/display utility functions (`getFilamentPreferredDisplay`, `getActualPreferredDisplay`, `getEstimatedPreferredDisplay`, `convertFilamentValue`)
- `preferredUnit` input added to `filament-usage-summary`, `print-card`, and `print-grouped-view` components
- `print-list` and `view-print-detail` load the setting from the API and propagate it to children
- Settings page control (toggle group) for saving/cancelling the preference
- E2E test fixes: direct navigation to edit URLs, timing guard in `clearPrefilledFilamentEntries`, and suppression of legacy "Other" filament card when modern filament records already exist

## API dependency

Requires the companion API PR in `3d-print-log-api` which adds `UserSettingType` row 14 (`Prints_PreferredFilamentDisplayUnit`): HoffmanEngineering/3d-print-log-api#15

## Test plan

- [ ] Settings page shows the toggle group with As Recorded / Weight (g) / Length (m) / Volume (ml)
- [ ] Selecting Weight and saving causes all print filament values to display in grams
- [ ] Selecting Length and saving causes values to display in meters (with fallback tooltip where diameter is missing)
- [ ] Selecting As Recorded (or no setting saved) shows each print's filament in its original unit
- [ ] Cancel reverts the control to the last saved value
- [ ] E2E suite passes: `npx cypress run`