### PR TITLE
release: v1.43.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "print-log-ui",
-  "version": "1.43.5",
+  "version": "1.43.6",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --ssl --host 0.0.0.0 ",

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -28,6 +28,9 @@ export class VersionReleaseNoteDialogService {
   private readonly LOCAL_STORAGE_KEY = 'LastLoggedInVersion';
 
   private releaseNotes: ReleaseNoteHistory = {
+    '1.43.6': {
+      redirect: '1.43.5',
+    },
     '1.43.5': {
       redirect: '1.43.4',
     },

--- a/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
+++ b/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
@@ -2,6 +2,22 @@
   <h2>Release Notes</h2>
   <hr />
 
+  <h3 id="v1.43.6">1.43.6 - Documentation Pages Load Faster</h3>
+  <p>
+    Every help and documentation page now loads as a fully rendered static page. This makes the docs
+    open faster and easier for search engines to find, so answers turn up more readily when you search
+    for how a feature works.
+  </p>
+  <h4>Full List of Changes:</h4>
+  <ul>
+    <li>
+      <strong>Prerendered documentation</strong> - All public documentation pages are now prerendered
+      with their own titles, descriptions, and social sharing details for quicker loads and better
+      search visibility.
+      (<a href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/51" rel="noreferrer noopener" target="_blank">PR #51</a>)
+    </li>
+  </ul>
+
   <h3 id="v1.43.5">1.43.5 - Dark Mode Flash Fix</h3>
   <p>
     This patch fully removes the brief light-mode flash when opening 3D Print Log with dark mode


### PR DESCRIPTION
## Release v1.43.6 (patch)

Bumps version `1.43.5` → `1.43.6`.

### Included
- **Prerendered documentation pages** (#51) — all 15 public `/docs/*` pages now prerender as static HTML with unique titles, meta descriptions, canonical URLs, and OG/Twitter tags, and are included in the sitemap + prerender-verification gate.

### Release housekeeping
- `package.json` bumped to 1.43.6
- HTML release notes entry added
- Version dialog: patch redirect to 1.43.5 (no release popup)