### PR TITLE
feat: bump version to 1.43.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "print-log-ui",
-  "version": "1.42.0",
+  "version": "1.43.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --ssl --host 0.0.0.0 ",

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -28,6 +28,31 @@ export class VersionReleaseNoteDialogService {
   private readonly LOCAL_STORAGE_KEY = 'LastLoggedInVersion';
 
   private releaseNotes: ReleaseNoteHistory = {
+    '1.43.0': {
+      title: '1.43.0 - Spool Weight Calculator',
+      body: `<p>
+<strong>Spool Weight Adjustment Calculator</strong> is here! On a material's detail page, weigh the whole spool, enter the measured total, and 3D Print Log works out the exact adjustment to match what you actually have left (no more mental math or guessing the sign).
+</p>
+<p>
+  <strong>Support development of 3D Print Log:</strong><br />
+  <a href="/subscription">Subscribe to Pro</a> for an ad-free experience and extra cloud storage,
+  buy me a coffee by <a
+    href="https://paypal.me/hoffmanengineering"
+    rel="noreferrer noopener"
+    target="_blank"
+    >donating via PayPal</a
+  >, or by becoming a
+  <a
+    href="https://www.patreon.com/HoffmanEngineering"
+    rel="noreferrer noopener"
+    target="_blank"
+  >
+    Patron of Hoffman Engineering</a
+  >
+  on Patreon.com
+  </p><p>Share <strong>3D Print Log</strong> with a friend, and Happy Printing!
+</p>`,
+    },
     '1.42.0': {
       title: '1.42.0 - Preferred Filament Units & Date Localization',
       body: `<p>

--- a/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
+++ b/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
@@ -2,6 +2,31 @@
   <h2>Release Notes</h2>
   <hr />
 
+  <h3 id="v1.43.0">1.43.0 - Spool Weight Calculator</h3>
+  <p>
+    This release adds a <strong>Spool Weight Adjustment Calculator</strong> to the material detail
+    page. Instead of working out a filament adjustment by hand, weigh the whole spool, enter the
+    measured total, and 3D Print Log calculates the exact adjustment needed to match what you
+    actually have left (then adds it to your adjustments, ready to review before you save).
+  </p>
+  <h4>Full List of Changes:</h4>
+  <ul>
+    <li>
+      <strong>Spool Weight Adjustment Calculator</strong> - On the
+      <a routerLink="/materials">Materials</a> detail page, use "Adjust from measured weight" to
+      reconcile your tracked remaining filament with a scale reading. It combines the spool weight
+      and the currently tracked remaining amount into a clear before (tracked) and after (measured)
+      comparison, and adds the resulting adjustment for you.
+      (<a href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/39" rel="noreferrer noopener" target="_blank">PR #39</a>)
+    </li>
+    <li>
+      <strong>Works with any tracked unit</strong> - The calculator supports materials tracked by
+      weight, length, or volume, converting your measured weight into the correct adjustment
+      automatically.
+      (<a href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/39" rel="noreferrer noopener" target="_blank">PR #39</a>)
+    </li>
+  </ul>
+
   <h3 id="v1.42.0">1.42.0 - Preferred Filament Units</h3>
   <p>
     This release introduces a <strong>Preferred Filament Display Unit</strong> setting, letting you


### PR DESCRIPTION
## Release 1.43.0 - Spool Weight Calculator

Version bump and release notes for **1.43.0**, shipping the Spool Weight Adjustment Calculator (PR #39).

### Changes
- `package.json`: `1.42.0` -> `1.43.0`
- Release notes page: new `1.43.0 - Spool Weight Calculator` section
- Version dialog service: new `1.43.0` release-note entry

### After merge
Tag the release to cut it:
```
git tag v1.43.0
git push origin v1.43.0
```