### PR TITLE
fix: dark mode text readability (black text + focused inputs)

### DIFF
--- a/src/app/feed/feed-list/feed-list.component.scss
+++ b/src/app/feed/feed-list/feed-list.component.scss
@@ -1,6 +1,6 @@
 .end-of-feed {
   text-align: center;
-  color: rgba(0, 0, 0, 0.5);
+  color: var(--app-text-tertiary);
   padding: 24px 0;
   font-size: 14px;
 }

--- a/src/app/filament/filament-list-container/filament-list-container.component.scss
+++ b/src/app/filament/filament-list-container/filament-list-container.component.scss
@@ -128,7 +128,7 @@ table {
 .selection-count {
   font-size: 14px;
   font-weight: 500;
-  color: rgba(0, 0, 0, 0.7);
+  color: var(--app-text-strong);
 }
 
 .clear-selection-btn {
@@ -290,7 +290,7 @@ table {
 
   .card-weight {
     font-size: 13px;
-    color: rgba(0, 0, 0, 0.6);
+    color: var(--app-text-secondary);
     white-space: nowrap;
     flex-shrink: 0;
   }
@@ -322,7 +322,7 @@ table {
 
   .card-row-secondary {
     font-size: 12px;
-    color: rgba(0, 0, 0, 0.54);
+    color: var(--app-text-tertiary);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/app/filament/spool-weight-calculator-dialog/spool-weight-calculator-dialog.component.scss
+++ b/src/app/filament/spool-weight-calculator-dialog/spool-weight-calculator-dialog.component.scss
@@ -4,7 +4,7 @@
 
 .calc-spool-note {
   margin-top: -8px;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--app-text-secondary);
   font-size: 0.85rem;
 }
 
@@ -26,7 +26,7 @@
 }
 
 .calc-state-label {
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--app-text-secondary);
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -48,13 +48,13 @@
   flex: 0 0 auto;
 
   mat-icon {
-    color: rgba(0, 0, 0, 0.4);
+    color: var(--app-text-hint);
   }
 }
 
 .calc-adjustment {
   font-weight: 600;
-  color: #1565c0;
+  color: var(--app-accent-info-text);
   white-space: nowrap;
 }
 
@@ -62,6 +62,6 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  color: #b26a00;
+  color: var(--app-accent-warn-text);
   margin-top: 12px;
 }

--- a/src/app/print/edit-print-detail/edit-print-detail.component.scss
+++ b/src/app/print/edit-print-detail/edit-print-detail.component.scss
@@ -129,7 +129,7 @@ mat-card-title {
     display: flex;
     align-items: center;
     cursor: grab;
-    color: rgba(0, 0, 0, 0.54);
+    color: var(--app-text-tertiary);
 
     &:active {
       cursor: grabbing;

--- a/src/app/print/print-list/print-grouped-view/print-grouped-view.component.scss
+++ b/src/app/print/print-list/print-grouped-view/print-grouped-view.component.scss
@@ -108,7 +108,7 @@
 }
 
 .more-prints-cell {
-  color: rgba(0, 0, 0, 0.54);
+  color: var(--app-text-tertiary);
   font-style: italic;
   padding-left: 48px;
   font-size: 0.85em;
@@ -364,7 +364,7 @@
 
 .more-prints-mobile-row {
   text-align: center;
-  color: rgba(0, 0, 0, 0.54);
+  color: var(--app-text-tertiary);
   font-style: italic;
   font-size: 0.85em;
   padding: 4px 8px;

--- a/src/app/shared/filament-list/filament-list.component.scss
+++ b/src/app/shared/filament-list/filament-list.component.scss
@@ -252,7 +252,7 @@ mat-checkbox {
 
   .card-weight {
     font-size: 13px;
-    color: rgba(0, 0, 0, 0.6);
+    color: var(--app-text-secondary);
     white-space: nowrap;
     flex-shrink: 0;
   }
@@ -280,7 +280,7 @@ mat-checkbox {
 
   .card-row-secondary {
     font-size: 12px;
-    color: rgba(0, 0, 0, 0.54);
+    color: var(--app-text-tertiary);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;

--- a/src/app/shared/filament-search-modal/filament-search-modal.component.scss
+++ b/src/app/shared/filament-search-modal/filament-search-modal.component.scss
@@ -39,7 +39,7 @@ mat-dialog-content {
 
   p {
     margin: 0;
-    color: rgba(0, 0, 0, 0.6);
+    color: var(--app-text-secondary);
   }
 }
 

--- a/src/app/shared/notification-bell/notification-bell.component.scss
+++ b/src/app/shared/notification-bell/notification-bell.component.scss
@@ -46,7 +46,7 @@
   align-items: center;
   justify-content: center;
   padding: 32px;
-  color: rgba(0, 0, 0, 0.54);
+  color: var(--app-text-tertiary);
 
   mat-icon {
     font-size: 48px;
@@ -111,7 +111,7 @@
 
   .notification-message {
     font-size: 13px;
-    color: rgba(0, 0, 0, 0.6);
+    color: var(--app-text-secondary);
     line-height: 1.3;
     word-wrap: break-word;
     display: -webkit-box;
@@ -122,7 +122,7 @@
 
   .notification-time {
     font-size: 12px;
-    color: rgba(0, 0, 0, 0.54);
+    color: var(--app-text-tertiary);
     margin-top: 2px;
   }
 

--- a/src/app/shared/qr-label-dialog/qr-label-dialog.component.scss
+++ b/src/app/shared/qr-label-dialog/qr-label-dialog.component.scss
@@ -15,7 +15,7 @@
 
   p {
     margin: 0;
-    color: rgba(0, 0, 0, 0.6);
+    color: var(--app-text-secondary);
   }
 }
 
@@ -32,7 +32,7 @@
 
 .page-info {
   margin-bottom: 16px;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--app-text-secondary);
   font-size: 14px;
 }
 

--- a/src/app/shared/qr-scanner/qr-scanner.component.scss
+++ b/src/app/shared/qr-scanner/qr-scanner.component.scss
@@ -20,7 +20,7 @@ app-qr-scanner {
 
     p {
       margin: 0;
-      color: rgba(0, 0, 0, 0.6);
+      color: var(--app-text-secondary);
     }
   }
 
@@ -38,12 +38,12 @@ app-qr-scanner {
       font-size: 64px;
       width: 64px;
       height: 64px;
-      color: rgba(0, 0, 0, 0.38);
+      color: var(--app-text-hint);
     }
 
     .error-message {
       margin: 0;
-      color: rgba(0, 0, 0, 0.6);
+      color: var(--app-text-secondary);
       max-width: 300px;
       line-height: 1.5;
     }
@@ -81,7 +81,7 @@ app-qr-scanner {
 
   .scan-instructions {
     margin: 0;
-    color: rgba(0, 0, 0, 0.6);
+    color: var(--app-text-secondary);
     text-align: center;
     font-size: 14px;
   }

--- a/src/app/shared/sidebar/sidebar.component.scss
+++ b/src/app/shared/sidebar/sidebar.component.scss
@@ -4,7 +4,7 @@
 }
 
 .mat-mdc-list-item {
-  color: rgba(0, 0, 0, 0.65);
+  color: var(--app-text-strong);
   font-size: 1.1rem;
 }
 

--- a/src/app/subscription/pricing/pricing.component.scss
+++ b/src/app/subscription/pricing/pricing.component.scss
@@ -1,5 +1,5 @@
 .subtitle {
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--app-text-secondary);
   font-size: 1.1em;
   margin-bottom: 16px;
 }
@@ -27,12 +27,12 @@
 
     .period {
       font-size: 1.1em;
-      color: rgba(0, 0, 0, 0.6);
+      color: var(--app-text-secondary);
     }
   }
 
   .price-detail {
-    color: rgba(0, 0, 0, 0.6);
+    color: var(--app-text-secondary);
     font-size: 0.9em;
     margin-top: -8px;
   }

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -18,10 +18,16 @@ $light-theme: mat.m2-define-light-theme(
   )
 );
 
+// Dark mode uses a lighter primary (indigo A100) so focused inputs and other
+// primary accents stay readable on the dark surface. Indigo 500 (#3f51b5) is
+// too dark against #121212 — the focused input label/underline become hard to
+// read.
+$dark-primary: mat.m2-define-palette(mat.$m2-indigo-palette, A100);
+
 $dark-theme: mat.m2-define-dark-theme(
   (
     color: (
-      primary: $primary,
+      primary: $dark-primary,
       accent: $accent,
       warn: $warn,
     ),

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -83,6 +83,18 @@ html {
     0px 24px 38px 3px rgba(0, 0, 0, 0.14), 0px 9px 46px 8px rgba(0, 0, 0, 0.12);
 
   @include mat.all-component-themes($light-theme);
+
+  // Semantic text colors that follow the active theme. Use these instead of
+  // hardcoded rgba(0, 0, 0, x) so text stays readable on the dark surface.
+  // Light values match Material's standard on-surface emphasis levels.
+  --app-text-primary: rgba(0, 0, 0, 0.87);
+  --app-text-strong: rgba(0, 0, 0, 0.7);
+  --app-text-secondary: rgba(0, 0, 0, 0.6);
+  --app-text-tertiary: rgba(0, 0, 0, 0.54);
+  --app-text-hint: rgba(0, 0, 0, 0.38);
+  // Accent-colored text that needs a lighter variant on the dark surface.
+  --app-accent-info-text: #1565c0;
+  --app-accent-warn-text: #b26a00;
 }
 
 // mat-elevation-z* class rules are not emitted by the custom M2 theme (only the prebuilt does this).
@@ -117,4 +129,14 @@ body.dark-theme {
   color-scheme: dark;
   background-color: #121212;
   color: #e0e0e0;
+
+  // On the dark surface, on-surface text switches to white at matching
+  // emphasis levels (hint bumped slightly for legibility on #121212).
+  --app-text-primary: rgba(255, 255, 255, 0.87);
+  --app-text-strong: rgba(255, 255, 255, 0.87);
+  --app-text-secondary: rgba(255, 255, 255, 0.7);
+  --app-text-tertiary: rgba(255, 255, 255, 0.6);
+  --app-text-hint: rgba(255, 255, 255, 0.5);
+  --app-accent-info-text: #64b5f6;
+  --app-accent-warn-text: #ffb74d;
 }


### PR DESCRIPTION
## Summary

Fixes two dark-mode readability problems where text was hard to read on the dark surface.

### 1. Hardcoded black text on the dark surface
Many components hardcoded text colors as `rgba(0, 0, 0, x)` / dark hex, which don't respond to `body.dark-theme` and rendered near-black on `#121212` — e.g. the mobile material card's brand and remaining weight, and the spool weight calculator dialog.

- Added semantic text-color CSS variables (`--app-text-primary/strong/secondary/tertiary/hint` plus accent-info/warn) in `theme.scss`. They keep Material's standard light values and switch to white equivalents under `body.dark-theme`.
- Converted the hardcoded values to these variables **only** in components that render on theme-following surfaces.
- Intentionally left dark text on fixed-light surfaces (home marketing panels, the QR label's printed-page preview, error banners), and left components that already had complete dark-mode overrides (print-card, notifications-list, docs) untouched.

### 2. Focused inputs too dark
The dark theme reused light mode's indigo 500 (`#3f51b5`) as primary, so focused form-field labels/underlines/carets — and other primary accents (buttons, tabs) — were too dark to read. The dark theme now uses its own lighter primary palette (indigo A100, `#8c9eff`). Material auto-computes the contrast text color, so primary-filled buttons flip to dark text on the lighter blue. Light mode is unchanged.

## Verification
- `npm run build:dev` compiles cleanly.
- Spot-checked live in dark mode: mobile material card (remaining + brand readable), focused search input (light periwinkle label/underline), and the spool weight calculator dialog (state labels readable, adjustment value now light blue `#64b5f6`, primary button light periwinkle with dark text). No regressions in the release-notes dialog, edit-material form, or desktop table; light mode unaffected.