### PR TITLE
Release v1.43.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "print-log-ui",
-  "version": "1.43.3",
+  "version": "1.43.4",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --ssl --host 0.0.0.0 ",

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -28,6 +28,9 @@ export class VersionReleaseNoteDialogService {
   private readonly LOCAL_STORAGE_KEY = 'LastLoggedInVersion';
 
   private releaseNotes: ReleaseNoteHistory = {
+    '1.43.4': {
+      redirect: '1.43.3',
+    },
     '1.43.3': {
       redirect: '1.43.2',
     },

--- a/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
+++ b/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
@@ -2,6 +2,22 @@
   <h2>Release Notes</h2>
   <hr />
 
+  <h3 id="v1.43.4">1.43.4 - Dark Mode Flash Fix</h3>
+  <p>
+    This patch fixes a brief flash of light mode when opening 3D Print Log with dark mode enabled. Your
+    saved theme is now applied before the page first renders, so dark mode users go straight to dark
+    with no flicker.
+  </p>
+  <h4>Full List of Changes:</h4>
+  <ul>
+    <li>
+      <strong>No more dark mode flash</strong> - Pages now apply your saved theme before they first
+      paint, removing the momentary light-mode flash on load (most noticeable on the slicer landing
+      pages).
+      (<a href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/47" rel="noreferrer noopener" target="_blank">PR #47</a>)
+    </li>
+  </ul>
+
   <h3 id="v1.43.3">1.43.3 - SEO &amp; Sitemap Improvements</h3>
   <p>
     This release focuses on search-engine visibility. 3D Print Log now publishes dedicated landing


### PR DESCRIPTION
Patch release. Fixes the dark-mode flash on prerendered pages (#47).

## Version
1.43.3 -> 1.43.4

## Included
- Saved theme is applied before first paint, removing the light-mode flash for dark-mode (and OS-dark) users on prerendered pages.

## Release-notes wiring
- `docs-release-notes.component.html`: new 1.43.4 entry.
- `version-release-note-dialog.service.ts`: 1.43.4 redirects to 1.43.3 (no version popup for this patch).

After merge, tag the release:
```
git tag v1.43.4
git push origin v1.43.4
```