### PR TITLE
Release v1.43.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "print-log-ui",
-  "version": "1.43.2",
+  "version": "1.43.3",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --ssl --host 0.0.0.0 ",

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -28,6 +28,9 @@ export class VersionReleaseNoteDialogService {
   private readonly LOCAL_STORAGE_KEY = 'LastLoggedInVersion';
 
   private releaseNotes: ReleaseNoteHistory = {
+    '1.43.3': {
+      redirect: '1.43.2',
+    },
     '1.43.2': {
       redirect: '1.43.1',
     },

--- a/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
+++ b/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
@@ -2,6 +2,30 @@
   <h2>Release Notes</h2>
   <hr />
 
+  <h3 id="v1.43.3">1.43.3 - SEO &amp; Sitemap Improvements</h3>
+  <p>
+    This release focuses on search-engine visibility. 3D Print Log now publishes dedicated landing
+    pages for popular slicers (Cura, PrusaSlicer, Bambu Studio, OrcaSlicer, and more) that are
+    pre-rendered so search engines can read them directly.
+  </p>
+  <p>
+    It also rebuilds how the sitemap is generated, so every public print and profile page is included
+    and kept up to date daily. There are no changes to the app you use day to day.
+  </p>
+  <h4>Full List of Changes:</h4>
+  <ul>
+    <li>
+      <strong>Slicer landing pages</strong> - New pre-rendered pages for major slicers, with links
+      between them, improving how 3D Print Log appears in search results.
+      (<a href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/45" rel="noreferrer noopener" target="_blank">PR #45</a>)
+    </li>
+    <li>
+      <strong>Rebuilt sitemap</strong> - The sitemap is now generated at deploy time and refreshed
+      daily, covering all public print and profile pages.
+      (<a href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/45" rel="noreferrer noopener" target="_blank">PR #45</a>)
+    </li>
+  </ul>
+
   <h3 id="v1.43.2">1.43.2 - Dark Mode Menu &amp; Print View Fixes</h3>
   <p>
     This patch fixes a few dark mode display issues. The navigation menu options (Printers and About),


### PR DESCRIPTION
Patch release. No changes to the app's day-to-day UI; this bundles the SEO/prerendering and sitemap work from #45.

## Version
1.43.2 -> 1.43.3

## Included
- Pre-rendered slicer landing pages (Cura, PrusaSlicer, Bambu Studio, OrcaSlicer, and forks) for search visibility.
- Build-time sitemap generation (`<sitemapindex>` + chunked child sitemaps) covering marketing routes plus all public print/user pages, refreshed daily; the orphaned Azure Function sitemap is retired.
- Prerender-infra cleanups (removed dead Express SSR scaffolding, registered `FlexLayoutServerModule`).
- Docs updated (CLAUDE.md, AGENTS.md, CONTRIBUTING.md, README.md) with prerendering/SSR-safety and sitemap notes.

## Release-notes wiring
- `docs-release-notes.component.html`: new 1.43.3 entry.
- `version-release-note-dialog.service.ts`: 1.43.3 redirects to 1.43.2 (no version popup for this patch).

After merge, tag the release:
```
git tag v1.43.3
git push origin v1.43.3
```