### PR TITLE
feat: bump version to 1.43.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "print-log-ui",
-  "version": "1.43.10",
+  "version": "1.43.11",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --ssl --host 0.0.0.0 ",

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -28,6 +28,9 @@ export class VersionReleaseNoteDialogService {
   private readonly LOCAL_STORAGE_KEY = 'LastLoggedInVersion';
 
   private releaseNotes: ReleaseNoteHistory = {
+    '1.43.11': {
+      redirect: '1.43.10',
+    },
     '1.43.10': {
       redirect: '1.43.9',
     },

--- a/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
+++ b/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
@@ -2,6 +2,22 @@
   <h2>Release Notes</h2>
   <hr />
 
+  <h3 id="v1.43.11">1.43.11 - QR Label Printing Fix</h3>
+  <p>
+    Fixed a bug where the Print QR Labels dialog would get stuck on "Generating QR codes" and never
+    finish. QR label generation now works again, and if anything does go wrong the dialog shows a
+    clear message with a retry option instead of spinning forever.
+  </p>
+  <h4>Full List of Changes:</h4>
+  <ul>
+    <li>
+      <strong>QR label generation fixed</strong> - Resolved an issue introduced in 1.43.9 where the
+      QR code library failed to load in production, leaving the Print Labels dialog stuck on the
+      loading spinner.
+    </li>
+  </ul>
+  <hr />
+
   <h3 id="v1.43.10">1.43.10 - Faster Page Loads</h3>
   <p>
     More behind-the-scenes work to speed up the app. The initial download was slimmed down further by


### PR DESCRIPTION
Patch release **1.43.11**.

Ships the QR label printing fix (PR #63): `qrcode` (a CommonJS module) failed to resolve when the production build code-split it, leaving the Print QR Labels dialog stuck on "Generating QR codes". The service now unwraps the CJS `.default` export, and the dialog surfaces a retryable error instead of hanging.

### Release notes
- **Docs page:** "1.43.11 - QR Label Printing Fix" — QR label generation works again; failures now show a retry instead of spinning forever.
- **Version dialog:** redirects to 1.43.10 (sequential chain; no popup for this fix).

### Files
- `package.json` -> 1.43.11
- `docs-release-notes.component.html` — new entry
- `version-release-note-dialog.service.ts` — redirect entry