### PR TITLE
Release v1.43.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "print-log-ui",
-  "version": "1.43.4",
+  "version": "1.43.5",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --ssl --host 0.0.0.0 ",

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -28,6 +28,9 @@ export class VersionReleaseNoteDialogService {
   private readonly LOCAL_STORAGE_KEY = 'LastLoggedInVersion';
 
   private releaseNotes: ReleaseNoteHistory = {
+    '1.43.5': {
+      redirect: '1.43.4',
+    },
     '1.43.4': {
       redirect: '1.43.3',
     },

--- a/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
+++ b/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
@@ -2,6 +2,21 @@
   <h2>Release Notes</h2>
   <hr />
 
+  <h3 id="v1.43.5">1.43.5 - Dark Mode Flash Fix</h3>
+  <p>
+    This patch fully removes the brief light-mode flash when opening 3D Print Log with dark mode
+    enabled. The previous release reduced it; pages now render in dark from the very first frame with
+    no flicker.
+  </p>
+  <h4>Full List of Changes:</h4>
+  <ul>
+    <li>
+      <strong>No dark mode flash</strong> - Your saved theme is now applied before the first frame
+      renders, so dark mode pages no longer flash light on load.
+      (<a href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/49" rel="noreferrer noopener" target="_blank">PR #49</a>)
+    </li>
+  </ul>
+
   <h3 id="v1.43.4">1.43.4 - Dark Mode Flash Fix</h3>
   <p>
     This patch fixes a brief flash of light mode when opening 3D Print Log with dark mode enabled. Your


### PR DESCRIPTION
Patch release. Fully eliminates the dark-mode flash on prerendered pages (#49), completing the partial fix from 1.43.4.

## Version
1.43.4 -> 1.43.5

## Included
- Theme is applied to `<html>` before the first paint (with the dark CSS made render-blocking), so dark-mode pages render dark from frame 0 with no light flash. Verified in Chrome DevTools.

## Release-notes wiring
- `docs-release-notes.component.html`: new 1.43.5 entry.
- `version-release-note-dialog.service.ts`: 1.43.5 redirects to 1.43.4 (no version popup for this patch).

After merge, tag the release:
```
git tag v1.43.5
git push origin v1.43.5
```