### PR TITLE
test: make AdsenseLoader spec order-independent (fixes v1.43.8 deploy)

### DIFF
--- a/src/app/core/services/adsense-loader.service.spec.ts
+++ b/src/app/core/services/adsense-loader.service.spec.ts
@@ -10,6 +10,14 @@ describe('AdsenseLoaderService', () => {
   });
 
   it('injects the AdSense loader once and is idempotent', () => {
+    // Other specs (e.g. AppComponent's interaction listeners, which are not
+    // torn down between specs) can leave a real loader <script> in the shared
+    // document. That would make load() early-return and break this spec
+    // depending on execution order, so start from a clean slate.
+    document
+      .querySelectorAll('script[data-adsense-loader]')
+      .forEach((s) => s.remove());
+
     // Capture the script element without actually inserting it into the test
     // document — appending a live adsbygoogle.js <script> makes a real network
     // request and starts filling stray ad slots from other specs, which hangs


### PR DESCRIPTION
The v1.43.8 Deploy failed at the Test gate on a flaky test-isolation bug (not related to PR #57's release changes).

## Root cause

`adsense-loader.service.spec.ts` spies on `document.head.appendChild`, but `load()` early-returns when a `script[data-adsense-loader]` already exists in the shared test document. `AppComponent.deferAdsenseLoad()` attaches `window` interaction listeners that are never torn down between specs, so a later spec that dispatches a `scroll`/`keydown`/`pointerdown`/`touchstart` on `window` fires a real `load()` and leaves that script behind.

When the AdsenseLoader spec then runs *after* such a spec, `appendChild` is never called and the captured `script` is `undefined` — failing order-dependently. This is why the release-branch CI passed but the main CI (different spec order) failed.

## Fix

Clear any leftover `script[data-adsense-loader]` before asserting, making the spec order-independent.

Verified locally: `npm run test:brief` → 639 SUCCESS.