### PR TITLE
perf: defer eager libraries (App Insights, html5-qrcode, qrcode)

### DIFF
--- a/src/app/core/services/logging.service.spec.ts
+++ b/src/app/core/services/logging.service.spec.ts
@@ -1,3 +1,4 @@
+import { Injectable } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { environment } from 'src/environments/environment';
 import { LoggingService } from './logging.service';
@@ -33,6 +34,7 @@ function makeFakeModule(
 }
 
 /** Test subclass that forces the "browser + key" deferral path and controls the import. */
+@Injectable()
 class TestableLoggingService extends LoggingService {
   // Default to a never-settling promise: every test assigns importResult before
   // calling runInitialize(), and an eagerly-rejected default would surface as an

--- a/src/app/core/services/logging.service.spec.ts
+++ b/src/app/core/services/logging.service.spec.ts
@@ -1,12 +1,182 @@
 import { TestBed } from '@angular/core/testing';
-
+import { environment } from 'src/environments/environment';
 import { LoggingService } from './logging.service';
 
-describe('LoggingService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+/** Minimal fake of the App Insights instance LoggingService uses. */
+function makeFakeAi() {
+  return {
+    loadAppInsights: jasmine.createSpy('loadAppInsights'),
+    context: { application: { ver: '' } },
+    trackPageView: jasmine.createSpy('trackPageView'),
+    trackEvent: jasmine.createSpy('trackEvent'),
+    trackMetric: jasmine.createSpy('trackMetric'),
+    trackException: jasmine.createSpy('trackException'),
+    trackTrace: jasmine.createSpy('trackTrace'),
+  };
+}
 
-  it('should be created', () => {
-    const service: LoggingService = TestBed.inject(LoggingService);
+/**
+ * Builds a fake `@microsoft/applicationinsights-web` module whose
+ * `ApplicationInsights` constructor returns `fakeAi` and records the config it
+ * was constructed with on `fakeAi.capturedConfig`.
+ */
+function makeFakeModule(
+  fakeAi: ReturnType<typeof makeFakeAi> & { capturedConfig?: any }
+) {
+  return {
+    ApplicationInsights: function (cfg: any) {
+      fakeAi.capturedConfig = cfg;
+      return fakeAi;
+    },
+    DistributedTracingModes: { AI: 1 },
+  };
+}
+
+/** Test subclass that forces the "browser + key" deferral path and controls the import. */
+class TestableLoggingService extends LoggingService {
+  importResult: Promise<any> = Promise.reject(
+    new Error('importResult not set')
+  );
+  protected override isTelemetryEnabled(): boolean {
+    return true;
+  }
+  // Prevent the constructor from auto-scheduling; tests call initialize() manually.
+  protected override scheduleInitialize(): void {
+    /* no-op in tests */
+  }
+  protected override importSdk(): Promise<any> {
+    return this.importResult;
+  }
+  runInitialize(): Promise<void> {
+    return (this as unknown as { initialize(): Promise<void> }).initialize();
+  }
+}
+
+describe('LoggingService', () => {
+  it('should be created (no-key stub path)', () => {
+    const service = TestBed.inject(LoggingService);
     expect(service).toBeTruthy();
+  });
+
+  it('stub path: log methods do not throw and logException console.errors', () => {
+    const service = TestBed.inject(LoggingService);
+    const err = new Error('boom');
+    const consoleSpy = spyOn(console, 'error');
+
+    expect(() => service.logEvent('E')).not.toThrow();
+    expect(() => service.logMetric('M', 1)).not.toThrow();
+    expect(() => service.logTrace('T')).not.toThrow();
+    expect(() => service.logPageView('P')).not.toThrow();
+    service.logException(err);
+
+    expect(consoleSpy).toHaveBeenCalledWith(err);
+  });
+
+  describe('deferred load path', () => {
+    let service: TestableLoggingService;
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: LoggingService, useClass: TestableLoggingService },
+        ],
+      });
+      service = TestBed.inject(LoggingService) as TestableLoggingService;
+    });
+
+    it('buffers pre-load calls and flushes them in order after load', async () => {
+      const fakeAi = makeFakeAi();
+      service.importResult = Promise.resolve(makeFakeModule(fakeAi));
+
+      service.logEvent('first');
+      service.logMetric('second', 2);
+      service.logTrace('third');
+      expect(fakeAi.trackEvent).not.toHaveBeenCalled();
+
+      await service.runInitialize();
+
+      expect(fakeAi.trackEvent).toHaveBeenCalledWith(
+        { name: 'first' },
+        undefined
+      );
+      expect(fakeAi.trackMetric).toHaveBeenCalledWith(
+        { name: 'second', average: 2 },
+        undefined
+      );
+      expect(fakeAi.trackTrace).toHaveBeenCalledWith(
+        { message: 'third' },
+        undefined
+      );
+    });
+
+    it('applies the exact App Insights config, loads it, and stamps the version on load', async () => {
+      const fakeAi = makeFakeAi() as ReturnType<typeof makeFakeAi> & {
+        capturedConfig?: any;
+      };
+      service.importResult = Promise.resolve(makeFakeModule(fakeAi));
+
+      await service.runInitialize();
+
+      const cfg = fakeAi.capturedConfig.config;
+      expect(cfg.instrumentationKey).toBe(
+        environment.appInsights.instrumentationKey
+      );
+      expect(cfg.enableAutoRouteTracking).toBeTrue();
+      expect(cfg.disableFetchTracking).toBeFalse();
+      expect(cfg.disableCorrelationHeaders).toBeFalse();
+      expect(cfg.enableCorsCorrelation).toBeTrue();
+      expect(cfg.distributedTracingMode).toBe(1); // DistributedTracingModes.AI
+      expect(cfg.correlationHeaderExcludedDomains).toEqual(['*.auth0.com']);
+      expect(cfg.enableRequestHeaderTracking).toBeFalse();
+      expect(cfg.enableResponseHeaderTracking).toBeTrue();
+      expect(fakeAi.loadAppInsights).toHaveBeenCalledTimes(1);
+      expect(fakeAi.context.application.ver).toBe(environment.version);
+    });
+
+    it('logException console.errors immediately before load and uploads after flush', async () => {
+      const fakeAi = makeFakeAi();
+      service.importResult = Promise.resolve(makeFakeModule(fakeAi));
+      const err = new Error('pre-load');
+      const consoleSpy = spyOn(console, 'error');
+
+      service.logException(err);
+      expect(consoleSpy).toHaveBeenCalledWith(err);
+      expect(fakeAi.trackException).not.toHaveBeenCalled();
+
+      await service.runInitialize();
+      expect(fakeAi.trackException).toHaveBeenCalledWith({
+        exception: err,
+        severityLevel: undefined,
+      });
+    });
+
+    it('caps the buffer at 50 and drops the oldest', async () => {
+      const fakeAi = makeFakeAi();
+      service.importResult = Promise.resolve(makeFakeModule(fakeAi));
+
+      for (let i = 0; i < 51; i++) {
+        service.logEvent(`e${i}`);
+      }
+      await service.runInitialize();
+
+      expect(fakeAi.trackEvent).toHaveBeenCalledTimes(50);
+      // Oldest (e0) dropped; e1 is the first flushed.
+      expect(fakeAi.trackEvent.calls.first().args).toEqual([
+        { name: 'e1' },
+        undefined,
+      ]);
+      // A dropped-count trace is emitted after flush.
+      expect(fakeAi.trackTrace).toHaveBeenCalled();
+    });
+
+    it('keeps running (no throw) when the SDK import fails', async () => {
+      service.importResult = Promise.reject(new Error('network fail'));
+      spyOn(console, 'error');
+
+      service.logEvent('lost');
+      await service.runInitialize();
+
+      expect(() => service.logEvent('after')).not.toThrow();
+    });
   });
 });

