### PR TITLE
fix(qr): unwrap CJS default export when lazy-loading qrcode (QR labels hang in prod)

### DIFF
--- a/src/app/core/services/qr-code.service.spec.ts
+++ b/src/app/core/services/qr-code.service.spec.ts
@@ -1,5 +1,26 @@
 import { TestBed } from '@angular/core/testing';
+import { Injectable } from '@angular/core';
 import { QrCodeService } from './qr-code.service';
+
+/**
+ * Simulates how the *production* build resolves `import('qrcode')`: the CommonJS
+ * library is code-split into its own chunk that esbuild emits as a default-only
+ * export, and the dynamically imported ESM namespace has a null prototype (so
+ * `namespace.toString` is undefined, not Object.prototype.toString). Reproduces
+ * the bug where the QR label dialog hung on "Generating QR Codes".
+ */
+@Injectable()
+class ProdShapedQrCodeService extends QrCodeService {
+  override importQrcode(): Promise<typeof import('qrcode')> {
+    const api = {
+      toString: () => Promise.resolve('<svg>default-export</svg>'),
+      toDataURL: () => Promise.resolve('data:image/png;base64,default'),
+    };
+    // Default-only, null-prototype namespace (matches the split prod chunk).
+    const ns = Object.assign(Object.create(null), { default: api });
+    return Promise.resolve(ns as unknown as typeof import('qrcode'));
+  }
+}
 
 describe('QrCodeService', () => {
   let service: QrCodeService;
@@ -11,6 +32,22 @@ describe('QrCodeService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('CommonJS default-export interop (production split chunk)', () => {
+    it('unwraps .default so generateSvg resolves instead of hanging', async () => {
+      const prodService = new ProdShapedQrCodeService();
+      const svg = await prodService.generateSvg('https://example.com/x');
+      expect(svg).toBe('<svg>default-export</svg>');
+    });
+
+    it('unwraps .default for generateDataUrl too', async () => {
+      const prodService = new ProdShapedQrCodeService();
+      const dataUrl = await prodService.generateDataUrl(
+        'https://example.com/x'
+      );
+      expect(dataUrl).toBe('data:image/png;base64,default');
+    });
   });
 
   describe('generateSvg', () => {

--- a/src/app/core/services/qr-code.service.ts
+++ b/src/app/core/services/qr-code.service.ts
@@ -28,9 +28,29 @@ export class QrCodeService {
   // calls share one dynamic import instead of racing two.
   private qrcodeModule: Promise<typeof import('qrcode')> | null = null;
 
-  /** Loads the qrcode library on demand, caching the promise after the first call. */
+  /**
+   * The raw dynamic import. Isolated so tests can simulate how the production
+   * build resolves the module (see loadQrcode for why that matters).
+   */
+  protected importQrcode(): Promise<typeof import('qrcode')> {
+    return import('qrcode');
+  }
+
+  /**
+   * Loads the qrcode library on demand, caching the promise after the first call.
+   *
+   * `qrcode` is a CommonJS module. When the production build code-splits it into
+   * its own chunk, esbuild emits a default-only export, so the dynamically
+   * imported namespace exposes the real API (`toString`, `toDataURL`, ...) under
+   * `.default`. Because an ESM namespace object has a null prototype, accessing
+   * `.toString` directly on it yields `undefined` (not a function) and throws at
+   * call time. Unwrap `.default` so callers always get the real API, in both the
+   * split (prod) and inlined (test/dev) builds.
+   */
   private loadQrcode(): Promise<typeof import('qrcode')> {
-    return (this.qrcodeModule ??= import('qrcode'));
+    return (this.qrcodeModule ??= this.importQrcode().then(
+      (m) => (m as { default?: typeof import('qrcode') }).default ?? m
+    ));
   }
 
   /**

--- a/src/app/shared/qr-label-dialog/qr-label-dialog.component.html
+++ b/src/app/shared/qr-label-dialog/qr-label-dialog.component.html
@@ -6,6 +6,15 @@
       <mat-spinner diameter="40"></mat-spinner>
       <p>Generating QR codes...</p>
     </div>
+  } @else if (error()) {
+    <div class="error-container">
+      <mat-icon color="warn">error_outline</mat-icon>
+      <p>{{ error() }}</p>
+      <button mat-stroked-button color="primary" (click)="retry()">
+        <mat-icon>refresh</mat-icon>
+        Try Again
+      </button>
+    </div>
   } @else {
     <div class="settings-panel no-print">
       <mat-form-field appearance="outline">

--- a/src/app/shared/qr-label-dialog/qr-label-dialog.component.ts
+++ b/src/app/shared/qr-label-dialog/qr-label-dialog.component.ts
@@ -91,6 +91,7 @@ export class QrLabelDialogComponent implements OnInit, OnDestroy {
   readonly labelSize = signal<LabelSize>('medium');
   readonly paperSize = signal<PaperSize>('A4');
   readonly loading = signal(true);
+  readonly error = signal<string | null>(null);
   readonly labels = signal<LabelData[]>([]);
 
   readonly columnOptions = [1, 2, 3, 4];
@@ -155,6 +156,7 @@ export class QrLabelDialogComponent implements OnInit, OnDestroy {
 
   private async generateQrCodes(): Promise<void> {
     this.loading.set(true);
+    this.error.set(null);
 
     const labelPromises = this.data.filaments.map(async (filament) => {
       const url = this.qrCodeService.generateFilamentUrl(filament.id);
@@ -172,10 +174,23 @@ export class QrLabelDialogComponent implements OnInit, OnDestroy {
       };
     });
 
-    const labels = await Promise.all(labelPromises);
+    try {
+      const labels = await Promise.all(labelPromises);
+      this.labels.set(labels);
+    } catch (error) {
+      // Never leave the dialog stuck on the spinner: surface the failure so the
+      // user can retry or close instead of waiting forever.
+      this.loggingService.logException(error as Error);
+      this.error.set(
+        'Something went wrong generating the QR codes. Please try again.'
+      );
+    } finally {
+      this.loading.set(false);
+    }
+  }
 
-    this.labels.set(labels);
-    this.loading.set(false);
+  retry(): void {
+    this.generateQrCodes();
   }
 
   print(): void {


### PR DESCRIPTION
## Problem
In production, the **Print QR Labels** dialog hangs forever on "Generating QR codes…" — no labels render.

## Root cause
`qrcode` is a **CommonJS** module. Phase 1–2 (v1.43.9) switched it to a dynamic `import('qrcode')`. When the production build code-splits it into its own chunk, esbuild emits a **default-only** export (`export default …`). A dynamically-imported ESM namespace has a **null prototype**, so `namespace.toString`/`.toDataURL` are `undefined` — calling them throws a `TypeError`. `generateQrCodes()` had no `catch`, so `loading` never cleared and the spinner spun forever.

Confirmed directly from the deployed bundle: the qrcode chunk (`chunk-*.js`, named `browser` after `qrcode/lib/browser.js`) ships `export default Nn()` with no named `toString`, while `QrCodeService` called `.toString(...)` on the namespace. The QR *scanner* is unaffected because `html5-qrcode` is a real ES module with named exports. Not related to Phase 3; regression dates to **1.43.9**.

Why CI didn't catch it: in the karma/test build `qrcode` is inlined (not split), so esbuild's interop copies the named exports onto the module object. The bug only appears when the library is code-split.

## Fix
- `QrCodeService.loadQrcode()` unwraps `.default` (falling back to the module itself for the inlined test/dev build), through an overridable `importQrcode()` seam.
- **Regression tests** simulate the prod-shaped default-only, null-prototype namespace and assert `generateSvg`/`generateDataUrl` resolve.
- **Defense-in-depth:** the dialog now catches generation failures, logs them, and shows a retryable error instead of hanging on the spinner.

## Verification
- 647 unit tests pass (645 + 2 new interop regression tests); lint clean.
- Production build inspected: compiled service now resolves `this.importQrcode().then(e=>e.default??e)`, so `.toString`/`.toDataURL` hit the real CJS API.