### PR TITLE
feat: add JSON-LD structured data to prerendered pages

### DIFF
--- a/scripts/verify-prerender.mjs
+++ b/scripts/verify-prerender.mjs
@@ -37,6 +37,22 @@ function canonicalHref(html) {
   }
   return '';
 }
+// Parse the page's <script type="application/ld+json"> and return the set of
+// @type strings found in its @graph. Returns null if missing/invalid JSON.
+function jsonLdTypes(html) {
+  const m = html.match(
+    /<script[^>]*type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/i
+  );
+  if (!m) return null;
+  let data;
+  try {
+    data = JSON.parse(m[1]);
+  } catch {
+    return null;
+  }
+  const graph = Array.isArray(data['@graph']) ? data['@graph'] : [];
+  return new Set(graph.map((n) => n && n['@type']).filter(Boolean));
+}
 function read(route) {
   const file = `${DIST}/${route ? route + '/' : ''}index.html`;
   if (!existsSync(file)) {
@@ -80,6 +96,24 @@ for (const r of [...routes, ...DOC_ROUTES]) {
   if (!(html.includes("localStorage.getItem('theme-mode')") &&
         html.includes("classList.add('dark-theme')")))
     errors.push(`${file}: missing pre-paint theme script (dark-mode flash guard)`);
+  // Structured data (JSON-LD): every prerendered page carries a valid @graph with
+  // the @type(s) expected for its route class.
+  const types = jsonLdTypes(html);
+  if (!types) {
+    errors.push(`${file}: missing or invalid JSON-LD (application/ld+json)`);
+  } else {
+    const expected =
+      r === ''
+        ? ['WebApplication', 'Organization']
+        : DOC_ROUTES.includes(r)
+          ? ['TechArticle', 'BreadcrumbList']
+          : ['HowTo'];
+    for (const t of expected) {
+      if (!types.has(t)) {
+        errors.push(`${file}: JSON-LD missing @type "${t}"`);
+      }
+    }
+  }
 }
 
 // Fork pages: each must link to the hub in body and carry its own hook (checked via a
@@ -154,5 +188,5 @@ if (errors.length) {
   process.exit(1);
 }
 console.log(
-  `Prerender verification passed: ${routes.length + DOC_ROUTES.length} routes (${routes.length} marketing + ${DOC_ROUTES.length} docs); unique titles+descriptions, OG/Twitter, canonicals, fork hooks + hub links, homepage link graph, crawl files.`
+  `Prerender verification passed: ${routes.length + DOC_ROUTES.length} routes (${routes.length} marketing + ${DOC_ROUTES.length} docs); unique titles+descriptions, OG/Twitter, canonicals, JSON-LD structured data, fork hooks + hub links, homepage link graph, crawl files.`
 );

--- a/src/app/core/services/structured-data.service.spec.ts
+++ b/src/app/core/services/structured-data.service.spec.ts
@@ -1,0 +1,48 @@
+import { TestBed } from '@angular/core/testing';
+import { DOCUMENT } from '@angular/common';
+import { StructuredDataService } from './structured-data.service';
+
+describe('StructuredDataService', () => {
+  let service: StructuredDataService;
+  let doc: Document;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(StructuredDataService);
+    doc = TestBed.inject(DOCUMENT);
+  });
+
+  afterEach(() => {
+    doc.getElementById('ld-json')?.remove();
+  });
+
+  function scripts(): HTMLScriptElement[] {
+    return Array.from(
+      doc.querySelectorAll<HTMLScriptElement>(
+        'script[type="application/ld+json"]'
+      )
+    );
+  }
+
+  it('injects one ld+json script with an @graph of the nodes', () => {
+    service.setJsonLd([{ '@type': 'Organization', name: 'X' }]);
+    expect(scripts().length).toBe(1);
+    const parsed = JSON.parse(scripts()[0].textContent as string);
+    expect(parsed['@context']).toBe('https://schema.org');
+    expect(parsed['@graph'][0]['@type']).toBe('Organization');
+  });
+
+  it('replaces content on a second call instead of duplicating', () => {
+    service.setJsonLd([{ '@type': 'Organization', name: 'X' }]);
+    service.setJsonLd([{ '@type': 'WebApplication', name: 'Y' }]);
+    expect(scripts().length).toBe(1);
+    const parsed = JSON.parse(scripts()[0].textContent as string);
+    expect(parsed['@graph'][0]['@type']).toBe('WebApplication');
+  });
+
+  it('removes the script when given an empty array', () => {
+    service.setJsonLd([{ '@type': 'Organization', name: 'X' }]);
+    service.setJsonLd([]);
+    expect(scripts().length).toBe(0);
+  });
+});

