### PR TITLE
Eliminate dark-mode flash on prerendered pages (theme <html> before first paint)

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -64,7 +64,14 @@
                 "input": "src/index.prod.html",
                 "output": "index.html"
               },
-              "optimization": true,
+              "optimization": {
+                "scripts": true,
+                "fonts": true,
+                "styles": {
+                  "minify": true,
+                  "inlineCritical": false
+                }
+              },
               "outputHashing": "all",
               "sourceMap": false,
               "namedChunks": false,

--- a/src/app/core/services/theme.service.spec.ts
+++ b/src/app/core/services/theme.service.spec.ts
@@ -21,7 +21,7 @@ describe('ThemeService', () => {
     spyOn(window, 'matchMedia').and.returnValue(mockMediaQuery as any);
 
     mockDocument = document;
-    mockDocument.body.className = '';
+    mockDocument.documentElement.className = '';
 
     TestBed.resetTestingModule();
     TestBed.configureTestingModule({
@@ -48,7 +48,9 @@ describe('ThemeService', () => {
   it('setMode(dark) adds dark-theme class to body', () => {
     buildService();
     service.setMode('dark');
-    expect(mockDocument.body.classList.contains('dark-theme')).toBeTrue();
+    expect(
+      mockDocument.documentElement.classList.contains('dark-theme')
+    ).toBeTrue();
   });
 
   it('setMode(dark) writes to localStorage', () => {
@@ -59,22 +61,28 @@ describe('ThemeService', () => {
 
   it('setMode(light) removes dark-theme class from body', () => {
     buildService('dark');
-    mockDocument.body.classList.add('dark-theme');
+    mockDocument.documentElement.classList.add('dark-theme');
     service.setMode('light');
-    expect(mockDocument.body.classList.contains('dark-theme')).toBeFalse();
+    expect(
+      mockDocument.documentElement.classList.contains('dark-theme')
+    ).toBeFalse();
   });
 
   it('setMode(system) adds dark-theme when OS prefers dark', () => {
     buildService(null, true /* osPrefersDark */);
     service.setMode('system');
-    expect(mockDocument.body.classList.contains('dark-theme')).toBeTrue();
+    expect(
+      mockDocument.documentElement.classList.contains('dark-theme')
+    ).toBeTrue();
   });
 
   it('setMode(system) removes dark-theme when OS prefers light', () => {
     buildService(null, false /* osPrefersDark */);
-    mockDocument.body.classList.add('dark-theme');
+    mockDocument.documentElement.classList.add('dark-theme');
     service.setMode('system');
-    expect(mockDocument.body.classList.contains('dark-theme')).toBeFalse();
+    expect(
+      mockDocument.documentElement.classList.contains('dark-theme')
+    ).toBeFalse();
   });
 
   it('initialize() registers media query change listener', () => {
@@ -99,10 +107,12 @@ describe('ThemeService', () => {
     const [, listener] = mockMediaQuery.addEventListener.calls.first().args;
 
     // OS switches to dark — should NOT change class since mode is 'dark', not 'system'
-    mockDocument.body.classList.remove('dark-theme');
+    mockDocument.documentElement.classList.remove('dark-theme');
     mockMediaQuery.matches = true;
     listener();
-    expect(mockDocument.body.classList.contains('dark-theme')).toBeFalse();
+    expect(
+      mockDocument.documentElement.classList.contains('dark-theme')
+    ).toBeFalse();
   });
 
   it('media query change applies dark-theme when mode is system and OS switches to dark', () => {
@@ -112,6 +122,8 @@ describe('ThemeService', () => {
 
     mockMediaQuery.matches = true;
     listener();
-    expect(mockDocument.body.classList.contains('dark-theme')).toBeTrue();
+    expect(
+      mockDocument.documentElement.classList.contains('dark-theme')
+    ).toBeTrue();
   });
 });

--- a/src/app/core/services/theme.service.ts
+++ b/src/app/core/services/theme.service.ts
@@ -58,6 +58,6 @@ export class ThemeService {
       mode === 'dark' ||
       (mode === 'system' && !!this.mediaQuery && this.mediaQuery.matches);
     this.isDark.set(isDark);
-    this.document.body.classList.toggle('dark-theme', isDark);
+    this.document.documentElement.classList.toggle('dark-theme', isDark);
   }
 }

--- a/src/app/documentation/docs/docs-getting-started/docs-getting-started.component.scss
+++ b/src/app/documentation/docs/docs-getting-started/docs-getting-started.component.scss
@@ -277,7 +277,7 @@
 }
 
 /* Dark Mode Overrides */
-:host-context(body.dark-theme) {
+:host-context(html.dark-theme) {
   .hero-title,
   .section-heading,
   .final-cta-heading {

--- a/src/app/documentation/documentation.component.scss
+++ b/src/app/documentation/documentation.component.scss
@@ -10,7 +10,7 @@
   z-index: 1;
 }
 
-:host-context(body.dark-theme) .example-toolbar {
+:host-context(html.dark-theme) .example-toolbar {
   background-color: var(--brand-toolbar-bg);
   // The dark theme's lighter primary makes Material's on-primary contrast color
   // dark, so the "Documentation" heading and the menu icon would render near-
@@ -38,7 +38,7 @@ h1.example-app-name {
   padding: 10px;
   background-color: white;
 
-  :host-context(body.dark-theme) & {
+  :host-context(html.dark-theme) & {
     background-color: #1e1e1e;
   }
 }

--- a/src/app/filament/filament-detail/filament-detail.component.scss
+++ b/src/app/filament/filament-detail/filament-detail.component.scss
@@ -9,7 +9,7 @@ mat-form-field {
   outline-offset: 2px;
 }
 
-:host-context(body.dark-theme) {
+:host-context(html.dark-theme) {
   ::ng-deep mat-chip-listbox .mat-mdc-chip-option.cdk-keyboard-focused {
     outline-color: rgba(255, 255, 255, 0.75);
   }

--- a/src/app/filament/filament-list-container/filament-list-container.component.scss
+++ b/src/app/filament/filament-list-container/filament-list-container.component.scss
@@ -329,7 +329,7 @@ table {
   }
 }
 
-:host-context(body.dark-theme) {
+:host-context(html.dark-theme) {
   .filament-color-cell {
     box-shadow:
       0 0 0 1px rgba(255, 255, 255, 0.15),

--- a/src/app/home/home.component.scss
+++ b/src/app/home/home.component.scss
@@ -325,7 +325,7 @@ mat-toolbar {
   height: auto;
 }
 
-:host-context(body.dark-theme) mat-toolbar {
+:host-context(html.dark-theme) mat-toolbar {
   background-color: var(--brand-toolbar-bg);
   // The dark theme's lighter primary makes Material's on-primary contrast color
   // dark, so hero/footer text would render near-invisible on this dark toolbar.

--- a/src/app/notifications/notifications-list/notifications-list.component.scss
+++ b/src/app/notifications/notifications-list/notifications-list.component.scss
@@ -62,7 +62,7 @@
   padding: 64px 16px;
   color: rgba(0, 0, 0, 0.54);
 
-  :host-context(body.dark-theme) & {
+  :host-context(html.dark-theme) & {
     color: rgba(255, 255, 255, 0.54);
   }
 
@@ -79,7 +79,7 @@
     font-weight: 500;
     color: rgba(0, 0, 0, 0.87);
 
-    :host-context(body.dark-theme) & {
+    :host-context(html.dark-theme) & {
       color: rgba(255, 255, 255, 0.87);
     }
   }
@@ -134,7 +134,7 @@
     color: rgba(0, 0, 0, 0.54);
     z-index: 1;
 
-    :host-context(body.dark-theme) & {
+    :host-context(html.dark-theme) & {
       color: rgba(255, 255, 255, 0.54);
     }
 
@@ -225,7 +225,7 @@
     line-height: 1.4;
     word-wrap: break-word;
 
-    :host-context(body.dark-theme) & {
+    :host-context(html.dark-theme) & {
       color: rgba(255, 255, 255, 0.6);
     }
   }
@@ -235,7 +235,7 @@
     color: rgba(0, 0, 0, 0.54);
     margin-top: 4px;
 
-    :host-context(body.dark-theme) & {
+    :host-context(html.dark-theme) & {
       color: rgba(255, 255, 255, 0.54);
     }
   }

--- a/src/app/print/edit-print-detail/edit-print-detail.component.scss
+++ b/src/app/print/edit-print-detail/edit-print-detail.component.scss
@@ -275,7 +275,7 @@ mat-card-title {
   border-radius: 0 0 4px 4px;
 }
 
-:host-context(body.dark-theme) {
+:host-context(html.dark-theme) {
   .sticky-actions {
     background: #1e1e1e;
     box-shadow: 0 -2px 8px rgba(0, 0, 0, 0.4);

--- a/src/app/print/print-card/print-card.component.scss
+++ b/src/app/print/print-card/print-card.component.scss
@@ -176,7 +176,7 @@
   align-items: flex-start;
 }
 
-:host-context(body.dark-theme) {
+:host-context(html.dark-theme) {
   .card-image {
     background-color: #2a2a2a;
   }

--- a/src/app/print/print-list/print-grouped-view/print-grouped-view.component.scss
+++ b/src/app/print/print-list/print-grouped-view/print-grouped-view.component.scss
@@ -370,7 +370,7 @@
   padding: 4px 8px;
 }
 
-:host-context(body.dark-theme) {
+:host-context(html.dark-theme) {
   .card-image {
     background-color: #2a2a2a;
   }

--- a/src/app/print/print-list/print-list.component.scss
+++ b/src/app/print/print-list/print-list.component.scss
@@ -215,7 +215,7 @@ table {
   }
 }
 
-:host-context(body.dark-theme) {
+:host-context(html.dark-theme) {
   .filter-panel-inner {
     border-top-color: rgba(255, 255, 255, 0.08);
   }

--- a/src/app/settings/settings.component.scss
+++ b/src/app/settings/settings.component.scss
@@ -8,7 +8,7 @@ hr {
   border-top: 1px solid rgba(0, 0, 0, 0.12);
   width: 100%;
 
-  :host-context(body.dark-theme) & {
+  :host-context(html.dark-theme) & {
     border-top-color: rgba(255, 255, 255, 0.12);
   }
 }

--- a/src/app/shared/filament-list/filament-list.component.scss
+++ b/src/app/shared/filament-list/filament-list.component.scss
@@ -299,7 +299,7 @@ mat-checkbox {
   }
 }
 
-:host-context(body.dark-theme) {
+:host-context(html.dark-theme) {
   .filament-color-cell,
   .card-swatch {
     box-shadow:

--- a/src/app/shared/navbar/navbar.component.scss
+++ b/src/app/shared/navbar/navbar.component.scss
@@ -86,7 +86,7 @@ mat-toolbar {
   border-top-right-radius: 3px;
 }
 
-:host-context(body.dark-theme) mat-toolbar {
+:host-context(html.dark-theme) mat-toolbar {
   background-color: var(--brand-toolbar-bg);
 }
 

--- a/src/app/shared/panels/donut-chart/donut-chart.component.scss
+++ b/src/app/shared/panels/donut-chart/donut-chart.component.scss
@@ -1,4 +1,4 @@
-/* ViewEncapsulation.None — body.dark-theme selectors work as-is, no :host-context needed */
-body.dark-theme app-donut-chart text {
+/* ViewEncapsulation.None — html.dark-theme selectors work as-is, no :host-context needed */
+html.dark-theme app-donut-chart text {
   fill: #e0e0e0;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -26,16 +26,51 @@
     <meta name="twitter:card" content="summary_large_image" />
     <link rel="canonical" href="https://www.3dprintlog.com/" />
     <meta name="theme-color" content="#3F50B5" />
+    <!-- Apply the saved theme before the first paint to avoid a light-mode flash.
+         Runs before any stylesheet so the class is set on <html> before render.
+         Keep in sync with ThemeService (key 'theme-mode'). -->
+    <script>
+      (function () {
+        try {
+          var mode = localStorage.getItem('theme-mode') || 'system';
+          var isDark =
+            mode === 'dark' ||
+            (mode === 'system' &&
+              window.matchMedia('(prefers-color-scheme: dark)').matches);
+          if (isDark) {
+            document.documentElement.classList.add('dark-theme');
+            var meta = document.querySelector('meta[name="theme-color"]');
+            if (meta) meta.setAttribute('content', '#283593');
+          }
+        } catch (e) {}
+      })();
+    </script>
     <link rel="icon" type="image/x-icon" href="favicon_1293b2036.ico" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />
+    <!-- Load fonts without blocking rendering, so the pre-paint theme script
+         above is not delayed behind these external stylesheets. -->
     <link
       href="https://fonts.googleapis.com/css?family=Roboto:light,regular,medium,thin,italic,mediumitalic,bold&display=swap"
       rel="stylesheet"
+      media="print"
+      onload="this.media='all'"
     />
     <link
       href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet"
+      media="print"
+      onload="this.media='all'"
     />
+    <noscript>
+      <link
+        href="https://fonts.googleapis.com/css?family=Roboto:light,regular,medium,thin,italic,mediumitalic,bold&display=swap"
+        rel="stylesheet"
+      />
+      <link
+        href="https://fonts.googleapis.com/icon?family=Material+Icons"
+        rel="stylesheet"
+      />
+    </noscript>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script
       async
@@ -57,24 +92,6 @@
     ></script>
   </head>
   <body class="mat-app-background">
-    <!-- Apply the saved theme before first paint to avoid a light-mode flash on
-         prerendered pages. Keep in sync with ThemeService (key 'theme-mode'). -->
-    <script>
-      (function () {
-        try {
-          var mode = localStorage.getItem('theme-mode') || 'system';
-          var isDark =
-            mode === 'dark' ||
-            (mode === 'system' &&
-              window.matchMedia('(prefers-color-scheme: dark)').matches);
-          if (isDark) {
-            document.body.classList.add('dark-theme');
-            var meta = document.querySelector('meta[name="theme-color"]');
-            if (meta) meta.setAttribute('content', '#283593');
-          }
-        } catch (e) {}
-      })();
-    </script>
     <app-root></app-root>
   </body>
 </html>

--- a/src/index.prod.html
+++ b/src/index.prod.html
@@ -26,16 +26,51 @@
     <meta name="twitter:card" content="summary_large_image" />
     <link rel="canonical" href="https://www.3dprintlog.com/" />
     <meta name="theme-color" content="#3F50B5" />
+    <!-- Apply the saved theme before the first paint to avoid a light-mode flash
+         on prerendered pages. Runs before any stylesheet so the class is set on
+         <html> before render. Keep in sync with ThemeService (key 'theme-mode'). -->
+    <script>
+      (function () {
+        try {
+          var mode = localStorage.getItem('theme-mode') || 'system';
+          var isDark =
+            mode === 'dark' ||
+            (mode === 'system' &&
+              window.matchMedia('(prefers-color-scheme: dark)').matches);
+          if (isDark) {
+            document.documentElement.classList.add('dark-theme');
+            var meta = document.querySelector('meta[name="theme-color"]');
+            if (meta) meta.setAttribute('content', '#283593');
+          }
+        } catch (e) {}
+      })();
+    </script>
     <link rel="icon" type="image/x-icon" href="favicon_1293b2036.ico" />
     <link rel="apple-touch-icon" href="/assets/apple-touch-icon.png" />
+    <!-- Load fonts without blocking rendering, so the pre-paint theme script
+         below is not delayed behind these external stylesheets. -->
     <link
       href="https://fonts.googleapis.com/css?family=Roboto:light,regular,medium,thin,italic,mediumitalic,bold&display=swap"
       rel="stylesheet"
+      media="print"
+      onload="this.media='all'"
     />
     <link
       href="https://fonts.googleapis.com/icon?family=Material+Icons"
       rel="stylesheet"
+      media="print"
+      onload="this.media='all'"
     />
+    <noscript>
+      <link
+        href="https://fonts.googleapis.com/css?family=Roboto:light,regular,medium,thin,italic,mediumitalic,bold&display=swap"
+        rel="stylesheet"
+      />
+      <link
+        href="https://fonts.googleapis.com/icon?family=Material+Icons"
+        rel="stylesheet"
+      />
+    </noscript>
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script
       async
@@ -61,24 +96,6 @@
     ></script>
   </head>
   <body>
-    <!-- Apply the saved theme before first paint to avoid a light-mode flash on
-         prerendered pages. Keep in sync with ThemeService (key 'theme-mode'). -->
-    <script>
-      (function () {
-        try {
-          var mode = localStorage.getItem('theme-mode') || 'system';
-          var isDark =
-            mode === 'dark' ||
-            (mode === 'system' &&
-              window.matchMedia('(prefers-color-scheme: dark)').matches);
-          if (isDark) {
-            document.body.classList.add('dark-theme');
-            var meta = document.querySelector('meta[name="theme-color"]');
-            if (meta) meta.setAttribute('content', '#283593');
-          }
-        } catch (e) {}
-      })();
-    </script>
     <app-root></app-root>
   </body>
 </html>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -21,8 +21,14 @@ body {
   --brand-toolbar-bg: #3f51b5; // indigo-500
 }
 
-body.dark-theme {
+html.dark-theme {
   --brand-toolbar-bg: #283593; // indigo-800: same hue, toned down for dark mode
+  background-color: #121212;
+}
+
+// The dark theme class lives on <html> (set before first paint), so the opaque
+// body background must be re-colored explicitly or it covers the html background.
+html.dark-theme body {
   background-color: #121212;
 }
 
@@ -160,13 +166,13 @@ mat-checkbox.text-wrap {
 }
 
 /* cdk-drag-preview is teleported to body during drag — must be global, not in component SCSS */
-body.dark-theme .cdk-drag-preview {
+html.dark-theme .cdk-drag-preview {
   background-color: #2a2a2a;
 }
 
 /* Dark mode overrides for notification menu panel
    Must be global because mat-menu teleports outside the component host. */
-body.dark-theme .notification-menu {
+html.dark-theme .notification-menu {
   .notification-item {
     .notification-message {
       color: rgba(255, 255, 255, 0.6);

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -130,7 +130,7 @@ html {
   box-shadow: var(--mat-app-elevation-shadow-level-8);
 }
 
-body.dark-theme {
+html.dark-theme {
   @include mat.all-component-colors($dark-theme);
   color-scheme: dark;
   background-color: #121212;


### PR DESCRIPTION
Follow-up to #47, which only reduced the flash. DevTools first-paint capture showed the prerendered pages still painting one or more light frames before flipping to dark.

## Root cause (two stacked issues)

1. **Dark CSS was deferred.** With `inlineCritical` on, Angular inlined only the light critical CSS and pushed `body.dark-theme{background:#121212}` into the async stylesheet (`media="print"` swap). So the dark rules weren't available at first paint even once the class was set.
2. **The pre-paint script was gated behind stylesheets.** The `#47` script lived in `<body>`, after the render-blocking `<head>` stylesheets (including external Google Fonts). It was parser-blocked, so the browser painted a light body before the script ran and added the class.

## Fix

- **`inlineCritical: false`** (production `optimization` in `angular.json`) so the full stylesheet, with the dark rules, is render-blocking and present at first paint.
- **Move the theme script to the top of `<head>`** and apply the class to `<html>` (`document.documentElement`), which exists during head parse and runs before any stylesheet.
- **Migrate the dark hook `body.dark-theme` -> `html.dark-theme`** across 16 SCSS files, `ThemeService` (toggles `documentElement`), and its spec. Added `html.dark-theme body { background:#121212 }` since the opaque body background otherwise covers the html background.
- **Make Google Fonts non-render-blocking** (`media="print"` + `<noscript>` fallback) so nothing external delays first paint.

## Verification (Chrome DevTools, 6x CPU throttle, first-paint rAF capture)

- **Before:** first ~3 frames light (`rgb(250,250,250)`), flipped to dark ~1.4s (Angular boot).
- **After:** dark from frame 0 (`rgb(18,18,18)`, `html.dark-theme` present) — no light frame.
- **Control:** light mode still light from frame 0.
- Visual screenshot confirmed dark theme renders correctly (background, indigo toolbar, text, links).

## Tests

- 616 unit tests pass (`theme.service.spec` updated to assert on `documentElement`).
- Lint clean. `verify-prerender.mjs` green (theme script still asserted present per route).