### PR TITLE
feat: spool weight adjustment calculator

### DIFF
--- a/cypress/e2e/filaments/spool-weight-calculator.cy.ts
+++ b/cypress/e2e/filaments/spool-weight-calculator.cy.ts
@@ -1,0 +1,98 @@
+describe('Spool weight adjustment calculator', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  // Fills the create form for a weight-based material with initial total and
+  // nominal weights (so a spool weight is derivable and remaining is known),
+  // then saves and yields the created filament id.
+  function createWeighableFilament(name: string): Cypress.Chainable<string> {
+    cy.visit('/filament');
+    cy.get('#add-new-filament').click();
+
+    cy.get('#edit-filament-name').type(name);
+
+    cy.get('mat-select[formControlName="materialCategoryNickname"]')
+      .click()
+      .get('mat-option')
+      .first()
+      .click();
+
+    cy.get('#edit-filament-material-type').type('PLA');
+    cy.get('#edit-filament-density')
+      .clear({ force: true })
+      .type('1.24', { force: true });
+    cy.get('#edit-filament-total-weight')
+      .clear({ force: true })
+      .type('1150', { force: true });
+    cy.get('#filament-inital-nominal-weight')
+      .clear({ force: true })
+      .type('1000', { force: true });
+
+    cy.intercept('POST', '/api/Filaments').as('createFilament');
+    cy.get('#edit-filament-submit-btn').click();
+
+    return cy
+      .wait('@createFilament')
+      .then((interception) => interception.response!.body.id as string);
+  }
+
+  it('calculates and adds an adjustment from a measured spool weight', () => {
+    const name = 'Spool Calc Filament - ' + new Date().getTime();
+
+    createWeighableFilament(name).then((filamentId) => {
+      // Re-open the saved material: form is pristine and filamentRemaining is
+      // computed by the API, so the calculator is available.
+      cy.visit(`/filament/${filamentId}`);
+
+      cy.get('#spool-calc-button')
+        .should('be.visible')
+        .should('not.be.disabled')
+        .click();
+
+      // Enter the measured total spool weight.
+      cy.get('#spool-calc-measured-weight').type('450');
+
+      // measured remaining = 450 - 150 (spool) = 300 g;
+      // adjustment = 300 - 1000 (tracked remaining) = -700 g.
+      cy.get('.calc-adjustment').should('contain.text', '-700');
+
+      cy.get('mat-dialog-container')
+        .contains('button', 'Add Adjustment')
+        .click();
+
+      // A new weight adjustment row is appended with the computed amount.
+      cy.get('#filament-adjustment-used-gram-0').should('have.value', '-700');
+
+      // Persist and confirm it round-trips.
+      cy.intercept('PUT', `/api/Filaments/${filamentId}`).as('updateFilament');
+      cy.get('#edit-filament-submit-btn').click();
+      cy.wait('@updateFilament');
+
+      cy.visit(`/filament/${filamentId}`);
+      cy.get('#filament-adjustment-used-gram-0').should('have.value', '-700');
+    });
+  });
+
+  it('hides the calculator on a new material and disables it while the form has unsaved edits', () => {
+    const name = 'Spool Calc Gate - ' + new Date().getTime();
+
+    // A brand-new (unsaved) material has no remaining to reconcile against.
+    cy.visit('/filament');
+    cy.get('#add-new-filament').click();
+    cy.get('#spool-calc-button').should('not.exist');
+
+    createWeighableFilament(name).then((filamentId) => {
+      cy.visit(`/filament/${filamentId}`);
+
+      // Pristine, saved, spool weight resolvable -> enabled.
+      cy.get('#spool-calc-button')
+        .should('be.visible')
+        .should('not.be.disabled');
+
+      // Any unsaved edit disables it so the calculation stays authoritative.
+      cy.get('#edit-filament-name').type(' edited');
+      cy.get('#spool-calc-button').should('be.disabled');
+    });
+  });
+});