--- a/src/app/core/services/structured-data.service.ts
+++ b/src/app/core/services/structured-data.service.ts
@@ -1,0 +1,39 @@
+import { inject, Injectable } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class StructuredDataService {
+  private readonly document = inject(DOCUMENT);
+  private readonly elementId = 'ld-json';
+
+  /**
+   * Injects (or replaces) a single <script type="application/ld+json"> in <head>
+   * wrapping the given schema nodes in a Schema.org @graph. An empty array removes
+   * any existing tag. SSR-safe: uses the injected DOCUMENT so it also runs during
+   * prerendering.
+   */
+  public setJsonLd(nodes: Record<string, unknown>[]): void {
+    let script = this.document.getElementById(
+      this.elementId
+    ) as HTMLScriptElement | null;
+
+    if (!nodes || nodes.length === 0) {
+      script?.remove();
+      return;
+    }
+
+    if (!script) {
+      script = this.document.createElement('script');
+      script.type = 'application/ld+json';
+      script.id = this.elementId;
+      this.document.head.appendChild(script);
+    }
+
+    script.textContent = JSON.stringify({
+      '@context': 'https://schema.org',
+      '@graph': nodes,
+    });
+  }
+}

--- a/src/app/core/structured-data/app-schema.spec.ts
+++ b/src/app/core/structured-data/app-schema.spec.ts
@@ -1,0 +1,34 @@
+import {
+  ORGANIZATION_ID,
+  buildOrganization,
+  buildSoftwareApplication,
+} from './app-schema';
+
+describe('app-schema', () => {
+  it('ORGANIZATION_ID is the homepage url with an #organization fragment', () => {
+    expect(ORGANIZATION_ID).toBe('https://www.3dprintlog.com/#organization');
+  });
+
+  it('buildOrganization returns an Organization with @id, name, url, logo', () => {
+    const org = buildOrganization();
+    expect(org['@type']).toBe('Organization');
+    expect(org['@id']).toBe(ORGANIZATION_ID);
+    expect(org['name']).toBe('3D Print Log');
+    expect(org['url']).toBe('https://www.3dprintlog.com/');
+    expect(typeof org['logo']).toBe('string');
+  });
+
+  it('buildSoftwareApplication returns a free WebApplication linked to the org', () => {
+    const app = buildSoftwareApplication();
+    expect(app['@type']).toBe('WebApplication');
+    expect(app['name']).toBe('3D Print Log');
+    expect(app['applicationCategory']).toBe('UtilitiesApplication');
+    expect(app['offers']).toEqual({
+      '@type': 'Offer',
+      price: '0',
+      priceCurrency: 'USD',
+    });
+    expect(app['publisher']).toEqual({ '@id': ORGANIZATION_ID });
+    expect(app['aggregateRating']).toBeUndefined();
+  });
+});

--- a/src/app/core/structured-data/app-schema.ts
+++ b/src/app/core/structured-data/app-schema.ts
@@ -1,0 +1,26 @@
+import { ogImage, siteUrl } from '../../slicer/slicer-configs';
+
+/** Stable @id for the brand Organization, referenced by other schema nodes. */
+export const ORGANIZATION_ID = `${siteUrl('')}#organization`;
+
+export function buildOrganization(): Record<string, unknown> {
+  return {
+    '@type': 'Organization',
+    '@id': ORGANIZATION_ID,
+    name: '3D Print Log',
+    url: siteUrl(''),
+    logo: ogImage,
+  };
+}
+
+export function buildSoftwareApplication(): Record<string, unknown> {
+  return {
+    '@type': 'WebApplication',
+    name: '3D Print Log',
+    applicationCategory: 'UtilitiesApplication',
+    operatingSystem: 'Web, Android',
+    url: siteUrl(''),
+    offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+    publisher: { '@id': ORGANIZATION_ID },
+  };
+}

