### PR TITLE
fix: use current currency selection for electricity rate label in settings

### DIFF
--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -468,7 +468,7 @@
             matTooltip="Your electricity rate from your bill, in currency per kWh."
             matTooltipPosition="right"
           >
-            Electricity Rate ({{ preferredCurrencySymbolSettingOnLoad?.value ?? '$' }}/kWh)
+            Electricity Rate ({{ currencies[preferredCurrency]?.symbol ?? '$' }}/kWh)
             <mat-icon inline>info</mat-icon>:</label
           >
           <input


### PR DESCRIPTION
## Summary

- The **Electricity Rate** label in Settings showed the *saved* currency symbol (`preferredCurrencySymbolSettingOnLoad`) while the **Default Filament Price** indicator showed the *current dropdown selection* (`currencies[preferredCurrency]?.symbol`)
- This caused the two fields to be out of sync when a user changed the currency dropdown but hadn't saved yet
- Fixed by making the electricity rate label use the same live-update pattern as the filament price indicator

## Test plan

- [ ] Go to Settings with a saved currency (e.g. USD / $)
- [ ] Change the currency dropdown to a different currency (e.g. EUR / €)
- [ ] Verify both the filament price indicator and the electricity rate label update to show the new symbol before saving
- [ ] Save the currency and verify both still show the correct symbol