### PR TITLE
Serve loading shells for client-only routes (kill the Home-page flicker)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,6 @@ jobs:
 
       - name: Verify prerendered output
         run: node scripts/verify-prerender.mjs
+
+      - name: Verify shells
+        run: node scripts/verify-shells.mjs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Verify prerendered output and sitemap index
         run: node scripts/verify-prerender.mjs
 
+      - name: Verify shells
+        run: node scripts/verify-shells.mjs
+
       - name: Deploy to Azure Static Web Apps (prebuilt)
         uses: Azure/static-web-apps-deploy@v1
         with:

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "ng serve --ssl --host 0.0.0.0 ",
     "start:auth0": "ng serve --ssl --host 0.0.0.0 --configuration=auth0-dev",
     "build:dev": "ng build --verbose",
-    "build": "ng build --configuration production --verbose",
+    "build": "ng build --configuration production --verbose && node scripts/generate-shells.mjs",
     "test": "ng test",
     "test:ci": "ng test --no-watch --code-coverage --browsers ChromeHeadless",
     "test:brief": "bash scripts/test-brief.sh",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:ci": "ng test --no-watch --code-coverage --browsers ChromeHeadless",
     "test:brief": "bash scripts/test-brief.sh",
     "test:sitemap": "node --test scripts/*.test.mjs",
+    "verify:shells": "node scripts/verify-shells.mjs",
     "lint": "ng lint",
     "lint:fix": "ng lint --fix",
     "lint:brief": "bash scripts/lint-brief.sh",