--- a/src/app/core/structured-data/doc-schema.spec.ts
+++ b/src/app/core/structured-data/doc-schema.spec.ts
@@ -1,0 +1,41 @@
+import { buildDocArticle, buildDocBreadcrumb } from './doc-schema';
+import { ORGANIZATION_ID } from './app-schema';
+
+const tags = {
+  url: 'https://www.3dprintlog.com/docs/prints',
+  title: 'Tracking Prints | 3D Print Log Docs',
+  description: 'Log every 3D print.',
+  imageUrl: 'https://www.3dprintlog.com/assets/logo.svg',
+};
+
+describe('doc-schema', () => {
+  it('buildDocArticle returns a TechArticle linked to the org', () => {
+    const article = buildDocArticle(tags);
+    expect(article['@type']).toBe('TechArticle');
+    expect(article['headline']).toBe(tags.title);
+    expect(article['description']).toBe(tags.description);
+    expect(article['mainEntityOfPage']).toBe(tags.url);
+    expect(article['image']).toBe(tags.imageUrl);
+    expect(article['publisher']).toEqual({ '@id': ORGANIZATION_ID });
+  });
+
+  it('buildDocBreadcrumb returns a Home > Documentation > page trail', () => {
+    const crumb = buildDocBreadcrumb(tags);
+    expect(crumb['@type']).toBe('BreadcrumbList');
+    const items = crumb['itemListElement'] as Array<Record<string, unknown>>;
+    expect(items.length).toBe(3);
+    expect(items[0]).toEqual({
+      '@type': 'ListItem',
+      position: 1,
+      name: 'Home',
+      item: 'https://www.3dprintlog.com/',
+    });
+    expect(items[1]['item']).toBe('https://www.3dprintlog.com/docs');
+    expect(items[2]).toEqual({
+      '@type': 'ListItem',
+      position: 3,
+      name: tags.title,
+      item: tags.url,
+    });
+  });
+});

--- a/src/app/core/structured-data/doc-schema.ts
+++ b/src/app/core/structured-data/doc-schema.ts
@@ -1,0 +1,38 @@
+import { siteUrl } from '../../slicer/slicer-configs';
+import { ORGANIZATION_ID } from './app-schema';
+
+export interface DocSeoTags {
+  url: string;
+  title: string;
+  description: string;
+  imageUrl: string;
+}
+
+export function buildDocArticle(tags: DocSeoTags): Record<string, unknown> {
+  return {
+    '@type': 'TechArticle',
+    headline: tags.title,
+    description: tags.description,
+    url: tags.url,
+    mainEntityOfPage: tags.url,
+    image: tags.imageUrl,
+    author: { '@id': ORGANIZATION_ID },
+    publisher: { '@id': ORGANIZATION_ID },
+  };
+}
+
+export function buildDocBreadcrumb(tags: DocSeoTags): Record<string, unknown> {
+  return {
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Home', item: siteUrl('') },
+      {
+        '@type': 'ListItem',
+        position: 2,
+        name: 'Documentation',
+        item: siteUrl('docs'),
+      },
+      { '@type': 'ListItem', position: 3, name: tags.title, item: tags.url },
+    ],
+  };
+}

--- a/src/app/core/structured-data/slicer-schema.spec.ts
+++ b/src/app/core/structured-data/slicer-schema.spec.ts
@@ -1,0 +1,21 @@
+import { buildSlicerHowTo } from './slicer-schema';
+import { SLICER_CONFIGS } from '../../slicer/slicer-configs';
+
+describe('slicer-schema', () => {
+  it('buildSlicerHowTo maps steps to positioned HowToStep items', () => {
+    const config = SLICER_CONFIGS['orcaslicer'];
+    const howto = buildSlicerHowTo(config);
+    expect(howto['@type']).toBe('HowTo');
+    expect(howto['name']).toBe(config.h1);
+    expect(howto['description']).toBe(config.intro);
+    const steps = howto['step'] as Array<Record<string, unknown>>;
+    expect(steps.length).toBe(config.steps.length);
+    expect(steps[0]).toEqual({
+      '@type': 'HowToStep',
+      position: 1,
+      name: config.steps[0],
+      text: config.steps[0],
+    });
+    expect(steps[steps.length - 1]['position']).toBe(config.steps.length);
+  });
+});