--- a/src/app/core/services/filament.service.ts
+++ b/src/app/core/services/filament.service.ts
@@ -79,6 +79,13 @@ export interface FilamentDetail {
   notes: string;
   isFavorite: boolean;
   filamentAdjustments: FilamentAdjustment[];
+
+  /**
+   * Server-computed remaining filament weight in mg (nominal − print usage +
+   * weight adjustments). Null when nominal weight is absent. Read-only: the
+   * server ignores it on write, so writers may omit it.
+   */
+  filamentRemaining?: number | null;
 }
 
 export interface FilamentSummary {

--- a/src/app/documentation/docs/docs-filaments/docs-filaments.component.html
+++ b/src/app/documentation/docs/docs-filaments/docs-filaments.component.html
@@ -161,6 +161,28 @@
     </div>
   </div>
 
+  <h4 id="adjust-from-measured-weight">Adjust from Measured Weight</h4>
+  <p>
+    Instead of working out an adjustment by hand, you can let 3D Print Log
+    calculate it from a scale reading. In the <strong>Adjustments</strong>
+    section, choose <strong>Adjust from measured weight</strong> to open the
+    calculator.
+  </p>
+  <p>
+    The calculator uses the spool weight (either the value you entered, or the
+    difference between the initial total and nominal weights) together with the
+    currently tracked remaining amount. Enter the current total weight of the
+    spool as measured on a scale, and it shows how much filament you actually
+    have left and the adjustment needed to match it. Confirming adds that
+    adjustment to the list, ready to review before you save.
+  </p>
+  <p>
+    The calculator is available once the material has been saved, has a known
+    remaining amount, and has a spool weight. Save any pending edits first — the
+    button is disabled while there are unsaved changes so the calculation uses
+    up-to-date numbers.
+  </p>
+
   <h4 id="add-temperatures">Temperatures</h4>
   <p>
     Record the recommended temperature and range in Celsius for this material.

--- a/src/app/filament/filament-detail/filament-detail.component.html
+++ b/src/app/filament/filament-detail/filament-detail.component.html
@@ -583,17 +583,21 @@
               Add New Adjustment
             </button>
             @if (canShowSpoolCalculator) {
-              <button
-                id="spool-calc-button"
-                type="button"
-                mat-raised-button
-                color="primary"
-                [disabled]="filamentForm.dirty"
+              <span
+                class="spool-calc-tooltip-wrapper"
                 [matTooltip]="spoolCalculatorTooltip"
-                (click)="openSpoolWeightCalculator()"
               >
-                Adjust from measured weight
-              </button>
+                <button
+                  id="spool-calc-button"
+                  type="button"
+                  mat-raised-button
+                  color="primary"
+                  [disabled]="filamentForm.dirty"
+                  (click)="openSpoolWeightCalculator()"
+                >
+                  Adjust from measured weight
+                </button>
+              </span>
             }
           </div>
         </div>

--- a/src/app/filament/filament-detail/filament-detail.component.html
+++ b/src/app/filament/filament-detail/filament-detail.component.html
@@ -582,6 +582,20 @@
           >
             Add New Adjustment
           </button>
+          @if (canShowSpoolCalculator) {
+            <button
+              id="spool-calc-button"
+              type="button"
+              mat-raised-button
+              color="primary"
+              [disabled]="filamentForm.dirty"
+              [matTooltip]="spoolCalculatorTooltip"
+              (click)="openSpoolWeightCalculator()"
+              style="margin-bottom: 5px; margin-left: 5px"
+            >
+              Adjust from measured weight
+            </button>
+          }
         </div>
         <div formArrayName="filamentAdjustments" fxFlex="grow" fxFlexFill>
           @for (

--- a/src/app/filament/filament-detail/filament-detail.component.html
+++ b/src/app/filament/filament-detail/filament-detail.component.html
@@ -573,29 +573,29 @@
               ></a
             >
           </h3>
-          <button
-            type="button"
-            mat-raised-button
-            (click)="addAdjustment()"
-            color="accent"
-            style="margin-bottom: 5px"
-          >
-            Add New Adjustment
-          </button>
-          @if (canShowSpoolCalculator) {
+          <div class="adjustment-actions">
             <button
-              id="spool-calc-button"
               type="button"
               mat-raised-button
-              color="primary"
-              [disabled]="filamentForm.dirty"
-              [matTooltip]="spoolCalculatorTooltip"
-              (click)="openSpoolWeightCalculator()"
-              style="margin-bottom: 5px; margin-left: 5px"
+              (click)="addAdjustment()"
+              color="accent"
             >
-              Adjust from measured weight
+              Add New Adjustment
             </button>
-          }
+            @if (canShowSpoolCalculator) {
+              <button
+                id="spool-calc-button"
+                type="button"
+                mat-raised-button
+                color="primary"
+                [disabled]="filamentForm.dirty"
+                [matTooltip]="spoolCalculatorTooltip"
+                (click)="openSpoolWeightCalculator()"
+              >
+                Adjust from measured weight
+              </button>
+            }
+          </div>
         </div>
         <div formArrayName="filamentAdjustments" fxFlex="grow" fxFlexFill>
           @for (

--- a/src/app/filament/filament-detail/filament-detail.component.scss
+++ b/src/app/filament/filament-detail/filament-detail.component.scss
@@ -23,3 +23,12 @@ mat-card-title {
 .mat-mdc-form-field:not(.mat-focused) .mat-mdc-form-field-hint {
   display: none;
 }
+
+// Keep the adjustment action buttons left-aligned and evenly spaced,
+// wrapping cleanly onto multiple lines on narrow screens.
+.adjustment-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  margin-bottom: 5px;
+}

--- a/src/app/filament/filament-detail/filament-detail.component.scss
+++ b/src/app/filament/filament-detail/filament-detail.component.scss
@@ -32,3 +32,15 @@ mat-card-title {
   gap: 5px;
   margin-bottom: 5px;
 }
+
+// The calculator tooltip lives on this wrapper so it still shows while the
+// button is disabled. Native disabled buttons swallow the pointer events the
+// tooltip relies on, so the disabled button is made transparent to them and
+// the wrapper receives the hover instead.
+.spool-calc-tooltip-wrapper {
+  display: inline-flex;
+
+  button:disabled {
+    pointer-events: none;
+  }
+}

--- a/src/app/filament/filament-detail/filament-detail.component.spec.ts
+++ b/src/app/filament/filament-detail/filament-detail.component.spec.ts
@@ -12,8 +12,12 @@ import { ActivatedRoute } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ToastrService } from 'ngx-toastr';
 import { of } from 'rxjs';
+import { MatButtonModule } from '@angular/material/button';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 import {
   ColorPatternType,
+  FilamentAdjustmentSourceMeasurement,
   FilamentService,
 } from 'src/app/core/services/filament.service';
 import { LoggingService } from 'src/app/core/services/logging.service';
@@ -123,5 +127,186 @@ describe('FilamentDetailComponent', () => {
       component.addColorStop();
       expect(component.colorsFormArray.length).toBe(8);
     });
+  });
+});
+
+describe('FilamentDetailComponent - spool weight calculator', () => {
+  let calcComponent: FilamentDetailComponent;
+  let calcFixture: ComponentFixture<FilamentDetailComponent>;
+  let mockDialog: jasmine.SpyObj<MatDialog>;
+
+  const baseFilament = {
+    id: 'filament-1',
+    displayName: 'Test',
+    materialType: 'PLA',
+    materialDensityGramPerCubicCm: 1.24,
+    spoolWeightMg: 150000,
+    initialTotalWeightMg: 1150000,
+    initialNominalWeightMg: 1000000,
+    filamentRemaining: 500000,
+    filamentAdjustments: [],
+    colors: [],
+  };
+
+  async function setup(filamentOverrides: Record<string, unknown>) {
+    mockDialog = jasmine.createSpyObj<MatDialog>('MatDialog', ['open']);
+
+    const mockFilamentService = jasmine.createSpyObj<FilamentService>(
+      'FilamentService',
+      {
+        getFilamentBrands: of({ brands: [] }),
+        getFilamentPurchaseLocations: of({ purchaseLocations: [] }),
+        getFilamentStorageLocations: of({ storageLocations: [] }),
+      }
+    );
+    const mockToastr = jasmine.createSpyObj<ToastrService>('ToastrService', [
+      'success',
+    ]);
+    const mockUserSettings = jasmine.createSpyObj<UserSettingService>(
+      'UserSettingService',
+      ['updateUserSetting']
+    );
+    const mockLog = jasmine.createSpyObj<LoggingService>('LoggingService', [
+      'logException',
+      'logEvent',
+    ]);
+
+    await TestBed.configureTestingModule({
+      declarations: [FilamentDetailComponent],
+      imports: [
+        RouterTestingModule,
+        FormsModule,
+        ReactiveFormsModule,
+        MatInputModule,
+        MatSelectModule,
+        MatDatepickerModule,
+        MatCheckboxModule,
+        MatNativeDateModule,
+        MatAutocompleteModule,
+        MatButtonToggleModule,
+        MatChipsModule,
+        MatButtonModule,
+        MatTooltipModule,
+      ],
+      providers: [
+        { provide: FilamentService, useValue: mockFilamentService },
+        { provide: ToastrService, useValue: mockToastr },
+        { provide: UserSettingService, useValue: mockUserSettings },
+        { provide: LoggingService, useValue: mockLog },
+        { provide: MatDialog, useValue: mockDialog },
+        { provide: MAT_DATE_LOCALE, useValue: 'en-US' },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            data: of({
+              filament: { ...baseFilament, ...filamentOverrides },
+              materials: [],
+              materialCategories: [],
+            }),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    calcFixture = TestBed.createComponent(FilamentDetailComponent);
+    calcComponent = calcFixture.componentInstance;
+    calcFixture.detectChanges();
+  }
+
+  it('shows the calculator when saved, remaining known, and spool weight resolvable', async () => {
+    await setup({});
+    expect(calcComponent.canShowSpoolCalculator).toBeTrue();
+  });
+
+  it('hides the calculator when filamentRemaining is null', async () => {
+    await setup({ filamentRemaining: null });
+    expect(calcComponent.canShowSpoolCalculator).toBeFalse();
+  });
+
+  it('hides the calculator when spool weight cannot be resolved', async () => {
+    await setup({
+      spoolWeightMg: 0,
+      initialTotalWeightMg: 1000000,
+      initialNominalWeightMg: 1000000,
+    });
+    expect(calcComponent.canShowSpoolCalculator).toBeFalse();
+  });
+
+  it('renders the calculator button disabled while the form is dirty', async () => {
+    await setup({});
+    calcComponent.filamentForm.markAsDirty();
+    calcFixture.detectChanges();
+
+    const button: HTMLButtonElement | null =
+      calcFixture.nativeElement.querySelector('#spool-calc-button');
+    expect(button).not.toBeNull();
+    expect(button!.disabled).toBeTrue();
+  });
+
+  it('exposes a save-first tooltip when dirty and a help tooltip when pristine', async () => {
+    await setup({});
+    expect(calcComponent.spoolCalculatorTooltip).toContain('measured weight');
+
+    calcComponent.filamentForm.markAsDirty();
+    expect(calcComponent.spoolCalculatorTooltip).toContain('Save your changes');
+  });
+
+  it('does not open the dialog when the form is dirty', async () => {
+    await setup({});
+    calcComponent.filamentForm.markAsDirty();
+
+    calcComponent.openSpoolWeightCalculator();
+
+    expect(mockDialog.open).not.toHaveBeenCalled();
+  });
+
+  it('appends a fully-formed weight adjustment row, logs, and marks the form dirty on confirm', async () => {
+    await setup({});
+    mockDialog.open.and.returnValue({
+      afterClosed: () =>
+        of({
+          adjustmentG: -200,
+          measuredTotalWeightG: 450,
+          note: 'measured note',
+        }),
+    } as MatDialogRef<unknown>);
+
+    const before = calcComponent.filamentAdjustments.length;
+    calcComponent.openSpoolWeightCalculator();
+
+    expect(calcComponent.filamentAdjustments.length).toBe(before + 1);
+    const added = calcComponent.filamentAdjustments.at(
+      calcComponent.filamentAdjustments.length - 1
+    );
+    expect(added.get('source')!.value).toBe(
+      FilamentAdjustmentSourceMeasurement.Weight
+    );
+    expect(added.get('amountG')!.value).toBe(-200);
+    expect(added.get('lengthInM')!.value).toBeNull();
+    expect(added.get('volumeMl')!.value).toBeNull();
+    expect(added.get('filamentId')!.value).toBe('filament-1');
+    expect(added.get('notes')!.value).toBe('measured note');
+    expect(calcComponent.filamentForm.dirty).toBeTrue();
+
+    const logSpy = TestBed.inject(LoggingService).logEvent as jasmine.Spy;
+    expect(logSpy).toHaveBeenCalledWith(
+      'SpoolWeightCalculator_AdjustmentAdded',
+      {
+        measuredTotalWeightG: 450,
+        adjustmentG: -200,
+      }
+    );
+  });
+
+  it('does nothing when the dialog is cancelled', async () => {
+    await setup({});
+    mockDialog.open.and.returnValue({
+      afterClosed: () => of(undefined),
+    } as MatDialogRef<unknown>);
+
+    const before = calcComponent.filamentAdjustments.length;
+    calcComponent.openSpoolWeightCalculator();
+
+    expect(calcComponent.filamentAdjustments.length).toBe(before);
   });
 });

--- a/src/app/filament/filament-detail/filament-detail.component.ts
+++ b/src/app/filament/filament-detail/filament-detail.component.ts
@@ -44,6 +44,12 @@ import {
   QrLabelDialogComponent,
   QrLabelDialogData,
 } from 'src/app/shared/qr-label-dialog/qr-label-dialog.component';
+import {
+  SpoolWeightCalculatorDialogComponent,
+  SpoolWeightCalculatorDialogData,
+  SpoolWeightCalculatorDialogResult,
+} from '../spool-weight-calculator-dialog/spool-weight-calculator-dialog.component';
+import { resolveSpoolWeightMg } from '../spool-weight-calculator-dialog/spool-weight-adjustment.util';
 
 const EMPTY_GUID = '00000000-0000-0000-0000-000000000000';
 
@@ -57,6 +63,7 @@ export class FilamentDetailComponent
   implements OnInit, ComponentCanDeactivate, OnDestroy
 {
   public filamentForm: UntypedFormGroup;
+  public loadedFilament: FilamentDetail | null = null;
   public saving = false;
 
   public materials: Material[] = [];
@@ -154,6 +161,7 @@ export class FilamentDetailComponent
       this.defaultFilamentPriceSetting = data.defaultFilamentPriceSetting;
 
       this.filamentForm = this.buildFormFromFilamentDetail(data.filament);
+      this.loadedFilament = (data.filament as FilamentDetail) ?? null;
 
       this.normalizedColors = this.computeNormalizedColors();
       this.colorsSubscription = this.colorsFormArray.valueChanges.subscribe(
@@ -519,6 +527,90 @@ export class FilamentDetailComponent
 
   removeAdjustment(index: number) {
     this.filamentAdjustments.removeAt(index);
+  }
+
+  get canShowSpoolCalculator(): boolean {
+    const f = this.loadedFilament;
+    if (!f || !f.id) {
+      return false;
+    }
+    if (f.filamentRemaining === null || f.filamentRemaining === undefined) {
+      return false;
+    }
+    return (
+      resolveSpoolWeightMg(
+        f.spoolWeightMg,
+        f.initialTotalWeightMg,
+        f.initialNominalWeightMg
+      ) !== null
+    );
+  }
+
+  get spoolCalculatorTooltip(): string {
+    return this.filamentForm.dirty
+      ? 'Save your changes before using the calculator'
+      : "Calculate an adjustment from the spool's measured weight";
+  }
+
+  openSpoolWeightCalculator(): void {
+    const f = this.loadedFilament;
+    if (!f) {
+      return;
+    }
+
+    // The launch button is disabled while the form is dirty; guard the method
+    // too so the saved filamentRemaining the calculator reads always matches
+    // the form (see spec: available only when pristine).
+    if (this.filamentForm.dirty) {
+      return;
+    }
+
+    const spoolWeightMg = resolveSpoolWeightMg(
+      f.spoolWeightMg,
+      f.initialTotalWeightMg,
+      f.initialNominalWeightMg
+    );
+    if (
+      spoolWeightMg === null ||
+      f.filamentRemaining === null ||
+      f.filamentRemaining === undefined
+    ) {
+      return;
+    }
+
+    const dialogRef = this.dialog.open(SpoolWeightCalculatorDialogComponent, {
+      data: {
+        spoolWeightMg,
+        filamentRemainingMg: f.filamentRemaining,
+      } as SpoolWeightCalculatorDialogData,
+      width: '500px',
+    });
+
+    dialogRef
+      .afterClosed()
+      .subscribe((result: SpoolWeightCalculatorDialogResult | undefined) => {
+        if (!result) {
+          return;
+        }
+
+        this.filamentAdjustments.push(
+          this.buildFilamentAdjustmentFormGroup(
+            EMPTY_GUID,
+            f.id ?? EMPTY_GUID,
+            FilamentAdjustmentSourceMeasurement.Weight,
+            result.adjustmentG,
+            null,
+            null,
+            result.note
+          )
+        );
+        this.filamentForm.markAsDirty();
+
+        this.loggingService.logEvent('SpoolWeightCalculator_AdjustmentAdded', {
+          measuredTotalWeightG: result.measuredTotalWeightG,
+          adjustmentG: result.adjustmentG,
+        });
+      });
   }
 
   onColorPatternChange(): void {

--- a/src/app/filament/spool-weight-calculator-dialog/spool-weight-adjustment.util.spec.ts
+++ b/src/app/filament/spool-weight-calculator-dialog/spool-weight-adjustment.util.spec.ts
@@ -1,0 +1,49 @@
+import {
+  calculateSpoolAdjustment,
+  resolveSpoolWeightMg,
+} from './spool-weight-adjustment.util';
+
+describe('resolveSpoolWeightMg', () => {
+  it('prefers the stored spool weight when positive', () => {
+    expect(resolveSpoolWeightMg(150000, 1150000, 1000000)).toBe(150000);
+  });
+
+  it('derives from total minus nominal when stored is missing', () => {
+    expect(resolveSpoolWeightMg(null, 1150000, 1000000)).toBe(150000);
+  });
+
+  it('returns null when derived value is zero or negative', () => {
+    expect(resolveSpoolWeightMg(null, 1000000, 1000000)).toBeNull();
+    expect(resolveSpoolWeightMg(null, 900000, 1000000)).toBeNull();
+  });
+
+  it('returns null when nothing is resolvable', () => {
+    expect(resolveSpoolWeightMg(0, null, 1000000)).toBeNull();
+    expect(resolveSpoolWeightMg(undefined, undefined, undefined)).toBeNull();
+  });
+});
+
+describe('calculateSpoolAdjustment', () => {
+  it('computes the worked example (measured below tracked remaining)', () => {
+    // spool 150g, tracked remaining 500g, measured total 450g -> measured remaining 300g
+    const result = calculateSpoolAdjustment(450000, 150000, 500000);
+    expect(result.measuredRemainingMg).toBe(300000);
+    expect(result.adjustmentMg).toBe(-200000);
+    expect(result.negativeRemaining).toBeFalse();
+  });
+
+  it('produces a positive adjustment when measured exceeds tracked', () => {
+    const result = calculateSpoolAdjustment(750000, 150000, 500000);
+    expect(result.adjustmentMg).toBe(100000);
+  });
+
+  it('produces a zero adjustment when they match', () => {
+    const result = calculateSpoolAdjustment(650000, 150000, 500000);
+    expect(result.adjustmentMg).toBe(0);
+  });
+
+  it('flags negative remaining when measured is below spool weight', () => {
+    const result = calculateSpoolAdjustment(100000, 150000, 500000);
+    expect(result.negativeRemaining).toBeTrue();
+  });
+});

--- a/src/app/filament/spool-weight-calculator-dialog/spool-weight-adjustment.util.ts
+++ b/src/app/filament/spool-weight-calculator-dialog/spool-weight-adjustment.util.ts
@@ -1,0 +1,51 @@
+export interface SpoolAdjustmentResult {
+  /** Remaining filament weight implied by the measurement (mg). */
+  measuredRemainingMg: number;
+  /** The adjustment to add so tracked remaining matches the measurement (mg). */
+  adjustmentMg: number;
+  /** True when the measurement implies a negative remaining amount. */
+  negativeRemaining: boolean;
+}
+
+/**
+ * Resolve the empty spool weight in mg, preferring the stored value and
+ * falling back to (initial total - initial nominal). Returns null when no
+ * strictly-positive value can be resolved.
+ */
+export function resolveSpoolWeightMg(
+  spoolWeightMg: number | null | undefined,
+  initialTotalWeightMg: number | null | undefined,
+  initialNominalWeightMg: number | null | undefined
+): number | null {
+  if (spoolWeightMg != null && spoolWeightMg > 0) {
+    return spoolWeightMg;
+  }
+
+  if (initialTotalWeightMg != null && initialNominalWeightMg != null) {
+    const derived = initialTotalWeightMg - initialNominalWeightMg;
+    if (derived > 0) {
+      return derived;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Compute the weight adjustment needed to reconcile the tracked remaining
+ * with a measured total spool weight. All values in milligrams.
+ */
+export function calculateSpoolAdjustment(
+  measuredTotalWeightMg: number,
+  spoolWeightMg: number,
+  filamentRemainingMg: number
+): SpoolAdjustmentResult {
+  const measuredRemainingMg = measuredTotalWeightMg - spoolWeightMg;
+  const adjustmentMg = measuredRemainingMg - filamentRemainingMg;
+
+  return {
+    measuredRemainingMg,
+    adjustmentMg,
+    negativeRemaining: measuredRemainingMg < 0,
+  };
+}

--- a/src/app/filament/spool-weight-calculator-dialog/spool-weight-calculator-dialog.component.html
+++ b/src/app/filament/spool-weight-calculator-dialog/spool-weight-calculator-dialog.component.html
@@ -1,0 +1,66 @@
+<h2 mat-dialog-title>Adjust from Measured Weight</h2>
+
+<mat-dialog-content>
+  <p>
+    Weigh the whole spool, then enter the total below. We'll calculate the
+    adjustment needed to match what you actually have.
+  </p>
+
+  <div class="calc-facts">
+    <div>
+      <span class="calc-label">Spool weight</span>
+      <span class="calc-value">{{ spoolWeightG }} g</span>
+    </div>
+    <div>
+      <span class="calc-label">Currently tracked remaining</span>
+      <span class="calc-value">{{ filamentRemainingG }} g</span>
+    </div>
+  </div>
+
+  <mat-form-field class="calc-input" appearance="fill">
+    <mat-label>Current measured total weight (g)</mat-label>
+    <input
+      matInput
+      type="number"
+      inputmode="decimal"
+      [formControl]="measuredTotalWeightControl"
+      id="spool-calc-measured-weight"
+    />
+  </mat-form-field>
+
+  @if (preview(); as result) {
+    <div class="calc-result">
+      <div>
+        <span class="calc-label">Measured remaining</span>
+        <span class="calc-value">{{ result.measuredRemainingMg / 1000 }} g</span>
+      </div>
+      <div>
+        <span class="calc-label">Adjustment</span>
+        <span class="calc-value calc-adjustment"
+          >{{ result.adjustmentMg > 0 ? '+' : ''
+          }}{{ result.adjustmentMg / 1000 }} g</span
+        >
+      </div>
+      @if (result.negativeRemaining) {
+        <p class="calc-warning">
+          <mat-icon inline>warning</mat-icon>
+          The measured weight is below the spool weight, which implies a negative
+          remaining amount. Double-check the spool weight and your measurement.
+        </p>
+      }
+    </div>
+  }
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button mat-button type="button" (click)="cancel()">Cancel</button>
+  <button
+    mat-raised-button
+    color="primary"
+    type="button"
+    [disabled]="preview() === null"
+    (click)="confirm()"
+  >
+    Add Adjustment
+  </button>
+</mat-dialog-actions>

--- a/src/app/filament/spool-weight-calculator-dialog/spool-weight-calculator-dialog.component.html
+++ b/src/app/filament/spool-weight-calculator-dialog/spool-weight-calculator-dialog.component.html
@@ -2,23 +2,12 @@
 
 <mat-dialog-content>
   <p>
-    Weigh the whole spool, then enter the total below. We'll calculate the
-    adjustment needed to match what you actually have.
+    Weigh the whole spool, then enter the total below. We'll work out the
+    adjustment to match what you actually have.
   </p>
 
-  <div class="calc-facts">
-    <div>
-      <span class="calc-label">Spool weight</span>
-      <span class="calc-value">{{ spoolWeightG }} g</span>
-    </div>
-    <div>
-      <span class="calc-label">Currently tracked remaining</span>
-      <span class="calc-value">{{ filamentRemainingG }} g</span>
-    </div>
-  </div>
-
   <mat-form-field class="calc-input" appearance="fill">
-    <mat-label>Current measured total weight (g)</mat-label>
+    <mat-label>Measured total weight (g)</mat-label>
     <input
       matInput
       type="number"
@@ -26,29 +15,38 @@
       [formControl]="measuredTotalWeightControl"
       id="spool-calc-measured-weight"
     />
+    <span matTextSuffix>g</span>
   </mat-form-field>
+  <p class="calc-spool-note">Empty spool weight: {{ spoolWeightG }} g</p>
 
   @if (preview(); as result) {
-    <div class="calc-result">
-      <div>
-        <span class="calc-label">Measured remaining</span>
-        <span class="calc-value">{{ result.measuredRemainingMg / 1000 }} g</span>
+    <div class="calc-compare">
+      <div class="calc-state">
+        <span class="calc-state-label">Tracked</span>
+        <span class="calc-state-value">{{ filamentRemainingG }} g</span>
       </div>
-      <div>
-        <span class="calc-label">Adjustment</span>
-        <span class="calc-value calc-adjustment"
+
+      <div class="calc-arrow">
+        <mat-icon>arrow_forward</mat-icon>
+        <span class="calc-adjustment"
           >{{ result.adjustmentMg > 0 ? '+' : ''
           }}{{ result.adjustmentMg / 1000 }} g</span
         >
       </div>
-      @if (result.negativeRemaining) {
-        <p class="calc-warning">
-          <mat-icon inline>warning</mat-icon>
-          The measured weight is below the spool weight, which implies a negative
-          remaining amount. Double-check the spool weight and your measurement.
-        </p>
-      }
+
+      <div class="calc-state">
+        <span class="calc-state-label">Measured</span>
+        <span class="calc-state-value">{{ result.measuredRemainingMg / 1000 }} g</span>
+      </div>
     </div>
+
+    @if (result.negativeRemaining) {
+      <p class="calc-warning">
+        <mat-icon inline>warning</mat-icon>
+        The measured weight is below the spool weight, which implies a negative
+        remaining amount. Double-check the spool weight and your measurement.
+      </p>
+    }
   }
 </mat-dialog-content>
 

--- a/src/app/filament/spool-weight-calculator-dialog/spool-weight-calculator-dialog.component.html
+++ b/src/app/filament/spool-weight-calculator-dialog/spool-weight-calculator-dialog.component.html
@@ -40,7 +40,7 @@
       </div>
     </div>
 
-    @if (result.negativeRemaining) {
+    @if (showNegativeWarning()) {
       <p class="calc-warning">
         <mat-icon inline>warning</mat-icon>
         The measured weight is below the spool weight, which implies a negative

--- a/src/app/filament/spool-weight-calculator-dialog/spool-weight-calculator-dialog.component.scss
+++ b/src/app/filament/spool-weight-calculator-dialog/spool-weight-calculator-dialog.component.scss
@@ -1,0 +1,37 @@
+.calc-facts,
+.calc-result {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 12px 0;
+
+  > div {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+  }
+}
+
+.calc-input {
+  width: 100%;
+}
+
+.calc-label {
+  color: rgba(0, 0, 0, 0.6);
+}
+
+.calc-value {
+  font-weight: 600;
+}
+
+.calc-adjustment {
+  font-size: 1.1rem;
+}
+
+.calc-warning {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: #b26a00;
+  margin-top: 8px;
+}

--- a/src/app/filament/spool-weight-calculator-dialog/spool-weight-calculator-dialog.component.scss
+++ b/src/app/filament/spool-weight-calculator-dialog/spool-weight-calculator-dialog.component.scss
@@ -12,8 +12,8 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 12px;
-  flex-wrap: wrap;
+  gap: 8px;
+  flex-wrap: nowrap;
   margin: 20px 0 4px;
 }
 
@@ -21,8 +21,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  flex: 1 1 90px;
-  min-width: 80px;
+  flex: 1 1 0;
+  min-width: 0;
 }
 
 .calc-state-label {
@@ -30,12 +30,14 @@
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
+  white-space: nowrap;
 }
 
 .calc-state-value {
-  font-size: 1.5rem;
+  font-size: 1.4rem;
   font-weight: 600;
   line-height: 1.2;
+  white-space: nowrap;
 }
 
 .calc-arrow {

--- a/src/app/filament/spool-weight-calculator-dialog/spool-weight-calculator-dialog.component.scss
+++ b/src/app/filament/spool-weight-calculator-dialog/spool-weight-calculator-dialog.component.scss
@@ -1,31 +1,59 @@
-.calc-facts,
-.calc-result {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  margin: 12px 0;
-
-  > div {
-    display: flex;
-    justify-content: space-between;
-    gap: 16px;
-  }
-}
-
 .calc-input {
   width: 100%;
 }
 
-.calc-label {
+.calc-spool-note {
+  margin-top: -8px;
   color: rgba(0, 0, 0, 0.6);
+  font-size: 0.85rem;
 }
 
-.calc-value {
+.calc-compare {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin: 20px 0 4px;
+}
+
+.calc-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  flex: 1 1 90px;
+  min-width: 80px;
+}
+
+.calc-state-label {
+  color: rgba(0, 0, 0, 0.6);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.calc-state-value {
+  font-size: 1.5rem;
   font-weight: 600;
+  line-height: 1.2;
+}
+
+.calc-arrow {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  flex: 0 0 auto;
+
+  mat-icon {
+    color: rgba(0, 0, 0, 0.4);
+  }
 }
 
 .calc-adjustment {
-  font-size: 1.1rem;
+  font-weight: 600;
+  color: #1565c0;
+  white-space: nowrap;
 }
 
 .calc-warning {
@@ -33,5 +61,5 @@
   align-items: center;
   gap: 6px;
   color: #b26a00;
-  margin-top: 8px;
+  margin-top: 12px;
 }

--- a/src/app/filament/spool-weight-calculator-dialog/spool-weight-calculator-dialog.component.spec.ts
+++ b/src/app/filament/spool-weight-calculator-dialog/spool-weight-calculator-dialog.component.spec.ts
@@ -1,4 +1,9 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ComponentFixture,
+  fakeAsync,
+  TestBed,
+  tick,
+} from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 
@@ -77,16 +82,25 @@ describe('SpoolWeightCalculatorDialogComponent', () => {
     expect(dialogRef.close).not.toHaveBeenCalled();
   });
 
-  it('renders the negative-remaining warning but still allows confirm', () => {
+  it('shows the numeric preview immediately but debounces the negative-remaining warning', fakeAsync(() => {
     // Measured 100 g total is below the 150 g spool weight -> negative remaining
     component.measuredTotalWeightControl.setValue(100);
     fixture.detectChanges();
 
-    const warning: HTMLElement | null =
-      fixture.nativeElement.querySelector('.calc-warning');
-    expect(warning).not.toBeNull();
-
+    // Preview is immediate; the warning is not shown yet (debounce pending).
     expect(component.preview()).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('.calc-warning')).toBeNull();
+
+    // After the debounce elapses, the warning appears.
+    tick(500);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.querySelector('.calc-warning')).not.toBeNull();
+  }));
+
+  it('still allows confirm when the measurement is below the spool weight', () => {
+    component.measuredTotalWeightControl.setValue(100);
+    expect(component.preview()).not.toBeNull();
+
     component.confirm();
     expect(dialogRef.close).toHaveBeenCalledTimes(1);
   });

--- a/src/app/filament/spool-weight-calculator-dialog/spool-weight-calculator-dialog.component.spec.ts
+++ b/src/app/filament/spool-weight-calculator-dialog/spool-weight-calculator-dialog.component.spec.ts
@@ -1,0 +1,98 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+
+import {
+  SpoolWeightCalculatorDialogComponent,
+  SpoolWeightCalculatorDialogData,
+  SpoolWeightCalculatorDialogResult,
+} from './spool-weight-calculator-dialog.component';
+
+describe('SpoolWeightCalculatorDialogComponent', () => {
+  let component: SpoolWeightCalculatorDialogComponent;
+  let fixture: ComponentFixture<SpoolWeightCalculatorDialogComponent>;
+  let dialogRef: jasmine.SpyObj<
+    MatDialogRef<SpoolWeightCalculatorDialogComponent>
+  >;
+
+  const data: SpoolWeightCalculatorDialogData = {
+    spoolWeightMg: 150000,
+    filamentRemainingMg: 500000,
+  };
+
+  beforeEach(async () => {
+    dialogRef = jasmine.createSpyObj<
+      MatDialogRef<SpoolWeightCalculatorDialogComponent>
+    >('MatDialogRef', ['close']);
+
+    await TestBed.configureTestingModule({
+      imports: [SpoolWeightCalculatorDialogComponent, NoopAnimationsModule],
+      providers: [
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialogRef, useValue: dialogRef },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(SpoolWeightCalculatorDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('has no preview until a measured weight is entered', () => {
+    expect(component.preview()).toBeNull();
+  });
+
+  it('computes the adjustment preview from the measured weight (grams)', () => {
+    component.measuredTotalWeightControl.setValue(450);
+    const preview = component.preview();
+    expect(preview).not.toBeNull();
+    expect(preview!.adjustmentMg).toBe(-200000);
+    expect(preview!.measuredRemainingMg).toBe(300000);
+    expect(preview!.negativeRemaining).toBeFalse();
+  });
+
+  it('closes with the adjustment, measured weight, and a descriptive note on confirm', () => {
+    component.measuredTotalWeightControl.setValue(450);
+    component.confirm();
+
+    expect(dialogRef.close).toHaveBeenCalledTimes(1);
+    const result = dialogRef.close.calls.mostRecent()
+      .args[0] as SpoolWeightCalculatorDialogResult;
+    expect(result.adjustmentG).toBe(-200);
+    expect(result.measuredTotalWeightG).toBe(450);
+    expect(result.note).toContain('450');
+    expect(result.note).toContain('300');
+  });
+
+  it('does not close on confirm when no measured weight is entered', () => {
+    component.confirm();
+    expect(dialogRef.close).not.toHaveBeenCalled();
+  });
+
+  it('has no preview and does not close when the measured weight is zero', () => {
+    component.measuredTotalWeightControl.setValue(0);
+    expect(component.preview()).toBeNull();
+
+    component.confirm();
+    expect(dialogRef.close).not.toHaveBeenCalled();
+  });
+
+  it('renders the negative-remaining warning but still allows confirm', () => {
+    // Measured 100 g total is below the 150 g spool weight -> negative remaining
+    component.measuredTotalWeightControl.setValue(100);
+    fixture.detectChanges();
+
+    const warning: HTMLElement | null =
+      fixture.nativeElement.querySelector('.calc-warning');
+    expect(warning).not.toBeNull();
+
+    expect(component.preview()).not.toBeNull();
+    component.confirm();
+    expect(dialogRef.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes with no result on cancel', () => {
+    component.cancel();
+    expect(dialogRef.close).toHaveBeenCalledWith();
+  });
+});

--- a/src/app/filament/spool-weight-calculator-dialog/spool-weight-calculator-dialog.component.ts
+++ b/src/app/filament/spool-weight-calculator-dialog/spool-weight-calculator-dialog.component.ts
@@ -1,0 +1,106 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+} from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { CommonModule } from '@angular/common';
+import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatIconModule } from '@angular/material/icon';
+
+import {
+  calculateSpoolAdjustment,
+  SpoolAdjustmentResult,
+} from './spool-weight-adjustment.util';
+
+export interface SpoolWeightCalculatorDialogData {
+  /** Empty spool weight in mg (already resolved and > 0 by the caller). */
+  spoolWeightMg: number;
+  /** Server-computed remaining filament weight in mg. */
+  filamentRemainingMg: number;
+}
+
+export interface SpoolWeightCalculatorDialogResult {
+  /** The adjustment to append, in grams (source = Weight). */
+  adjustmentG: number;
+  /** The measured total spool weight the user entered, in grams. */
+  measuredTotalWeightG: number;
+  /** Auto-generated, user-editable note describing the measurement. */
+  note: string;
+}
+
+@Component({
+  selector: 'app-spool-weight-calculator-dialog',
+  templateUrl: './spool-weight-calculator-dialog.component.html',
+  styleUrls: ['./spool-weight-calculator-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatDialogModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatIconModule,
+  ],
+})
+export class SpoolWeightCalculatorDialogComponent {
+  readonly data = inject<SpoolWeightCalculatorDialogData>(MAT_DIALOG_DATA);
+  private readonly dialogRef =
+    inject<MatDialogRef<SpoolWeightCalculatorDialogComponent>>(MatDialogRef);
+
+  readonly spoolWeightG = this.data.spoolWeightMg / 1000;
+  readonly filamentRemainingG = this.data.filamentRemainingMg / 1000;
+
+  readonly measuredTotalWeightControl = new FormControl<number | null>(null, {
+    validators: [Validators.required, Validators.min(0.001)],
+  });
+
+  private readonly measuredValue = toSignal(
+    this.measuredTotalWeightControl.valueChanges,
+    { initialValue: this.measuredTotalWeightControl.value }
+  );
+
+  readonly preview = computed<SpoolAdjustmentResult | null>(() => {
+    const measuredG = this.measuredValue();
+    if (measuredG == null || measuredG <= 0) {
+      return null;
+    }
+    return calculateSpoolAdjustment(
+      measuredG * 1000,
+      this.data.spoolWeightMg,
+      this.data.filamentRemainingMg
+    );
+  });
+
+  confirm(): void {
+    const result = this.preview();
+    const measuredG = this.measuredTotalWeightControl.value;
+    if (!result || measuredG == null) {
+      return;
+    }
+
+    const adjustmentG = result.adjustmentMg / 1000;
+    const remainingG = result.measuredRemainingMg / 1000;
+    const note = `Measured total ${measuredG} g → ${remainingG} g remaining`;
+
+    this.dialogRef.close({
+      adjustmentG,
+      measuredTotalWeightG: measuredG,
+      note,
+    } as SpoolWeightCalculatorDialogResult);
+  }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/filament/spool-weight-calculator-dialog/spool-weight-calculator-dialog.component.ts
+++ b/src/app/filament/spool-weight-calculator-dialog/spool-weight-calculator-dialog.component.ts
@@ -5,6 +5,7 @@ import {
   inject,
 } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
+import { debounceTime } from 'rxjs';
 import { CommonModule } from '@angular/common';
 import { FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import {
@@ -80,6 +81,26 @@ export class SpoolWeightCalculatorDialogComponent {
       this.data.spoolWeightMg,
       this.data.filamentRemainingMg
     );
+  });
+
+  // The numeric preview updates instantly, but the "below spool weight" warning
+  // is driven off a debounced value so it does not flash while the user is still
+  // typing an intermediate number (e.g. "1" before "187").
+  private readonly debouncedMeasuredValue = toSignal(
+    this.measuredTotalWeightControl.valueChanges.pipe(debounceTime(500)),
+    { initialValue: this.measuredTotalWeightControl.value }
+  );
+
+  readonly showNegativeWarning = computed<boolean>(() => {
+    const measuredG = this.debouncedMeasuredValue();
+    if (measuredG == null || measuredG <= 0) {
+      return false;
+    }
+    return calculateSpoolAdjustment(
+      measuredG * 1000,
+      this.data.spoolWeightMg,
+      this.data.filamentRemainingMg
+    ).negativeRemaining;
   });
 
   confirm(): void {


### PR DESCRIPTION
## Summary

Adds a **Spool Weight Adjustment Calculator** to the filament detail page. Instead of computing a filament adjustment by hand, the user weighs the physical spool, enters the measured total, and the calculator produces the exact `Weight` adjustment needed to reconcile the tracked remaining amount with reality — then appends it as an unsaved, editable row.

## Depends on

- API PR HoffmanEngineering/3d-print-log-api#17 (adds `filamentRemaining` to the filament detail response). The calculator button only appears once the API returns that field.

## How it works

- **Availability gate:** filament saved, `filamentRemaining` known, spool weight resolvable (`spoolWeightMg`, else `initialTotal − initialNominal`), and the form is pristine (disabled with a tooltip while there are unsaved edits, so the calculation stays authoritative).
- **Dialog** (`Before → After` design): a `Tracked → Measured` comparison where the adjustment reads as the delta between them. Empty spool weight shown as a caption; numeric preview updates live.
- On confirm, appends a `Weight` adjustment (`amountG`, computed) with an auto note; the server converts it to length/volume on save.

## Notable details

- Numeric preview is instant; the "below spool weight" warning is **debounced (500ms)** so it doesn't flash while typing a partial number.
- Responsive fixes: adjustment action buttons wrap/left-align cleanly, and the comparison row stays on one line on small screens.
- Read-only `filamentRemaining?` added to the `FilamentDetail` model (optional; ignored on write).

## Tests

- Unit: pure calculation helper, dialog (preview, validation, debounced warning via `fakeAsync`), and detail-page wiring (gate, dirty-disable/tooltip, appended row shape, analytics payload). 614 passing, lint clean.
- E2E (`cypress/e2e/filaments/spool-weight-calculator.cy.ts`): full happy path (compute → append → persist) and gating (hidden on new material, disabled on dirty form). Both passing.
- Docs: new subsection on the materials documentation page.