--- a/src/app/core/services/logging.service.spec.ts
+++ b/src/app/core/services/logging.service.spec.ts
@@ -34,9 +34,10 @@ function makeFakeModule(
 
 /** Test subclass that forces the "browser + key" deferral path and controls the import. */
 class TestableLoggingService extends LoggingService {
-  importResult: Promise<any> = Promise.reject(
-    new Error('importResult not set')
-  );
+  // Default to a never-settling promise: every test assigns importResult before
+  // calling runInitialize(), and an eagerly-rejected default would surface as an
+  // unhandled rejection (order-dependent Karma failure).
+  importResult: Promise<any> = new Promise<never>(() => {});
   protected override isTelemetryEnabled(): boolean {
     return true;
   }

--- a/src/app/core/services/logging.service.ts
+++ b/src/app/core/services/logging.service.ts
@@ -1,65 +1,54 @@
 import { inject, Injectable, PLATFORM_ID } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
-import {
-  ApplicationInsights,
-  DistributedTracingModes,
-} from '@microsoft/applicationinsights-web';
 import { environment } from 'src/environments/environment';
 
+/** The subset of the App Insights API that LoggingService depends on. */
+interface TelemetrySink {
+  trackPageView(v: { name?: string; uri?: string }): void;
+  trackEvent(v: { name: string }, properties?: { [key: string]: any }): void;
+  trackMetric(
+    v: { name: string; average: number },
+    properties?: { [key: string]: any }
+  ): void;
+  trackException(v: { exception: Error; severityLevel?: number }): void;
+  trackTrace(v: { message: string }, properties?: { [key: string]: any }): void;
+}
+
+const MAX_BUFFER = 50;
+
+/**
+ * Wraps Azure Application Insights. The heavy SDK (~0.9 MB) is loaded lazily
+ * via dynamic import after first paint, so it stays out of the eager bundle.
+ * Until it loads, telemetry runs against a stub and calls are buffered; once
+ * loaded, buffered calls flush in order. With no instrumentation key (unit
+ * tests, SSR) the stub is permanent — identical to the previous behavior.
+ */
 @Injectable({
   providedIn: 'root',
 })
 export class LoggingService {
-  appInsights: ApplicationInsights;
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+  private sink: TelemetrySink = this.stubSink();
+  private loaded = false;
+  private buffer: Array<(sink: TelemetrySink) => void> = [];
+  private dropped = 0;
+  private loadPromise: Promise<void> | null = null;
+
   constructor() {
-    const isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
-    if (
-      isBrowser &&
-      environment &&
-      environment.appInsights &&
-      environment.appInsights.instrumentationKey &&
-      environment.appInsights.instrumentationKey !== ''
-    ) {
-      this.appInsights = new ApplicationInsights({
-        config: {
-          instrumentationKey: environment.appInsights.instrumentationKey,
-          enableAutoRouteTracking: true, // option to log all route changes,
-          disableFetchTracking: false,
-          disableCorrelationHeaders: false,
-          enableCorsCorrelation: true,
-          distributedTracingMode: DistributedTracingModes.AI,
-          correlationHeaderExcludedDomains: ['*.auth0.com'],
-          enableRequestHeaderTracking: false,
-          enableResponseHeaderTracking: true,
-        },
-      });
-      this.appInsights.loadAppInsights();
-      this.appInsights.context.application.ver = environment.version;
+    if (this.isTelemetryEnabled()) {
+      this.scheduleInitialize();
     } else {
-      this.appInsights = {
-        trackPageView: () => {},
-        trackEvent: () => {},
-        trackMetric: () => {},
-        trackException: (exception: Error, severityLevel?: number) => {
-          console.error(exception);
-        },
-        trackTrace: (message: string, properties?: { [key: string]: any }) => {
-          console.log(message, { properties });
-        },
-      } as unknown as ApplicationInsights;
+      // No key / not a browser: permanent stub, no buffering.
+      this.loaded = true;
     }
   }
 
   logPageView(name?: string, url?: string) {
-    // option to call manually
-    this.appInsights.trackPageView({
-      name,
-      uri: url,
-    });
+    this.dispatch((s) => s.trackPageView({ name, uri: url }));
   }
 
   logEvent(name: string, properties?: { [key: string]: any }) {
-    this.appInsights.trackEvent({ name }, properties);
+    this.dispatch((s) => s.trackEvent({ name }, properties));
   }
 
   logMetric(
@@ -67,14 +56,132 @@ export class LoggingService {
     average: number,
     properties?: { [key: string]: any }
   ) {
-    this.appInsights.trackMetric({ name, average }, properties);
+    this.dispatch((s) => s.trackMetric({ name, average }, properties));
   }
 
   logException(exception: Error, severityLevel?: number) {
-    this.appInsights.trackException({ exception, severityLevel });
+    // Surface immediately while the SDK is still loading so errors are never lost.
+    if (!this.loaded) {
+      console.error(exception);
+    }
+    this.dispatch((s) => s.trackException({ exception, severityLevel }));
   }
 
   logTrace(message: string, properties?: { [key: string]: any }) {
-    this.appInsights.trackTrace({ message }, properties);
+    this.dispatch((s) => s.trackTrace({ message }, properties));
+  }
+
+  protected isTelemetryEnabled(): boolean {
+    return (
+      this.isBrowser &&
+      !!environment?.appInsights?.instrumentationKey &&
+      environment.appInsights.instrumentationKey !== ''
+    );
+  }
+
+  protected scheduleInitialize(): void {
+    const run = () => {
+      this.loadPromise ??= this.initialize();
+    };
+    const g = globalThis as {
+      requestIdleCallback?: (cb: () => void) => void;
+      requestAnimationFrame?: (cb: () => void) => void;
+    };
+    if (typeof g.requestIdleCallback === 'function') {
+      g.requestIdleCallback(run);
+    } else if (typeof g.requestAnimationFrame === 'function') {
+      // Safari has no requestIdleCallback: wait for the next frame (post-paint),
+      // then a macrotask, so the import stays off the first-paint critical path.
+      // (Plain setTimeout(0) can fire before first paint during bootstrap.)
+      g.requestAnimationFrame(() => setTimeout(run, 0));
+    } else {
+      setTimeout(run, 0);
+    }
+  }
+
+  /** Dynamic-import seam; overridable in tests. */
+  protected importSdk(): Promise<
+    typeof import('@microsoft/applicationinsights-web')
+  > {
+    return import('@microsoft/applicationinsights-web');
+  }
+
+  private async initialize(): Promise<void> {
+    try {
+      const mod = await this.importSdk();
+      const appInsights = new mod.ApplicationInsights({
+        config: {
+          instrumentationKey: environment.appInsights.instrumentationKey!,
+          enableAutoRouteTracking: true,
+          disableFetchTracking: false,
+          disableCorrelationHeaders: false,
+          enableCorsCorrelation: true,
+          distributedTracingMode: mod.DistributedTracingModes.AI,
+          correlationHeaderExcludedDomains: ['*.auth0.com'],
+          enableRequestHeaderTracking: false,
+          enableResponseHeaderTracking: true,
+        },
+      });
+      appInsights.loadAppInsights();
+      appInsights.context.application.ver = environment.version;
+      this.activate(appInsights as unknown as TelemetrySink);
+    } catch (e) {
+      // SDK failed to load: run silently. Pre-load exceptions already reached
+      // the console at call time, so flush to a no-op sink to avoid double logs.
+      console.error(
+        'Application Insights failed to load; telemetry disabled',
+        e
+      );
+      this.activate(this.silentSink());
+    }
+  }
+
+  private activate(sink: TelemetrySink) {
+    this.sink = sink;
+    this.loaded = true;
+    for (const fn of this.buffer) {
+      fn(sink);
+    }
+    this.buffer = [];
+    if (this.dropped > 0) {
+      sink.trackTrace({
+        message: `LoggingService dropped ${this.dropped} buffered telemetry entries before load`,
+      });
+      this.dropped = 0;
+    }
+  }
+
+  private dispatch(fn: (sink: TelemetrySink) => void) {
+    if (this.loaded) {
+      fn(this.sink);
+      return;
+    }
+    if (this.buffer.length >= MAX_BUFFER) {
+      this.buffer.shift();
+      this.dropped++;
+    }
+    this.buffer.push(fn);
+  }
+
+  /** Stub used before load / when no key: exceptions and traces log, rest no-op. */
+  private stubSink(): TelemetrySink {
+    return {
+      trackPageView: () => {},
+      trackEvent: () => {},
+      trackMetric: () => {},
+      trackException: (v) => console.error(v.exception),
+      trackTrace: (v, properties) => console.log(v.message, { properties }),
+    };
+  }
+
+  /** Fully silent sink used after a failed SDK load. */
+  private silentSink(): TelemetrySink {
+    return {
+      trackPageView: () => {},
+      trackEvent: () => {},
+      trackMetric: () => {},
+      trackException: () => {},
+      trackTrace: () => {},
+    };
   }
 }

--- a/src/app/core/services/qr-code.service.ts
+++ b/src/app/core/services/qr-code.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import * as QRCode from 'qrcode';
 
 export interface QrCodeOptions {
   width?: number;
@@ -25,6 +24,15 @@ const DEFAULT_OPTIONS: QrCodeOptions = {
   providedIn: 'root',
 })
 export class QrCodeService {
+  // Cache the import *promise* (not the resolved module) so concurrent first
+  // calls share one dynamic import instead of racing two.
+  private qrcodeModule: Promise<typeof import('qrcode')> | null = null;
+
+  /** Loads the qrcode library on demand, caching the promise after the first call. */
+  private loadQrcode(): Promise<typeof import('qrcode')> {
+    return (this.qrcodeModule ??= import('qrcode'));
+  }
+
   /**
    * Generates a QR code as an SVG string.
    * @param data The data to encode in the QR code
@@ -36,6 +44,7 @@ export class QrCodeService {
     options: QrCodeOptions = {}
   ): Promise<string> {
     const mergedOptions = { ...DEFAULT_OPTIONS, ...options };
+    const QRCode = await this.loadQrcode();
 
     return QRCode.toString(data, {
       type: 'svg',
@@ -57,6 +66,7 @@ export class QrCodeService {
     options: QrCodeOptions = {}
   ): Promise<string> {
     const mergedOptions = { ...DEFAULT_OPTIONS, ...options };
+    const QRCode = await this.loadQrcode();
 
     return QRCode.toDataURL(data, {
       width: mergedOptions.width,

--- a/src/app/core/services/qr-scanner.service.ts
+++ b/src/app/core/services/qr-scanner.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Html5Qrcode, CameraDevice } from 'html5-qrcode';
+import type { Html5Qrcode, CameraDevice } from 'html5-qrcode';
 
 export interface QrScanResult {
   success: boolean;
@@ -14,6 +14,16 @@ export interface QrScanResult {
 export class QrScannerService {
   private html5QrCode: Html5Qrcode | null = null;
 
+  // Cache the import *promise* (not the resolved module) so concurrent first
+  // calls share one dynamic import instead of racing two.
+  private html5QrcodeModule: Promise<typeof import('html5-qrcode')> | null =
+    null;
+
+  /** Loads the html5-qrcode library on demand, caching the promise after the first call. */
+  private loadHtml5Qrcode(): Promise<typeof import('html5-qrcode')> {
+    return (this.html5QrcodeModule ??= import('html5-qrcode'));
+  }
+
   /**
    * Starts scanning for QR codes using the device camera.
    * @param elementId The ID of the HTML element to render the camera viewfinder
@@ -27,6 +37,7 @@ export class QrScannerService {
   ): Promise<void> {
     await this.stopScanning();
 
+    const { Html5Qrcode } = await this.loadHtml5Qrcode();
     this.html5QrCode = new Html5Qrcode(elementId);
 
     const config = {
@@ -116,6 +127,7 @@ export class QrScannerService {
    * @returns Promise resolving to an array of camera devices
    */
   async getCameras(): Promise<CameraDevice[]> {
+    const { Html5Qrcode } = await this.loadHtml5Qrcode();
     return Html5Qrcode.getCameras();
   }
 }

--- a/src/app/shared/qr-scanner/qr-scanner.component.ts
+++ b/src/app/shared/qr-scanner/qr-scanner.component.ts
@@ -14,7 +14,7 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatSelectModule } from '@angular/material/select';
-import { CameraDevice } from 'html5-qrcode';
+import type { CameraDevice } from 'html5-qrcode';
 
 import {
   QrScannerService,


### PR DESCRIPTION
## What & why

Phase 1 + 2 of the eager-bundle-splitting work (see design/plan docs). The mobile homepage was downloading and executing a ~2.4 MB eager chunk containing libraries it never uses, dominating Total Blocking Time. This defers the three biggest non-essential libraries out of the initial load.

## Changes

- **App Insights (~0.9 MB)** — `LoggingService` now dynamic-imports `@microsoft/applicationinsights-web` after first paint (`requestIdleCallback`, paint-safe fallback). Until it loads, telemetry runs a stub and buffers calls (cap 50, drop-oldest), flushing in order on load. Exceptions still reach `console.error` immediately during the load window; a failed import keeps the app running with telemetry disabled. No-key/SSR path is unchanged. The static `DistributedTracingModes` import was removed too (it would have re-anchored the package).
- **html5-qrcode (~1 MB)** — `QrScannerService` dynamic-imports it on first scan; the `CameraDevice` import in the service and component is now `import type` so the bundler drops the last eager anchor.
- **qrcode (~71 KB)** — `QrCodeService` dynamic-imports it on first use (methods were already async; no call-site changes).

Both QR loaders cache the import **promise** so concurrent first calls share one import.

## Verification

- `npm run test:brief` → **645 SUCCESS**; `npm run lint:brief` clean.
- New `LoggingService` specs cover buffering/ordering, exact config + `loadAppInsights()` + version stamping, exception immediacy, buffer cap, and import-failure.
- Production build + source-map analysis of the **initial** chunks (from `index.html`):
  - ✅ No `applicationinsights` / `html5-qrcode` / `qrcode` in any initial chunk
  - ✅ All three present in lazy chunks (moved, not removed)
  - **Initial JS total: 1.91 MB** (was a single ~2.4 MB eager chunk)

## Notes

- Telemetry timing: the initial page view is captured when the SDK loads (slightly later); a pre-load navigation could miss it — accepted trade-off, no manual `trackPageView()` to avoid double-counting.
- The unit suite has pre-existing order-dependent flakiness in unrelated specs (an ad-component `TagError` and a `print-grouped-view` date test) — both pass in isolation; not touched here.
- Lighthouse re-measurement follows after deploy.
