### PR TITLE
feat: bump version to 1.43.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "print-log-ui",
-  "version": "1.43.1",
+  "version": "1.43.2",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --ssl --host 0.0.0.0 ",

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -28,6 +28,9 @@ export class VersionReleaseNoteDialogService {
   private readonly LOCAL_STORAGE_KEY = 'LastLoggedInVersion';
 
   private releaseNotes: ReleaseNoteHistory = {
+    '1.43.2': {
+      redirect: '1.43.1',
+    },
     '1.43.1': {
       redirect: '1.43.0',
     },

--- a/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
+++ b/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
@@ -2,6 +2,31 @@
   <h2>Release Notes</h2>
   <hr />
 
+  <h3 id="v1.43.2">1.43.2 - Dark Mode Menu &amp; Print View Fixes</h3>
+  <p>
+    This patch fixes a few dark mode display issues. The navigation menu options (Printers and About),
+    the notification bell icon, and the headings on the home and documentation pages were showing in a
+    hard-to-read dark color on the dark toolbar, and now stay white and legible.
+  </p>
+  <p>
+    It also fixes a broken image icon that could appear on the print view when a print was uploaded by
+    someone without a profile picture (a default avatar is now shown instead).
+  </p>
+  <h4>Full List of Changes:</h4>
+  <ul>
+    <li>
+      <strong>Readable dark mode menu bar</strong> - The menu buttons (Printers, About), the
+      notification bell, and the home and documentation page headings now stay white on the dark
+      toolbar instead of turning a dark, hard-to-read color.
+      (<a href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/43" rel="noreferrer noopener" target="_blank">PR #43</a>)
+    </li>
+    <li>
+      <strong>Default avatar on the print view</strong> - Prints uploaded by users without a profile
+      picture no longer show a broken image icon; a default avatar is shown instead.
+      (<a href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/43" rel="noreferrer noopener" target="_blank">PR #43</a>)
+    </li>
+  </ul>
+
   <h3 id="v1.43.1">1.43.1 - Dark Mode Readability Fixes</h3>
   <p>
     This patch improves readability in dark mode. Several spots that showed hard-to-read dark text


### PR DESCRIPTION
## Release v1.43.2

Patch release covering the fixes from #43.

### Changes
- **Readable dark mode menu bar** — the menu buttons (Printers, About), the notification bell, and the home/documentation page headings now stay white on the dark toolbar instead of turning a dark, hard-to-read color.
- **Default avatar on the print view** — prints uploaded by users without a profile picture no longer show a broken-image icon; a default avatar is shown instead.

### Release chores
- Bumped `package.json` to 1.43.2
- Added the 1.43.2 section to the docs release notes page
- Added a dialog redirect entry (no version popup for this patch)
