### PR TITLE
release: v1.43.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "print-log-ui",
-  "version": "1.43.6",
+  "version": "1.43.7",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --ssl --host 0.0.0.0 ",

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -28,6 +28,9 @@ export class VersionReleaseNoteDialogService {
   private readonly LOCAL_STORAGE_KEY = 'LastLoggedInVersion';
 
   private releaseNotes: ReleaseNoteHistory = {
+    '1.43.7': {
+      redirect: '1.43.6',
+    },
     '1.43.6': {
       redirect: '1.43.5',
     },

--- a/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
+++ b/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
@@ -2,6 +2,23 @@
   <h2>Release Notes</h2>
   <hr />
 
+  <h3 id="v1.43.7">1.43.7 - Better Search Engine Understanding</h3>
+  <p>
+    The homepage, slicer guides, and every documentation page now describe themselves to search
+    engines using structured data. This helps search engines (and AI assistants) understand what 3D
+    Print Log is and what each page covers, so the right pages surface when people look for a 3D print
+    tracker or for help with a specific feature.
+  </p>
+  <h4>Full List of Changes:</h4>
+  <ul>
+    <li>
+      <strong>Structured data for prerendered pages</strong> - Added Schema.org structured data
+      (app, organization, documentation articles with breadcrumbs, and slicer how-to guides) to every
+      prerendered page for better search visibility.
+      (<a href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/53" rel="noreferrer noopener" target="_blank">PR #53</a>)
+    </li>
+  </ul>
+
   <h3 id="v1.43.6">1.43.6 - Documentation Pages Load Faster</h3>
   <p>
     Every help and documentation page now loads as a fully rendered static page. This makes the docs


### PR DESCRIPTION
## Release v1.43.7 (patch)

Bumps version `1.43.6` → `1.43.7`.

### Included
- **JSON-LD structured data** (#53) — Schema.org structured data on every prerendered page: `WebApplication` + `Organization` (homepage), `HowTo` (10 slicer landing pages), and `TechArticle` + `BreadcrumbList` (15 docs pages). Injected via an SSR-safe `StructuredDataService`, gated by `verify-prerender.mjs`. Includes the review fix unsubscribing the docs router listener on destroy.

### Release housekeeping
- `package.json` bumped to 1.43.7
- HTML release notes entry added
- Version dialog: patch redirect to 1.43.6 (no release popup)