--- a/scripts/generate-shells.mjs
+++ b/scripts/generate-shells.mjs
@@ -1,0 +1,32 @@
+import { readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { buildShell, resolveBrowserDir } from './shell-lib.mjs';
+
+const TITLE = 'Loading… — 3D Print Log';
+const DESCRIPTION = 'Loading your 3D Print Log.';
+
+const SHELLS = [
+  { out: 'app-shell.html', body: 'src/shells/app-shell.body.html' },
+  { out: 'list-skeleton.html', body: 'src/shells/list-skeleton.body.html' },
+];
+
+function main() {
+  const angularJson = JSON.parse(readFileSync('angular.json', 'utf8'));
+  const browserDir = resolveBrowserDir(angularJson);
+  const indexHtml = readFileSync(join(browserDir, 'index.html'), 'utf8');
+  const shellsDir = join(browserDir, 'shells');
+  mkdirSync(shellsDir, { recursive: true });
+
+  for (const shell of SHELLS) {
+    const bodyHtml = readFileSync(shell.body, 'utf8').trim();
+    const html = buildShell(indexHtml, {
+      bodyHtml,
+      title: TITLE,
+      description: DESCRIPTION,
+    });
+    writeFileSync(join(shellsDir, shell.out), html);
+    console.log(`Wrote ${join(shellsDir, shell.out)}`);
+  }
+}
+
+main();

--- a/scripts/shell-lib.mjs
+++ b/scripts/shell-lib.mjs
@@ -1,0 +1,106 @@
+// Pure transforms to derive a non-hydrated loading shell from the built index.
+// String-based (no HTML parser dependency), matching the repo's script style.
+// The exact artifact shapes are confirmed by the Task 1 spike.
+
+export function replaceAppRoot(html, bodyHtml) {
+  // Replace the ENTIRE <app-root ...>...</app-root> element (drops ngh, _nghost,
+  // ng-version, ng-server-context, and all prerendered DOM in one move).
+  return html.replace(
+    /<app-root\b[^>]*>[\s\S]*?<\/app-root>/i,
+    `<app-root>${bodyHtml}</app-root>`
+  );
+}
+
+export function stripSsrArtifacts(html) {
+  let out = html;
+  // Transfer-state hydration payload.
+  out = out.replace(/<script\b[^>]*\bid=["']ng-state["'][\s\S]*?<\/script>/gi, '');
+  // Hydration marker comment.
+  out = out.replace(/<!--nghm-->/g, '');
+  // Event-replay bootstrap: inline (no src) script carrying an Angular hydration
+  // token (confirmed in Task 1: __jsaction / __nghData). The inner
+  // `(?:(?!<\/script>)[\s\S])*?` guards prevent the match from crossing a
+  // </script> boundary and swallowing unrelated scripts/markup in between.
+  out = out.replace(
+    /<script\b(?![^>]*\bsrc=)[^>]*>(?:(?!<\/script>)[\s\S])*?(?:__jsaction|ngContracts|__nghData__)(?:(?!<\/script>)[\s\S])*?<\/script>/gi,
+    ''
+  );
+  // SSR-injected component critical CSS.
+  out = out.replace(/<style\b[^>]*\bng-app-id=["']ng["'][\s\S]*?<\/style>/gi, '');
+  // Flex-layout SSR styles.
+  out = out.replace(
+    /<style\b[^>]*\bclass=["']flex-layout-ssr["'][\s\S]*?<\/style>/gi,
+    ''
+  );
+  return out;
+}
+
+export function setHeadMetadata(html, { title, description }) {
+  let out = html;
+  out = out.replace(/<title>[\s\S]*?<\/title>/i, `<title>${title}</title>`);
+  out = out.replace(
+    /<meta\s+name=["']description["'][^>]*>/i,
+    `<meta name="description" content="${description}">`
+  );
+  // Drop Home identity metadata.
+  out = out.replace(/<link\b[^>]*\brel=["']canonical["'][^>]*>/gi, '');
+  out = out.replace(
+    /<meta\b[^>]*\b(?:property=["']og:|name=["']twitter:)[^>]*>/gi,
+    ''
+  );
+  out = out.replace(
+    /<script\b[^>]*type=["']application\/ld\+json["'][\s\S]*?<\/script>/gi,
+    ''
+  );
+  // Add noindex once, before </head>.
+  if (!/name=["']robots["']/i.test(out)) {
+    out = out.replace(
+      /<\/head>/i,
+      '<meta name="robots" content="noindex"><meta name="googlebot" content="noindex"></head>'
+    );
+  }
+  return out;
+}
+
+export function buildShell(indexHtml, { bodyHtml, title, description }) {
+  let out = replaceAppRoot(indexHtml, bodyHtml);
+  out = stripSsrArtifacts(out);
+  out = setHeadMetadata(out, { title, description });
+  return out;
+}
+
+export function findSsrArtifacts(html) {
+  const checks = [
+    ['ngh', /\bngh=/],
+    ['_nghost', /_nghost/],
+    ['ng-version', /\bng-version=/],
+    ['ng-server-context', /\bng-server-context=/],
+    ['ng-state', /\bid=["']ng-state["']/],
+    ['nghm-comment', /<!--nghm-->/],
+    ['event-replay', /(?:__jsaction|ngContracts|__nghData__)/],
+    ['ng-app-id-style', /<style\b[^>]*\bng-app-id=/i],
+    ['flex-layout-ssr', /flex-layout-ssr/],
+    ['home-content', /Home page content/],
+  ];
+  return checks.filter(([, re]) => re.test(html)).map(([name]) => name);
+}
+
+export function localAssetRefs(html) {
+  const refs = [];
+  const re = /\b(?:src|href)=["']([^"']+)["']/gi;
+  let m;
+  while ((m = re.exec(html)) !== null) {
+    const url = m[1];
+    if (url.startsWith('data:') || url.startsWith('#') || url.startsWith('mailto:'))
+      continue;
+    if (/^[a-z]+:\/\//i.test(url) || url.startsWith('//')) continue; // external/absolute
+    refs.push(url);
+  }
+  return refs;
+}
+
+export function resolveBrowserDir(angularJson) {
+  const project = Object.values(angularJson.projects)[0];
+  const base = project.architect.build.options.outputPath.base;
+  return `${base}/browser`;
+}

--- a/scripts/shell-lib.test.mjs
+++ b/scripts/shell-lib.test.mjs
@@ -1,0 +1,90 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  buildShell,
+  findSsrArtifacts,
+  localAssetRefs,
+  resolveBrowserDir,
+} from './shell-lib.mjs';
+
+// Synthetic fixture covering every artifact the transform must handle. Shapes
+// mirror the real prerendered index.html verified in the Task 1 spike.
+const FIXTURE = `<!doctype html><html lang="en"><head>
+<title>3D Print Log — Track your 3D prints</title>
+<meta name="description" content="Home marketing description">
+<link rel="canonical" href="https://www.3dprintlog.com/">
+<meta property="og:title" content="3D Print Log">
+<meta name="twitter:card" content="summary_large_image">
+<script type="application/ld+json">{"@type":"WebApplication"}</script>
+<script>(function(){var m=localStorage.getItem('theme-mode')||'system';if(m==='dark'){document.documentElement.classList.add('dark-theme');}})();</script>
+<link rel="stylesheet" href="/styles-ABC123.css">
+<style ng-app-id="ng">.home{color:red}</style>
+<style class="flex-layout-ssr">.fx{display:flex}</style>
+</head><body>
+<!--nghm-->
+<app-root ng-version="21.2.12" _nghost-ng-c3350497413="" ngh="7" ng-server-context="ssg"><h1>Home page content</h1></app-root>
+<script>window.__jsaction_bootstrap(document.body,"ng",["click"],[]);</script>
+<script id="ng-state" type="application/json">{"__nghData__":[]}</script>
+<script src="/main-DEF456.js" type="module"></script>
+</body></html>`;
+
+const OPTS = {
+  bodyHtml: '<div class="app-loading-shell">shell</div>',
+  title: 'Loading… — 3D Print Log',
+  description: 'Loading your 3D Print Log.',
+};
+
+test('buildShell removes all SSR/hydration artifacts', () => {
+  const out = buildShell(FIXTURE, OPTS);
+  assert.deepEqual(findSsrArtifacts(out), []);
+});
+
+test('buildShell replaces the whole app-root element with clean shell body', () => {
+  const out = buildShell(FIXTURE, OPTS);
+  assert.match(
+    out,
+    /<app-root><div class="app-loading-shell">shell<\/div><\/app-root>/
+  );
+  assert.doesNotMatch(out, /Home page content/);
+  assert.doesNotMatch(out, /ngh=|_nghost|ng-version|ng-server-context/);
+});
+
+test('buildShell keeps bundle script, css link, and theme script', () => {
+  const out = buildShell(FIXTURE, OPTS);
+  assert.match(out, /<script src="\/main-DEF456\.js" type="module">/);
+  assert.match(out, /<link rel="stylesheet" href="\/styles-ABC123\.css">/);
+  assert.match(out, /theme-mode/);
+});
+
+test('buildShell rewrites head metadata to generic + noindex', () => {
+  const out = buildShell(FIXTURE, OPTS);
+  assert.match(out, /<title>Loading… — 3D Print Log<\/title>/);
+  assert.match(
+    out,
+    /<meta name="description" content="Loading your 3D Print Log\.">/
+  );
+  assert.match(out, /<meta name="robots" content="noindex">/);
+  assert.doesNotMatch(out, /rel="canonical"/);
+  assert.doesNotMatch(out, /og:title|twitter:card/);
+  assert.doesNotMatch(out, /application\/ld\+json/);
+});
+
+test('localAssetRefs returns local paths, skips external and data urls', () => {
+  const html =
+    `<link href="/a.css"><script src="https://cdn/x.js"></script>` +
+    `<img src="data:image/png;base64,xx"><script src="/b.js"></script>`;
+  assert.deepEqual(localAssetRefs(html), ['/a.css', '/b.js']);
+});
+
+test('resolveBrowserDir joins outputPath.base with browser', () => {
+  const angularJson = {
+    projects: {
+      'print-log-ui': {
+        architect: {
+          build: { options: { outputPath: { base: 'dist/print-log-ui' } } },
+        },
+      },
+    },
+  };
+  assert.equal(resolveBrowserDir(angularJson), 'dist/print-log-ui/browser');
+});

--- a/scripts/verify-shells.mjs
+++ b/scripts/verify-shells.mjs
@@ -1,0 +1,83 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  findSsrArtifacts,
+  localAssetRefs,
+  resolveBrowserDir,
+} from './shell-lib.mjs';
+
+const SHELLS = ['app-shell.html', 'list-skeleton.html'];
+const errors = [];
+
+function check(cond, msg) {
+  if (!cond) errors.push(msg);
+}
+
+function main() {
+  const angularJson = JSON.parse(readFileSync('angular.json', 'utf8'));
+  const browserDir = resolveBrowserDir(angularJson);
+  const shellsDir = join(browserDir, 'shells');
+
+  for (const name of SHELLS) {
+    const path = join(shellsDir, name);
+    check(existsSync(path), `${name}: missing at ${path}`);
+    if (!existsSync(path)) continue;
+    const html = readFileSync(path, 'utf8');
+
+    const artifacts = findSsrArtifacts(html);
+    check(
+      artifacts.length === 0,
+      `${name}: SSR artifacts present: ${artifacts.join(', ')}`
+    );
+    check(/theme-mode/.test(html), `${name}: missing pre-paint theme script`);
+    check(
+      /type=["']module["']/.test(html),
+      `${name}: missing module bootstrap script`
+    );
+    check(
+      /name=["']robots["'][^>]*noindex/i.test(html),
+      `${name}: missing noindex`
+    );
+    check(!/rel=["']canonical["']/i.test(html), `${name}: canonical present`);
+    check(
+      !/property=["']og:|name=["']twitter:/i.test(html),
+      `${name}: social meta present`
+    );
+    check(!/application\/ld\+json/i.test(html), `${name}: JSON-LD present`);
+
+    for (const ref of localAssetRefs(html)) {
+      const assetPath = join(browserDir, ref.replace(/^\//, '').split('?')[0]);
+      check(existsSync(assetPath), `${name}: referenced asset missing: ${ref}`);
+    }
+  }
+
+  // Config rewrite targets must exist as output files.
+  const config = JSON.parse(readFileSync('src/staticwebapp.config.json', 'utf8'));
+  const targets = [
+    ...(config.routes || []).map((r) => r.rewrite).filter(Boolean),
+    config.navigationFallback?.rewrite,
+  ].filter(Boolean);
+  for (const t of [...new Set(targets)]) {
+    check(
+      existsSync(join(browserDir, t.replace(/^\//, ''))),
+      `config rewrite target missing: ${t}`
+    );
+  }
+
+  // Regression: prerendered Home still has hydration info.
+  const homeHtml = readFileSync(join(browserDir, 'index.html'), 'utf8');
+  check(
+    /\bngh=|id=["']ng-state["']/.test(homeHtml),
+    'home index.html lost hydration info'
+  );
+
+  if (errors.length) {
+    console.error(
+      'verify-shells FAILED:\n' + errors.map((e) => ` - ${e}`).join('\n')
+    );
+    process.exit(1);
+  }
+  console.log('verify-shells passed.');
+}
+
+main();

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -7,7 +7,7 @@ import { PendingChangesGuard } from './core/guards/pending-changes.guard';
 import { HomeComponent } from './home/home.component';
 import { SlicerLandingComponent } from './slicer/slicer-landing.component';
 
-const routes: Routes = [
+export const appRoutes: Routes = [
   {
     path: 'callback',
     loadComponent: () =>
@@ -44,6 +44,7 @@ const routes: Routes = [
       import('./printer-maintenance/printer-maintenance.module').then(
         (m) => m.PrinterMaintenanceModule
       ),
+    canActivate: [AuthGuard],
   },
   {
     path: 'home',
@@ -70,6 +71,7 @@ const routes: Routes = [
     path: 'analytics',
     loadChildren: () =>
       import('./analytics/analytics.module').then((m) => m.AnalyticsModule),
+    canActivate: [AuthGuard],
   },
   environment.features.userProfile
     ? {
@@ -82,6 +84,7 @@ const routes: Routes = [
     path: 'settings',
     loadChildren: () =>
       import('./settings/settings.module').then((m) => m.SettingsModule),
+    canActivate: [AuthGuard],
   },
   {
     path: 'filament',
@@ -96,6 +99,7 @@ const routes: Routes = [
     path: 'api-keys',
     loadChildren: () =>
       import('./apikeys/apikeys.module').then((m) => m.ApikeysModule),
+    canActivate: [AuthGuard],
   },
   {
     path: 'notifications',
@@ -178,6 +182,7 @@ const routes: Routes = [
   {
     path: 'feed',
     loadChildren: () => import('./feed/feed.module').then((m) => m.FeedModule),
+    canActivate: [AuthGuard],
   },
 
   {
@@ -189,7 +194,7 @@ const routes: Routes = [
 
 @NgModule({
   imports: [
-    RouterModule.forRoot(routes, {
+    RouterModule.forRoot(appRoutes, {
       scrollPositionRestoration: 'enabled',
     }),
   ],

--- a/src/app/core/routing/route-guard-matrix.spec.ts
+++ b/src/app/core/routing/route-guard-matrix.spec.ts
@@ -1,0 +1,62 @@
+import { Routes } from '@angular/router';
+import { AuthGuard } from '../guards/auth.guard';
+
+// Import the route arrays under test (exported from their routing modules).
+import { appRoutes } from '../../app-routing.module';
+import { printRoutes } from '../../print/print-routing.module';
+import { filamentRoutes } from '../../filament/filament-routing.module';
+import { printerRoutes } from '../../printer/printer-routing.module';
+
+function find(routes: Routes, path: string): Routes[number] | undefined {
+  return routes.find((r) => r.path === path);
+}
+function guarded(route?: Routes[number]): boolean {
+  return !!route?.canActivate?.includes(AuthGuard);
+}
+
+describe('route guard matrix', () => {
+  it('guards wholly-private top-level modules', () => {
+    for (const path of [
+      'analytics',
+      'settings',
+      'api-keys',
+      'printer-maintenance',
+      'feed',
+    ]) {
+      expect(guarded(find(appRoutes, path)))
+        .withContext(path)
+        .toBe(true);
+    }
+  });
+
+  it('guards private list/edit children but leaves public print view open', () => {
+    const printChildren = find(printRoutes, '')?.children ?? [];
+    expect(guarded(find(printChildren, '')))
+      .withContext('prints list')
+      .toBe(true);
+    expect(guarded(find(printChildren, 'copy/:id')))
+      .withContext('print copy')
+      .toBe(true);
+    expect(guarded(find(printChildren, ':id')))
+      .withContext('print view is public')
+      .toBe(false);
+  });
+
+  it('guards all filament children (detail is private)', () => {
+    const children = find(filamentRoutes, '')?.children ?? [];
+    for (const path of ['', 'copy/:id', ':id']) {
+      expect(guarded(find(children, path)))
+        .withContext(`filament ${path}`)
+        .toBe(true);
+    }
+  });
+
+  it('guards all printer children (detail is private)', () => {
+    const children = find(printerRoutes, '')?.children ?? [];
+    for (const path of ['', ':id']) {
+      expect(guarded(find(children, path)))
+        .withContext(`printer ${path}`)
+        .toBe(true);
+    }
+  });
+});

--- a/src/app/filament/filament-routing.module.ts
+++ b/src/app/filament/filament-routing.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { AuthGuard } from '../core/guards/auth.guard';
 import { PendingChangesGuard } from '../core/guards/pending-changes.guard';
 import { CurrencySymbolResolverService } from '../core/resolvers/currency-symbol-resolver.service';
 import { DefaultFilamentDiameterSettingResolverService } from '../core/resolvers/default-filament-diameter-setting-resolver.service';
@@ -14,13 +15,14 @@ import { MaterialResolverService } from './resolvers/material-resolver.service';
 import { MaterialCategoryResolverService } from '../core/resolvers/material-category-resolver.service';
 import { FilamentStorageLocationResolverService } from './resolvers/filament-storage-location-resolver.service';
 
-const routes: Routes = [
+export const filamentRoutes: Routes = [
   {
     path: '',
     children: [
       {
         path: '',
         component: FilamentListContainerComponent,
+        canActivate: [AuthGuard],
         resolve: {
           filamentList: FilamentListResolverService,
           materialCategories: MaterialCategoryResolverService,
@@ -30,6 +32,7 @@ const routes: Routes = [
       {
         path: 'copy/:id',
         component: FilamentDetailComponent,
+        canActivate: [AuthGuard],
         resolve: {
           filament: CopyFilamentDetailResolverService,
           materials: MaterialResolverService,
@@ -45,6 +48,7 @@ const routes: Routes = [
       {
         path: ':id',
         component: FilamentDetailComponent,
+        canActivate: [AuthGuard],
         resolve: {
           filament: FilamentDetailResolverService,
           materials: MaterialResolverService,
@@ -62,7 +66,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forChild(routes)],
+  imports: [RouterModule.forChild(filamentRoutes)],
   exports: [RouterModule],
 })
 export class FilamentRoutingModule {}

--- a/src/app/print/print-routing.module.ts
+++ b/src/app/print/print-routing.module.ts
@@ -21,13 +21,14 @@ import { PrintListResolverService } from './resolvers/print-list-resolver.servic
 import { ViewPrintDetailComponent } from './view-print-detail/view-print-detail.component';
 import { FilamentListResolverService } from './resolvers/filament-list-resolver.service';
 
-const routes: Routes = [
+export const printRoutes: Routes = [
   {
     path: '',
     children: [
       {
         path: '',
         component: PrintListComponent,
+        canActivate: [AuthGuard],
         resolve: {
           printList: PrintListResolverService,
           printers: CurrentUserPrinterSummaryResolverService,
@@ -44,6 +45,7 @@ const routes: Routes = [
       {
         path: 'copy/:id',
         component: EditPrintDetailComponent,
+        canActivate: [AuthGuard],
         resolve: {
           print: CopyPrintDetailResolverService,
           printers: CurrentUserPrinterSummaryResolverService,
@@ -111,6 +113,6 @@ const routes: Routes = [
 
 @NgModule({
   exports: [RouterModule],
-  imports: [RouterModule.forChild(routes)],
+  imports: [RouterModule.forChild(printRoutes)],
 })
 export class PrintRoutingModule {}

--- a/src/app/printer/printer-routing.module.ts
+++ b/src/app/printer/printer-routing.module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
+import { AuthGuard } from '../core/guards/auth.guard';
 import { PendingChangesGuard } from '../core/guards/pending-changes.guard';
 import { PrinterDetailComponent } from './printer-detail/printer-detail.component';
 import { PrinterListComponent } from './printer-list/printer-list.component';
@@ -8,18 +9,20 @@ import { PrinterListResolverService } from './resolvers/printer-list-resolver.se
 import { PrinterCategoryResolverService } from '../core/resolvers/printer-category-resolver.service';
 import { MaterialCategoryResolverService } from '../core/resolvers/material-category-resolver.service';
 
-const routes: Routes = [
+export const printerRoutes: Routes = [
   {
     path: '',
     children: [
       {
         path: '',
         component: PrinterListComponent,
+        canActivate: [AuthGuard],
         resolve: { printerList: PrinterListResolverService },
       },
       {
         path: ':id',
         component: PrinterDetailComponent,
+        canActivate: [AuthGuard],
         resolve: {
           printer: PrinterDetailResolverService,
           printerCategories: PrinterCategoryResolverService,
@@ -32,7 +35,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forChild(routes)],
+  imports: [RouterModule.forChild(printerRoutes)],
   exports: [RouterModule],
 })
 export class PrinterRoutingModule {}

--- a/src/shells/app-shell.body.html
+++ b/src/shells/app-shell.body.html
@@ -1,0 +1,14 @@
+<div class="app-loading-shell" role="status" aria-live="polite">
+  <div class="app-loading-shell__toolbar">
+    <span class="app-loading-shell__brand">3D Print Log</span>
+  </div>
+  <div class="app-loading-shell__center">
+    <div class="app-loading-shell__spinner" aria-hidden="true"></div>
+    <span class="app-loading-shell__sr">Loading…</span>
+  </div>
+  <noscript>
+    <p style="padding:1rem;text-align:center">
+      This app requires JavaScript. <a href="/">Return to the home page</a>.
+    </p>
+  </noscript>
+</div>

--- a/src/shells/list-skeleton.body.html
+++ b/src/shells/list-skeleton.body.html
@@ -1,0 +1,26 @@
+<div class="app-loading-shell" role="status" aria-live="polite">
+  <div class="app-loading-shell__toolbar">
+    <span class="app-loading-shell__brand">3D Print Log</span>
+  </div>
+  <div class="app-loading-shell__list">
+    <div class="app-loading-shell__controls">
+      <div class="app-loading-shell__search shimmer"></div>
+      <div class="app-loading-shell__chip shimmer"></div>
+      <div class="app-loading-shell__chip shimmer"></div>
+    </div>
+    <div class="app-loading-shell__table">
+      <div class="app-loading-shell__row shimmer"></div>
+      <div class="app-loading-shell__row shimmer"></div>
+      <div class="app-loading-shell__row shimmer"></div>
+      <div class="app-loading-shell__row shimmer"></div>
+      <div class="app-loading-shell__row shimmer"></div>
+      <div class="app-loading-shell__row shimmer"></div>
+    </div>
+    <span class="app-loading-shell__sr">Loading…</span>
+  </div>
+  <noscript>
+    <p style="padding:1rem;text-align:center">
+      This app requires JavaScript. <a href="/">Return to the home page</a>.
+    </p>
+  </noscript>
+</div>

--- a/src/staticwebapp.config.json
+++ b/src/staticwebapp.config.json
@@ -1,5 +1,10 @@
 {
-  "navigationFallback": {
-    "rewrite": "/index.html"
-  }
+  "routes": [
+    { "route": "/prints", "rewrite": "/shells/list-skeleton.html" },
+    { "route": "/materials", "rewrite": "/shells/list-skeleton.html" },
+    { "route": "/filament", "rewrite": "/shells/list-skeleton.html" },
+    { "route": "/printers", "rewrite": "/shells/list-skeleton.html" },
+    { "route": "/shells/*", "headers": { "cache-control": "no-cache" } }
+  ],
+  "navigationFallback": { "rewrite": "/shells/app-shell.html" }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -195,3 +195,145 @@ html.dark-theme .notification-menu {
     color: #90caf9;
   }
 }
+
+// Loading shell (served as a non-hydrated fallback for client routes). All rules
+// scoped under .app-loading-shell to avoid colliding with the live app after boot.
+.app-loading-shell {
+  --shell-shimmer-base: #e9e9e9;
+  --shell-shimmer-hi: #f5f5f5;
+
+  &__toolbar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 64px;
+    display: flex;
+    align-items: center;
+    padding: 0 16px;
+    background-color: var(--brand-toolbar-bg);
+    color: #fff;
+    z-index: 2;
+  }
+
+  &__brand {
+    font-size: 20px;
+    font-weight: 500;
+  }
+
+  &__center {
+    min-height: calc(100vh - 64px);
+    margin-top: 64px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+  }
+
+  &__spinner {
+    width: 48px;
+    height: 48px;
+    border: 4px solid var(--shell-shimmer-base);
+    border-top-color: var(--brand-toolbar-bg);
+    border-radius: 50%;
+    animation: app-loading-shell-spin 0.9s linear infinite;
+  }
+
+  &__list {
+    max-width: 1200px;
+    margin: 80px auto 0;
+    padding: 0 16px;
+  }
+
+  &__controls {
+    display: flex;
+    gap: 12px;
+    margin-bottom: 20px;
+  }
+
+  &__search {
+    flex: 1;
+    height: 40px;
+    border-radius: 4px;
+  }
+
+  &__chip {
+    width: 96px;
+    height: 40px;
+    border-radius: 20px;
+  }
+
+  &__table {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  &__row {
+    height: 48px;
+    border-radius: 4px;
+  }
+
+  .shimmer {
+    background: linear-gradient(
+      90deg,
+      var(--shell-shimmer-base) 25%,
+      var(--shell-shimmer-hi) 37%,
+      var(--shell-shimmer-base) 63%
+    );
+    background-size: 400% 100%;
+    animation: app-loading-shell-shimmer 1.4s ease infinite;
+  }
+
+  &__sr {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  @media (max-width: 599px) {
+    &__toolbar {
+      height: 56px;
+    }
+    &__center {
+      min-height: calc(100vh - 56px);
+      margin-top: 56px;
+    }
+    &__list {
+      margin-top: 72px;
+    }
+  }
+}
+
+html.dark-theme .app-loading-shell {
+  --shell-shimmer-base: #2a2a2a;
+  --shell-shimmer-hi: #3a3a3a;
+}
+
+@keyframes app-loading-shell-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes app-loading-shell-shimmer {
+  0% {
+    background-position: 100% 0;
+  }
+  100% {
+    background-position: 0 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .app-loading-shell__spinner,
+  .app-loading-shell .shimmer {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Problem

After the static-prerender work, hard-refreshing a non-prerendered authenticated route (`/prints`, `/materials`, `/printers`, `/analytics`, …) briefly rendered the **prerendered Home page**, then swapped to the real screen — a visible flicker — because `navigationFallback` served the hydrated Home `index.html` for every client route.

## Solution

At production build time, derive two lightweight, **non-hydrated** static shells from the built `index.html` and serve them via Azure SWA rewrites so client routes paint neutral chrome (never Home) until Angular hydrates:

- **List skeleton** (`/prints`, `/materials`, `/filament`, `/printers`) — toolbar + search + filter chips + bare shimmer table.
- **App shell / spinner** (`navigationFallback` for everything else client-rendered) — toolbar + centered spinner.

Because the shells carry **no hydration markers**, Angular does a clean client bootstrap (NG0505) on top of them instead of attempting a mismatched hydration — so there's structurally no Home content in the payload to flash.

### How the shells are built
- `scripts/shell-lib.mjs` — pure transforms (swap `<app-root>` body, strip all SSR/hydration artifacts, rewrite `<head>` metadata to a neutral `noindex` "Loading…" page), with unit tests in `shell-lib.test.mjs`.
- `scripts/generate-shells.mjs` — runs after `ng build --configuration production`, injecting `src/shells/*.body.html` into the derived shells.
- `scripts/verify-shells.mjs` — CI/deploy gate: asserts shells exist, contain no SSR artifacts, keep the pre-paint theme script + module scripts + local assets, are `noindex` with no canonical/OG/JSON-LD, that rewrite targets resolve, and that the real Home index is still hydrated.

### Theming
Shell styles are scoped under `.app-loading-shell` in `styles.scss` with a `.dark-theme` override. The existing pre-paint theme script sets `html.dark-theme` before the render-blocking stylesheet loads, so the shell's **first frame** is already the correct theme (no white flash). Honors `prefers-reduced-motion`.

### Auth hardening (bundled)
Private client routes previously relied on the API rejecting requests rather than route guards. Added `AuthGuard` to the wholly-private routes (`analytics`, `settings`, `api-keys`, `printer-maintenance`, `feed`, and the print/printer/filament list + copy/edit routes) while intentionally leaving genuinely public routes open (`/prints/:id`, `/projects/:id`, `/users`). Locked in by `route-guard-matrix.spec.ts`.

## Verification

- Full unit suite: **651 passing**.
- Browser walkthrough against the Auth0 dev tenant via SWA CLI:
  - Logged-in: list routes → skeleton → real data with **no Home flash**; `/analytics` → spinner → screen; dark first-paint confirmed.
  - Served-HTML matrix confirms each path emits the correct shell (`noindex`, no hydration), `/cura` + `/docs` still serve their real prerendered pages, `/` still hydrated.
  - Logged-out: private routes correctly redirect to Auth0 login.

## Known issue (pre-existing, not from this PR)

Logged-out deep-links to a **public** print (`/prints/:id`) redirect to Home because auth-required settings resolvers on that route cancel the navigation. Verified present on `main`/production and untracked to this diff. Filed as #66.