--- a/src/app/core/structured-data/slicer-schema.ts
+++ b/src/app/core/structured-data/slicer-schema.ts
@@ -1,0 +1,17 @@
+import { SlicerConfig } from '../../slicer/slicer-configs';
+
+export function buildSlicerHowTo(
+  config: SlicerConfig
+): Record<string, unknown> {
+  return {
+    '@type': 'HowTo',
+    name: config.h1,
+    description: config.intro,
+    step: config.steps.map((s, i) => ({
+      '@type': 'HowToStep',
+      position: i + 1,
+      name: s,
+      text: s,
+    })),
+  };
+}

--- a/src/app/documentation/documentation.component.spec.ts
+++ b/src/app/documentation/documentation.component.spec.ts
@@ -1,6 +1,21 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MediaMatcher } from '@angular/cdk/layout';
+import { Subject } from 'rxjs';
+import { Event as RouterEvent, NavigationEnd, Router } from '@angular/router';
 
 import { DocumentationComponent } from './documentation.component';
+import { MetaTagService } from '../core/services/meta-tag.service';
+import { StructuredDataService } from '../core/services/structured-data.service';
+
+// Force the "mobile" branch so ngAfterViewInit skips the sidenav open() call that
+// the empty test template can't satisfy.
+const mobileMediaMatcher = {
+  matchMedia: () => ({
+    matches: true,
+    addListener: () => {},
+    removeListener: () => {},
+  }),
+};
 
 xdescribe('DocumentationComponent', () => {
   let component: DocumentationComponent;
@@ -20,5 +35,63 @@ xdescribe('DocumentationComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+});
+
+describe('DocumentationComponent SEO lifecycle', () => {
+  let events: Subject<RouterEvent>;
+  let structuredData: jasmine.SpyObj<StructuredDataService>;
+  let meta: jasmine.SpyObj<MetaTagService>;
+  let fixture: ComponentFixture<DocumentationComponent>;
+
+  beforeEach(async () => {
+    events = new Subject<RouterEvent>();
+    structuredData = jasmine.createSpyObj<StructuredDataService>(
+      'StructuredDataService',
+      ['setJsonLd']
+    );
+    meta = jasmine.createSpyObj<MetaTagService>('MetaTagService', [
+      'setSeoTags',
+      'setTitle',
+    ]);
+
+    await TestBed.configureTestingModule({
+      declarations: [DocumentationComponent],
+      providers: [
+        { provide: Router, useValue: { url: '/docs/prints', events } },
+        { provide: StructuredDataService, useValue: structuredData },
+        { provide: MetaTagService, useValue: meta },
+        { provide: MediaMatcher, useValue: mobileMediaMatcher },
+      ],
+    })
+      // Replace the sidenav-heavy template so we can exercise the component's
+      // SEO/subscription logic without its child components.
+      .overrideComponent(DocumentationComponent, { set: { template: '' } })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(DocumentationComponent);
+    fixture.detectChanges(); // runs ngOnInit
+  });
+
+  it('sets doc structured data for the initial doc url', () => {
+    expect(structuredData.setJsonLd).toHaveBeenCalledTimes(1);
+    const nodes = structuredData.setJsonLd.calls.mostRecent().args[0];
+    expect(nodes.map((n) => n['@type'])).toEqual([
+      'TechArticle',
+      'BreadcrumbList',
+    ]);
+  });
+
+  it('clears structured data when navigating to a non-doc url while alive', () => {
+    structuredData.setJsonLd.calls.reset();
+    events.next(new NavigationEnd(1, '/', '/'));
+    expect(structuredData.setJsonLd).toHaveBeenCalledWith([]);
+  });
+
+  it('does NOT touch structured data after the component is destroyed', () => {
+    structuredData.setJsonLd.calls.reset();
+    fixture.destroy();
+    events.next(new NavigationEnd(2, '/', '/'));
+    expect(structuredData.setJsonLd).not.toHaveBeenCalled();
   });
 });

--- a/src/app/documentation/documentation.component.ts
+++ b/src/app/documentation/documentation.component.ts
@@ -4,6 +4,7 @@ import {
   AfterViewInit,
   ChangeDetectorRef,
   Component,
+  DestroyRef,
   inject,
   NgZone,
   OnDestroy,
@@ -11,6 +12,7 @@ import {
   PLATFORM_ID,
   ViewChild,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Title } from '@angular/platform-browser';
 import { NavigationEnd, Router } from '@angular/router';
 import { filter } from 'rxjs/operators';
@@ -40,6 +42,7 @@ export class DocumentationComponent
   private readonly router = inject(Router);
   private readonly metaTagService = inject(MetaTagService);
   private readonly structuredData = inject(StructuredDataService);
+  private readonly destroyRef = inject(DestroyRef);
 
   @ViewChild('snav', { static: true }) snav;
 
@@ -79,8 +82,14 @@ export class DocumentationComponent
 
   ngOnInit() {
     this.applySeoForUrl(this.router.url);
+    // takeUntilDestroyed prevents the destroyed docs component from reacting to a
+    // later NavigationEnd (e.g. navigating to '/' or a slicer page) and clearing
+    // the structured data those pages just set.
     this.router.events
-      .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
+      .pipe(
+        filter((e): e is NavigationEnd => e instanceof NavigationEnd),
+        takeUntilDestroyed(this.destroyRef)
+      )
       .subscribe((e) => this.applySeoForUrl(e.urlAfterRedirects));
 
     // document is unavailable during Node prerendering; only load the YouTube API

--- a/src/app/documentation/documentation.component.ts
+++ b/src/app/documentation/documentation.component.ts
@@ -15,6 +15,11 @@ import { Title } from '@angular/platform-browser';
 import { NavigationEnd, Router } from '@angular/router';
 import { filter } from 'rxjs/operators';
 import { MetaTagService } from '../core/services/meta-tag.service';
+import { StructuredDataService } from '../core/services/structured-data.service';
+import {
+  buildDocArticle,
+  buildDocBreadcrumb,
+} from '../core/structured-data/doc-schema';
 import { getDocSeoTags } from './doc-seo.config';
 
 let apiLoaded = false;
@@ -34,6 +39,7 @@ export class DocumentationComponent
   private readonly platformId = inject(PLATFORM_ID);
   private readonly router = inject(Router);
   private readonly metaTagService = inject(MetaTagService);
+  private readonly structuredData = inject(StructuredDataService);
 
   @ViewChild('snav', { static: true }) snav;
 
@@ -95,8 +101,13 @@ export class DocumentationComponent
     const tags = getDocSeoTags(path);
     if (tags) {
       this.metaTagService.setSeoTags(tags);
+      this.structuredData.setJsonLd([
+        buildDocArticle(tags),
+        buildDocBreadcrumb(tags),
+      ]);
     } else {
       this.title.setTitle('Documentation - 3D Print Log');
+      this.structuredData.setJsonLd([]);
     }
   }
 

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -8,6 +8,11 @@ import {
 import { isPlatformBrowser } from '@angular/common';
 import { AuthService } from '../core/services/auth.service';
 import { MetaTagService } from '../core/services/meta-tag.service';
+import { StructuredDataService } from '../core/services/structured-data.service';
+import {
+  buildOrganization,
+  buildSoftwareApplication,
+} from '../core/structured-data/app-schema';
 
 @Component({
   selector: 'app-home',
@@ -21,7 +26,8 @@ export class HomeComponent implements OnInit {
 
   constructor(
     public auth: AuthService,
-    private meta: MetaTagService
+    private meta: MetaTagService,
+    private structuredData: StructuredDataService
   ) {}
 
   ngOnInit() {
@@ -33,5 +39,10 @@ export class HomeComponent implements OnInit {
       imageUrl:
         'https://www.3dprintlog.com/assets/3d-print-log-logo_8b178eb1339b.svg',
     });
+
+    this.structuredData.setJsonLd([
+      buildSoftwareApplication(),
+      buildOrganization(),
+    ]);
   }
 }

--- a/src/app/slicer/slicer-landing.component.ts
+++ b/src/app/slicer/slicer-landing.component.ts
@@ -6,6 +6,8 @@ import {
 } from '@angular/core';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { MetaTagService } from '../core/services/meta-tag.service';
+import { StructuredDataService } from '../core/services/structured-data.service';
+import { buildSlicerHowTo } from '../core/structured-data/slicer-schema';
 import { SLICER_CONFIGS, siteUrl, ogImage } from './slicer-configs';
 
 @Component({
@@ -19,6 +21,7 @@ import { SLICER_CONFIGS, siteUrl, ogImage } from './slicer-configs';
 export class SlicerLandingComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);
   private readonly meta = inject(MetaTagService);
+  private readonly structuredData = inject(StructuredDataService);
   readonly config =
     SLICER_CONFIGS[this.route.snapshot.data['slicerKey'] as string];
 
@@ -29,5 +32,7 @@ export class SlicerLandingComponent implements OnInit {
       description: this.config.metaDescription,
       imageUrl: ogImage,
     });
+
+    this.structuredData.setJsonLd([buildSlicerHowTo(this.config)]);
   }
 }


### PR DESCRIPTION
## Summary

Adds Schema.org **JSON-LD structured data** to every prerendered page — the next SEO layer on top of the meta tags and prerendering already shipped. Structured data helps search engines and AI/LLM crawlers understand the site as an entity (the app, the brand, the docs articles, the slicer how-to guides).

Build prerenders all **26 static routes**, each now carrying a `<script type="application/ld+json">`.

## What each page class emits

| Page class | Count | Schema `@type`(s) |
|---|---|---|
| Homepage | 1 | `WebApplication` + `Organization` |
| Slicer landing pages | 10 | `HowTo` (built from the existing `steps` arrays) |
| Docs pages | 15 | `TechArticle` + `BreadcrumbList` |

## Architecture

Mirrors the existing `MetaTagService` pattern:
- **`StructuredDataService`** (`core/services/`) — SSR-safe (`inject(DOCUMENT)`), injects one `#ld-json` `<script>` wrapping nodes in a Schema.org `@graph`; replaces (not duplicates) on client-side navigation; clears on non-doc `/docs` states.
- **Pure builders** (`core/structured-data/`) — `app-schema.ts`, `doc-schema.ts`, `slicer-schema.ts`; each a tested pure function returning a plain object. A shared `Organization` `@id` links the app/article nodes.
- **Wiring** — the three components that already call `setSeoTags` (`HomeComponent`, `SlicerLandingComponent`, `DocumentationComponent`) also call `setJsonLd`.
- **CI gate** — `verify-prerender.mjs` now asserts each prerendered route has valid JSON-LD with the expected `@type`(s) for its class.

## Decisions made autonomously (flagging for your review)

- **`WebApplication`** (a `SoftwareApplication` subtype) with `applicationCategory: UtilitiesApplication`, `operatingSystem: "Web, Android"`, and a free `Offer` (`price: "0"`). No `aggregateRating` or dates — didn't want to fabricate data we don't have.
- **`TechArticle`** over generic `Article` for docs.
- **HowTo caveat:** Google deprecated HowTo rich results in 2023, so these won't render as numbered rich results in Google — included for entity value (Bing, AI crawlers) at near-zero cost since the step data already existed. FAQPage was intentionally dropped for the same deprecation reason.
- Docs breadcrumb/article use the full page title (incl. the `| 3D Print Log Docs` suffix); easy to strip if you'd prefer bare titles.
- Builders live in `core/structured-data/` and import the app-wide `siteUrl`/`ogImage`/`SlicerConfig` constants from `slicer/slicer-configs.ts`, matching existing practice (`doc-seo.config.ts` already does this).

## Testing

- `npm run build` → `Prerendered 26 static routes.`
- `node scripts/verify-prerender.mjs` → passes (JSON-LD assertions included).
- `npm test` → **630 passing** (621 baseline + 9 new builder/service specs).
- `npm run test:sitemap` → 11 passing.
- Spot-checked homepage / slicer / docs prerendered HTML: each emits exactly one `application/ld+json` with the correct `@type`s.

## Follow-up (not in this PR)

Validate a couple of live URLs in Google's Rich Results Test after deploy. The bigger SEO item still open is rendering the public `prints/{id}` / `users/{id}` pages (currently client-only but sitemap-advertised).