### PR TITLE
feat: bump version to 1.43.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "print-log-ui",
-  "version": "1.43.0",
+  "version": "1.43.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --ssl --host 0.0.0.0 ",

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -28,6 +28,9 @@ export class VersionReleaseNoteDialogService {
   private readonly LOCAL_STORAGE_KEY = 'LastLoggedInVersion';
 
   private releaseNotes: ReleaseNoteHistory = {
+    '1.43.1': {
+      redirect: '1.43.0',
+    },
     '1.43.0': {
       title: '1.43.0 - Spool Weight Calculator',
       body: `<p>

--- a/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
+++ b/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
@@ -2,6 +2,28 @@
   <h2>Release Notes</h2>
   <hr />
 
+  <h3 id="v1.43.1">1.43.1 - Dark Mode Readability Fixes</h3>
+  <p>
+    This patch improves readability in dark mode. Several spots that showed hard-to-read dark text
+    on the dark background (such as the material list cards on mobile and the spool weight calculator
+    dialog) now use theme-aware colors, and focused input fields use a lighter, more legible blue.
+  </p>
+  <h4>Full List of Changes:</h4>
+  <ul>
+    <li>
+      <strong>Readable text on dark surfaces</strong> - Text that was hardcoded to a dark color
+      (including the material card brand and remaining weight, and the spool weight calculator) now
+      follows the active theme, so it stays legible in dark mode.
+      (<a href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/41" rel="noreferrer noopener" target="_blank">PR #41</a>)
+    </li>
+    <li>
+      <strong>Lighter focused inputs</strong> - Focused form fields (and other primary accents like
+      buttons and tabs) now use a lighter blue in dark mode, so the focused label and underline are
+      easier to read against the dark background.
+      (<a href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/41" rel="noreferrer noopener" target="_blank">PR #41</a>)
+    </li>
+  </ul>
+
   <h3 id="v1.43.0">1.43.0 - Spool Weight Calculator</h3>
   <p>
     This release adds a <strong>Spool Weight Adjustment Calculator</strong> to the material detail


### PR DESCRIPTION
## Release 1.43.1 (patch)

Ships the dark-mode readability fixes from #41.

### Changes
- Bump version `1.43.0` -> `1.43.1` (`package.json`)
- Add 1.43.1 changelog section to the release notes page
- Add a redirect release-note entry (`1.43.1` -> `1.43.0`) so no new version dialog pops up for this patch

### Included fixes (from #41)
- Hardcoded dark text now follows the active theme, so it stays readable on the dark surface (material card brand/remaining weight, spool weight calculator dialog, and other components)
- Dark mode uses a lighter primary (indigo A100), so focused inputs and other primary accents are legible against the dark background

### After merge
Tag the release:
```
git tag v1.43.1
git push origin v1.43.1
```