### PR TITLE
fix: dark-mode toolbar text and broken avatar in print view

### DIFF
--- a/src/app/documentation/documentation.component.scss
+++ b/src/app/documentation/documentation.component.scss
@@ -12,6 +12,10 @@
 
 :host-context(body.dark-theme) .example-toolbar {
   background-color: var(--brand-toolbar-bg);
+  // The dark theme's lighter primary makes Material's on-primary contrast color
+  // dark, so the "Documentation" heading and the menu icon would render near-
+  // invisible on this dark toolbar. Force white to match the dark background.
+  color: white;
 }
 
 h1.example-app-name {

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -313,6 +313,10 @@ mat-toolbar {
 
 :host-context(body.dark-theme) mat-toolbar {
   background-color: var(--brand-toolbar-bg);
+  // The dark theme's lighter primary makes Material's on-primary contrast color
+  // dark, so hero/footer text would render near-invisible on this dark toolbar.
+  // Force white to match the dark indigo background.
+  color: white;
 }
 
 .wrapper {

--- a/src/app/print/view-print-detail/view-print-detail.component.html
+++ b/src/app/print/view-print-detail/view-print-detail.component.html
@@ -7,7 +7,11 @@
   <mat-card appearance="outlined" fxFlex="500px" fxFlex.xs="100%">
     <div fxLayout="column" fxLayoutAlign="start center" fxLayoutGap="10px">
       <mat-card-header fxFlex="grow">
-        <img mat-card-avatar [src]="this.user.profilePicture" />
+        <img
+          mat-card-avatar
+          [src]="this.user.profilePicture || '/assets/user.svg'"
+          alt="Uploader's profile picture"
+        />
         <mat-card-title>
           {{ print.title }}
         </mat-card-title>

--- a/src/app/shared/navbar/navbar.component.scss
+++ b/src/app/shared/navbar/navbar.component.scss
@@ -65,6 +65,15 @@ a:not([mat-menu-item]) {
   }
 }
 
+// The toolbar background is always a dark indigo, but the menu-trigger buttons
+// (Printers, About) are <button> elements that inherit Material's on-primary
+// text color rather than the white forced on the <a> links above. When the dark
+// theme switched primary to a lighter indigo, that contrast color became dark
+// and the buttons rendered near-invisible. Force them white to match the links.
+button.link {
+  color: white;
+}
+
 .profile-picture {
   vertical-align: middle;
   width: 50px;

--- a/src/app/shared/notification-bell/notification-bell.component.scss
+++ b/src/app/shared/notification-bell/notification-bell.component.scss
@@ -1,5 +1,8 @@
 .notification-bell-button {
-  color: inherit;
+  // The toolbar background is always a dark indigo. Inheriting Material's
+  // on-primary text color made the icon dark once the dark theme switched to a
+  // lighter primary, so pin it to white to stay visible on the toolbar.
+  color: white;
 }
 
 .notification-header {


### PR DESCRIPTION
## Summary

Two dark-mode / image display fixes.

### 1. Primary toolbar text & icons unreadable in dark mode
The dark theme switched `primary` to a lighter indigo (A100), so Material now computes a **dark** on-primary contrast color. The brand toolbars override their background to a dark indigo but still inherited that dark foreground, so these rendered near-invisible:

- Navbar menu-trigger buttons (**Printers**, **About**)
- The **notification bell** icon
- The home hero/footer headings ("Log and analyze your 3D Prints")
- The **Documentation** header and its menu icon on `/docs`

Fixed by forcing white text on the affected toolbar elements to match the dark indigo background. These were the only `color="primary"` toolbars in the app; other dark-mode surfaces use the semantic `--app-text-*` variables and were unaffected.

### 2. Broken-image glyph on the print detail view
The print detail view rendered the uploader's avatar with an unguarded `<img [src]="user.profilePicture">`, so prints from users without a profile picture showed the browser's broken-image icon. Now falls back to the default `user.svg`, matching the navbar.

## Testing
- `npm run build:dev` compiles clean
- Existing unit tests pass
