### PR TITLE
Fix dark-mode flash on prerendered pages

### DIFF
--- a/scripts/verify-prerender.mjs
+++ b/scripts/verify-prerender.mjs
@@ -74,6 +74,11 @@ for (const r of routes) {
     errors.push(`${file}: missing og:type`);
   if (metaContent(html, 'name="twitter:card"') !== 'summary_large_image')
     errors.push(`${file}: missing/wrong twitter:card`);
+  // Pre-paint theme script: without it the prerendered (light) HTML flashes before
+  // ThemeService applies the saved dark theme on boot.
+  if (!(html.includes("localStorage.getItem('theme-mode')") &&
+        html.includes("classList.add('dark-theme')")))
+    errors.push(`${file}: missing pre-paint theme script (dark-mode flash guard)`);
 }
 
 // Fork pages: each must link to the hub in body and carry its own hook (checked via a

--- a/src/index.html
+++ b/src/index.html
@@ -57,6 +57,24 @@
     ></script>
   </head>
   <body class="mat-app-background">
+    <!-- Apply the saved theme before first paint to avoid a light-mode flash on
+         prerendered pages. Keep in sync with ThemeService (key 'theme-mode'). -->
+    <script>
+      (function () {
+        try {
+          var mode = localStorage.getItem('theme-mode') || 'system';
+          var isDark =
+            mode === 'dark' ||
+            (mode === 'system' &&
+              window.matchMedia('(prefers-color-scheme: dark)').matches);
+          if (isDark) {
+            document.body.classList.add('dark-theme');
+            var meta = document.querySelector('meta[name="theme-color"]');
+            if (meta) meta.setAttribute('content', '#283593');
+          }
+        } catch (e) {}
+      })();
+    </script>
     <app-root></app-root>
   </body>
 </html>

--- a/src/index.prod.html
+++ b/src/index.prod.html
@@ -61,6 +61,24 @@
     ></script>
   </head>
   <body>
+    <!-- Apply the saved theme before first paint to avoid a light-mode flash on
+         prerendered pages. Keep in sync with ThemeService (key 'theme-mode'). -->
+    <script>
+      (function () {
+        try {
+          var mode = localStorage.getItem('theme-mode') || 'system';
+          var isDark =
+            mode === 'dark' ||
+            (mode === 'system' &&
+              window.matchMedia('(prefers-color-scheme: dark)').matches);
+          if (isDark) {
+            document.body.classList.add('dark-theme');
+            var meta = document.querySelector('meta[name="theme-color"]');
+            if (meta) meta.setAttribute('content', '#283593');
+          }
+        } catch (e) {}
+      })();
+    </script>
     <app-root></app-root>
   </body>
 </html>


### PR DESCRIPTION
## Problem

Prerendered marketing pages flash light mode before switching to dark. Prerendering runs in Node with no `localStorage`, so the static HTML ships with a bare `<body>`. The browser paints it light, then Angular boots, `ThemeService.initialize()` adds `body.dark-theme`, and the page repaints. Dark-mode (and OS-dark `system`-mode) users see a flash.

## Fix

Add a small synchronous inline script as the first child of `<body>` that mirrors `ThemeService`'s logic and applies the theme before first paint (the standard no-flash theme pattern):

- Runs as a blocking inline script while `<body>` already exists, so `body.dark-theme` lands before `<app-root>` renders. No repaint.
- Targets `body.dark-theme`, matching the existing CSS (no selector refactor).
- Handles `system` mode via `matchMedia`, so OS-dark users with no saved preference also avoid the flash.
- Also updates the `theme-color` meta to the dark toolbar color (`#283593`) so the browser chrome matches.
- After boot, `ThemeService.initialize()` re-applies the same class (a visual no-op); the `isDark` signal still drives the toolbar.

Added to `src/index.prod.html` (prerender/production template) and `src/index.html` (dev parity).

## Regression guard

`scripts/verify-prerender.mjs` now asserts every prerendered route contains the pre-paint theme script, so it can't silently disappear from the template.

## Testing

- `npm run build` + `verify-prerender.mjs`: green; script confirmed present in the prerendered homepage and slicer routes (exactly once).
- 616 unit tests pass; lint clean.

Manual check after deploy: with dark mode saved, load `/` or `/orcaslicer` fresh (hard refresh) and confirm no light flash.