### PR TITLE
Release v1.43.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "print-log-ui",
-  "version": "1.43.8",
+  "version": "1.43.9",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --ssl --host 0.0.0.0 ",

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -28,6 +28,9 @@ export class VersionReleaseNoteDialogService {
   private readonly LOCAL_STORAGE_KEY = 'LastLoggedInVersion';
 
   private releaseNotes: ReleaseNoteHistory = {
+    '1.43.9': {
+      redirect: '1.43.7',
+    },
     '1.43.8': {
       redirect: '1.43.7',
     },

--- a/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
+++ b/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
@@ -2,6 +2,25 @@
   <h2>Release Notes</h2>
   <hr />
 
+  <h3 id="v1.43.9">1.43.9 - Faster Initial Load</h3>
+  <p>
+    The app now starts up faster. Several heavy behind-the-scenes libraries (analytics and QR code
+    tools) no longer load up front. They now load only when they are actually needed, which reduces
+    the amount of code the browser has to download and process before the page becomes usable.
+  </p>
+  <h4>Full List of Changes:</h4>
+  <ul>
+    <li>
+      <strong>Deferred analytics loading</strong> - The usage analytics library now loads after the
+      page has finished painting instead of blocking the initial load.
+    </li>
+    <li>
+      <strong>On-demand QR code tools</strong> - The QR code scanner and generator libraries now load
+      only when you open the scanner or create a label, keeping them out of the initial download.
+    </li>
+  </ul>
+  <hr />
+
   <h3 id="v1.43.8">1.43.8 - Faster, More Accessible Homepage</h3>
   <p>
     The homepage now loads faster and feels more responsive. Advertising scripts wait until you start


### PR DESCRIPTION
Patch release bumping the version to **1.43.9**.

Ships the eager-bundle-splitting work from #59 (Phases 1 & 2):

- **Deferred Application Insights** - the analytics SDK (~0.9 MB) now dynamic-imports after first paint, with a buffered telemetry stub in the meantime.
- **On-demand QR libraries** - `html5-qrcode` (~1 MB) and `qrcode` load only when the scanner/label flows are used.

Initial JS dropped from a single ~2.4 MB eager chunk to ~1.91 MB across split chunks.

Includes the version bump, release-notes entry, and version-dialog redirect.

After merge, tag the release:
```
git tag v1.43.9 && git push origin v1.43.9
```
