### PR TITLE
fix: render logged-out public print view instead of redirecting home (#66)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,13 +70,10 @@ These commands are optimized for minimal token usage while preserving actionable
 
 ### Public / Anonymous Routes (don't break these)
 
-Some routes render for logged-out visitors (no `AuthGuard`) so public content is deep-linkable and shareable — e.g. `/prints/:id`, public user profiles, public materials. A logged-out request to an **auth-required** endpoint rejects with Auth0's `missing_refresh_token` (the interceptor only retries anonymously when the request carries the `allow-anonymous-request` header). This is easy to break because it works fine while you're logged in.
+Routes without `AuthGuard` (e.g. `/prints/:id`, public profiles/materials) must render for logged-out visitors. A **rejected resolver cancels navigation and bounces to `/`** (#66) — and this only shows up logged-out, so it's easy to miss.
 
-When adding to a public route:
-
-- **Resolvers must tolerate a logged-out user.** A resolver whose observable/promise **rejects** cancels the Angular navigation, bouncing the visitor to `/` (see #66). Any data a public-route resolver fetches must either come from an endpoint the client calls with `allow-anonymous-request` **and** the API marks `[AllowAnonymous]`, or the service must degrade to a sensible default/`null` for anonymous users instead of throwing. Prefer fixing this in the **service** (one place) over each resolver — the same service is often also called from `ngOnInit`, where a rejection won't cancel navigation but will surface an unhandled promise rejection.
-- **Don't add auth-required sidecar data to a public route** (user settings, subscription, etc.) unless the service already returns anonymous-safe defaults. `UserSettingService.getCurrentUsersSettingByType` returns `null` for anonymous visitors by design — keep new settings consumers null-tolerant (`?.value`, `?? default`).
-- **Test logged-out locally without Auth0.** Under `devAuthBypass`, append `?devUserId=anonymous` to any URL to simulate a logged-out visitor (persisted per-tab in `sessionStorage`; `isDevAnonymous` in `src/app/core/utils/dev-anonymous.ts`). The Cypress spec `cypress/e2e/prints/public-print-anonymous.cy.ts` is the regression pattern — a public-route E2E that does **not** call `cy.login()`.
+- On a public route, resolvers/services must degrade to a default/`null` for anonymous users, never throw. Fix in the **service** (also protects `ngOnInit` callers), and keep settings consumers null-tolerant (`?.value`, `?? default`). Auth-required endpoints reject with `missing_refresh_token` unless the request sets `allow-anonymous-request` **and** the API marks them `[AllowAnonymous]`.
+- Test logged-out without Auth0: append `?devUserId=anonymous` (dev only; `isDevAnonymous` util). Regression pattern: `cypress/e2e/prints/public-print-anonymous.cy.ts` (a public-route E2E with no `cy.login()`).
 
 ### Environment Configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,16 @@ These commands are optimized for minimal token usage while preserving actionable
 - `allow-anonymous-request` header bypasses authentication for public endpoints
 - `AuthGuard` protects authenticated routes
 
+### Public / Anonymous Routes (don't break these)
+
+Some routes render for logged-out visitors (no `AuthGuard`) so public content is deep-linkable and shareable — e.g. `/prints/:id`, public user profiles, public materials. A logged-out request to an **auth-required** endpoint rejects with Auth0's `missing_refresh_token` (the interceptor only retries anonymously when the request carries the `allow-anonymous-request` header). This is easy to break because it works fine while you're logged in.
+
+When adding to a public route:
+
+- **Resolvers must tolerate a logged-out user.** A resolver whose observable/promise **rejects** cancels the Angular navigation, bouncing the visitor to `/` (see #66). Any data a public-route resolver fetches must either come from an endpoint the client calls with `allow-anonymous-request` **and** the API marks `[AllowAnonymous]`, or the service must degrade to a sensible default/`null` for anonymous users instead of throwing. Prefer fixing this in the **service** (one place) over each resolver — the same service is often also called from `ngOnInit`, where a rejection won't cancel navigation but will surface an unhandled promise rejection.
+- **Don't add auth-required sidecar data to a public route** (user settings, subscription, etc.) unless the service already returns anonymous-safe defaults. `UserSettingService.getCurrentUsersSettingByType` returns `null` for anonymous visitors by design — keep new settings consumers null-tolerant (`?.value`, `?? default`).
+- **Test logged-out locally without Auth0.** Under `devAuthBypass`, append `?devUserId=anonymous` to any URL to simulate a logged-out visitor (persisted per-tab in `sessionStorage`; `isDevAnonymous` in `src/app/core/utils/dev-anonymous.ts`). The Cypress spec `cypress/e2e/prints/public-print-anonymous.cy.ts` is the regression pattern — a public-route E2E that does **not** call `cy.login()`.
+
 ### Environment Configuration
 
 - `src/environments/environment.ts` - Development (localhost:5001 API)

--- a/cypress/e2e/prints/public-print-anonymous.cy.ts
+++ b/cypress/e2e/prints/public-print-anonymous.cy.ts
@@ -1,0 +1,51 @@
+// Regression for #66: a logged-out visitor deep-linking to a public print at
+// /prints/:id must see it render, not get bounced to /.
+//
+// Uses the dev-only anonymous simulation (?devUserId=anonymous). Requires the
+// dev server + dev API running with at least one public print seeded.
+// Deliberately does NOT call cy.login().
+
+const API = 'https://localhost:5001';
+const ANON_HEADERS = { 'allow-anonymous-request': 'true' };
+
+describe('Anonymous public print view', () => {
+  it('renders a public print for a logged-out visitor without redirecting home', () => {
+    cy.clearLocalStorage();
+    cy.window().then((win) => win.sessionStorage.clear());
+
+    // Discover a public print id anonymously. GET /api/Prints/public is the
+    // AllowAnonymous endpoint the sitemap uses; it returns an array of ids.
+    cy.request({
+      method: 'GET',
+      url: `${API}/api/Prints/public`,
+      headers: ANON_HEADERS,
+    }).then((idsResp) => {
+      expect(idsResp.status).to.eq(200);
+      expect(
+        idsResp.body,
+        'at least one public print exists'
+      ).to.have.length.greaterThan(0);
+
+      const id = idsResp.body[0];
+
+      // Fetch the print detail (also AllowAnonymous) to know its title.
+      cy.request({
+        method: 'GET',
+        url: `${API}/api/Prints/${id}`,
+        headers: ANON_HEADERS,
+      }).then((printResp) => {
+        expect(printResp.status).to.eq(200);
+        const title = printResp.body.title;
+
+        // Visit the deep link as an anonymous (logged-out) visitor.
+        cy.visit(`/prints/${id}?devUserId=anonymous`);
+
+        // 1) No bounce to home.
+        cy.location('pathname').should('eq', `/prints/${id}`);
+
+        // 2) Print content rendered (title appears on the page).
+        cy.contains(title).should('be.visible');
+      });
+    });
+  });
+});

--- a/src/app/core/http/auth-interceptor.service.spec.ts
+++ b/src/app/core/http/auth-interceptor.service.spec.ts
@@ -24,6 +24,7 @@ describe('AuthInterceptorService', () => {
 
   afterEach(() => {
     (environment as any).devAuthBypass = false;
+    sessionStorage.removeItem('devAnonymous');
   });
 
   it('should be created', () => {
@@ -94,5 +95,60 @@ describe('AuthInterceptorService', () => {
     };
 
     interceptor.intercept(req, next).subscribe();
+  });
+
+  it('dispatches allow-anonymous requests without a dev user when devUserId=anonymous', (done) => {
+    (environment as any).devAuthBypass = true;
+    const interceptor = TestBed.inject(AuthInterceptorService);
+    spyOn(interceptor as any, 'getLocationSearch').and.returnValue(
+      '?devUserId=anonymous'
+    );
+
+    const req = new HttpRequest(
+      'GET',
+      'https://localhost:5001/api/public',
+      null,
+      { headers: new HttpHeaders({ 'allow-anonymous-request': 'true' }) }
+    );
+    const next: HttpHandler = {
+      handle: (r: HttpRequest<any>) => {
+        expect(r.headers.get('allow-anonymous-request')).toBeNull();
+        expect(r.headers.get('X-Dev-User-Id')).toBeNull();
+        expect(r.headers.get('Authorization')).toBeNull();
+        done();
+        return of(new HttpResponse({ status: 200 })) as any;
+      },
+    };
+
+    interceptor.intercept(req, next).subscribe();
+  });
+
+  it('errors before dispatch for auth-required requests when devUserId=anonymous', (done) => {
+    (environment as any).devAuthBypass = true;
+    const interceptor = TestBed.inject(AuthInterceptorService);
+    spyOn(interceptor as any, 'getLocationSearch').and.returnValue(
+      '?devUserId=anonymous'
+    );
+
+    let handled = false;
+    const req = new HttpRequest(
+      'GET',
+      'https://localhost:5001/api/Users/me/user-settings'
+    );
+    const next: HttpHandler = {
+      handle: () => {
+        handled = true;
+        return of(new HttpResponse({ status: 200 })) as any;
+      },
+    };
+
+    interceptor.intercept(req, next).subscribe({
+      next: () => fail('should not emit a response'),
+      error: (err) => {
+        expect(handled).toBeFalse();
+        expect(err.error).toBe('missing_refresh_token');
+        done();
+      },
+    });
   });
 });

--- a/src/app/core/http/auth-interceptor.service.ts
+++ b/src/app/core/http/auth-interceptor.service.ts
@@ -9,6 +9,7 @@ import { Observable, throwError } from 'rxjs';
 import { catchError, mergeMap } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 import { AuthService } from '../services/auth.service';
+import { isDevAnonymous } from '../utils/dev-anonymous';
 
 @Injectable({
   providedIn: 'root',
@@ -25,7 +26,23 @@ export class AuthInterceptorService implements HttpInterceptor {
     next: HttpHandler
   ): Observable<HttpEvent<any>> {
     if (environment.devAuthBypass) {
-      const params = new URLSearchParams(this.getLocationSearch());
+      const search = this.getLocationSearch();
+
+      if (isDevAnonymous(search)) {
+        // Simulate an unauthenticated visitor (dev-only, gated on devAuthBypass).
+        if (req.headers.get('allow-anonymous-request')) {
+          const anonReq = req.clone({
+            headers: req.headers.delete('allow-anonymous-request'),
+          });
+          return next.handle(anonReq);
+        }
+        // Mirror the real interceptor's pre-dispatch rethrow of the Auth0 token
+        // error (a non-HttpErrorResponse) so UserSettingService's anonymous
+        // fallback is exercised faithfully.
+        return throwError(() => ({ error: 'missing_refresh_token' }));
+      }
+
+      const params = new URLSearchParams(search);
       const userId = params.get('devUserId') ?? '1';
       const devReq = req.clone({
         headers: req.headers

--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -65,5 +65,20 @@ describe('AuthService', () => {
           done();
         });
     });
+
+    it('sets loggedIn=false and emits no profile when the dev anonymous flag is set', () => {
+      sessionStorage.setItem('devAnonymous', 'true');
+      const service = TestBed.inject(AuthService);
+
+      let latestProfile: unknown = 'unset';
+      service.userProfile$.subscribe((p) => (latestProfile = p));
+
+      service.localAuthSetup();
+
+      expect(service.loggedIn).toBeFalse();
+      expect(latestProfile).toBeNull(); // BehaviorSubject initial null, never overwritten
+
+      sessionStorage.removeItem('devAnonymous');
+    });
   });
 });

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -19,6 +19,7 @@ import { NotificationService } from './notification.service';
 import { SubscriptionService } from './subscription.service';
 import { ProfileViewStatus, UserDetailDto, UserService } from './user.service';
 import { UserSettingService } from './user-setting.service';
+import { isDevAnonymous } from '../utils/dev-anonymous';
 const cordovaCallbackUri =
   'com.hoffmanengineering.printlog://cordova/com.hoffmanengineering.printlog/callback';
 
@@ -207,6 +208,11 @@ export class AuthService {
     }
 
     if (environment.devAuthBypass) {
+      if (isDevAnonymous(window.location.search)) {
+        // Dev-only: render the logged-out state for E2E / manual testing.
+        this.loggedIn = false;
+        return;
+      }
       this.loggedIn = true;
       this.userProfileSubject$.next(this.devMockProfile);
       return;

--- a/src/app/core/services/user-setting.service.spec.ts
+++ b/src/app/core/services/user-setting.service.spec.ts
@@ -114,6 +114,17 @@ describe('UserSettingService', () => {
       await expectAsync(promise).toBeRejected();
     });
 
+    it('rejects (does not swallow) a response-mapping/programming error', async () => {
+      const promise = service.getCurrentUsersSettingByType(
+        UserSettingType.Currency_Symbol
+      );
+      // A null body makes `for (const dto of dtos)` throw inside the map — this
+      // is not the anonymous auth error and must not be swallowed as empty.
+      httpTesting.expectOne(apiUrl).flush(null);
+
+      await expectAsync(promise).toBeRejected();
+    });
+
     it('does not cache an HttpErrorResponse failure (next call refetches)', async () => {
       const first = service.getCurrentUsersSettingByType(
         UserSettingType.Currency_Symbol

--- a/src/app/core/services/user-setting.service.spec.ts
+++ b/src/app/core/services/user-setting.service.spec.ts
@@ -4,16 +4,20 @@ import {
   provideHttpClientTesting,
 } from '@angular/common/http/testing';
 import {
+  HTTP_INTERCEPTORS,
+  HttpClient,
   provideHttpClient,
   withInterceptorsFromDi,
 } from '@angular/common/http';
-import { lastValueFrom } from 'rxjs';
+import { lastValueFrom, throwError } from 'rxjs';
 import {
   UserSettingService,
   UserSettingType,
   UserSettingDto,
 } from './user-setting.service';
 import { environment } from 'src/environments/environment';
+import { AuthService } from './auth.service';
+import { AuthInterceptorService } from '../http/auth-interceptor.service';
 
 const apiUrl = `${environment.printLogApiUrl}/api/Users/me/user-settings`;
 
@@ -97,6 +101,33 @@ describe('UserSettingService', () => {
       // Second call — no HTTP request should be made
       await service.getCurrentUsersSettingByType(UserSettingType.Currency_Name);
       httpTesting.expectNone(apiUrl);
+    });
+
+    it('rejects (does not swallow) when the fetch fails with an HttpErrorResponse', async () => {
+      const promise = service.getCurrentUsersSettingByType(
+        UserSettingType.Currency_Symbol
+      );
+      httpTesting
+        .expectOne(apiUrl)
+        .flush('boom', { status: 500, statusText: 'Server Error' });
+
+      await expectAsync(promise).toBeRejected();
+    });
+
+    it('does not cache an HttpErrorResponse failure (next call refetches)', async () => {
+      const first = service.getCurrentUsersSettingByType(
+        UserSettingType.Currency_Symbol
+      );
+      httpTesting
+        .expectOne(apiUrl)
+        .flush('boom', { status: 500, statusText: 'Server Error' });
+      await expectAsync(first).toBeRejected();
+
+      const second = service.getCurrentUsersSettingByType(
+        UserSettingType.Currency_Symbol
+      );
+      httpTesting.expectOne(apiUrl).flush([]); // a second request IS made
+      await second;
     });
 
     it('deduplicates concurrent cache-miss requests into a single HTTP call', async () => {
@@ -249,5 +280,77 @@ describe('UserSettingService', () => {
       expect(resultA!.value).toBe('EUR');
       expect(resultB!.value).toBe('$');
     });
+  });
+});
+
+describe('UserSettingService — anonymous visitor (mocked HttpClient)', () => {
+  let service: UserSettingService;
+  let mockHttp: jasmine.SpyObj<HttpClient>;
+
+  beforeEach(() => {
+    mockHttp = jasmine.createSpyObj<HttpClient>('HttpClient', ['get']);
+    mockHttp.get.and.returnValue(
+      throwError(() => ({ error: 'missing_refresh_token' }))
+    );
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: HttpClient, useValue: mockHttp }],
+    });
+    service = TestBed.inject(UserSettingService);
+  });
+
+  it('resolves to null when the request fails before dispatch', async () => {
+    const result = await service.getCurrentUsersSettingByType(
+      UserSettingType.Currency_Symbol
+    );
+    expect(result).toBeNull();
+  });
+
+  it('does not cache the anonymous fallback (next call refetches)', async () => {
+    await service.getCurrentUsersSettingByType(UserSettingType.Currency_Symbol);
+    await service.getCurrentUsersSettingByType(UserSettingType.Currency_Symbol);
+    expect(mockHttp.get).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('UserSettingService — anonymous through the real interceptor', () => {
+  let service: UserSettingService;
+  let httpTesting: HttpTestingController;
+
+  beforeEach(() => {
+    (environment as any).devAuthBypass = false;
+    const mockAuth = jasmine.createSpyObj<AuthService>('AuthService', [
+      'getTokenSilently$',
+    ]);
+    mockAuth.getTokenSilently$.and.returnValue(
+      throwError(() => ({ error: 'missing_refresh_token' }))
+    );
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+        {
+          provide: HTTP_INTERCEPTORS,
+          useClass: AuthInterceptorService,
+          multi: true,
+        },
+        { provide: AuthService, useValue: mockAuth },
+      ],
+    });
+    service = TestBed.inject(UserSettingService);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  it('returns null and never dispatches the settings request', async () => {
+    const result = await service.getCurrentUsersSettingByType(
+      UserSettingType.Currency_Symbol
+    );
+    expect(result).toBeNull();
+    httpTesting.expectNone(apiUrl);
   });
 });

--- a/src/app/core/services/user-setting.service.ts
+++ b/src/app/core/services/user-setting.service.ts
@@ -1,7 +1,7 @@
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { lastValueFrom } from 'rxjs';
-import { map, tap } from 'rxjs/operators';
+import { lastValueFrom, of, throwError } from 'rxjs';
+import { catchError, map, tap } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 
 export enum UserSettingType {
@@ -102,8 +102,24 @@ export class UserSettingService {
         return result;
       }),
       tap((settings) => {
+        // Runs only on a successful response — caches real settings (incl. []).
         this.settingsMap = settings;
         this.loaded = true;
+      }),
+      catchError((err) => {
+        if (err instanceof HttpErrorResponse) {
+          // The request reached the server (or failed at the network layer with
+          // status 0). This only happens for a logged-in user, since the
+          // interceptor never dispatches this endpoint anonymously. Surface it —
+          // preserves the current navigation-cancelling behavior for real errors.
+          return throwError(() => err);
+        }
+        // The request was never dispatched: the interceptor could not obtain a
+        // token for an anonymous visitor and rethrew the Auth0 token error.
+        // Treat as "no settings". Deliberately NOT cached (this branch bypasses
+        // the tap above, so `loaded` stays false) so a later authenticated call
+        // refetches — this is what makes an in-process (Cordova) login recover.
+        return of(new Map<UserSettingType, UserSetting>());
       })
     );
   }

--- a/src/app/core/services/user-setting.service.ts
+++ b/src/app/core/services/user-setting.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
 import { lastValueFrom, of, throwError } from 'rxjs';
 import { catchError, map, tap } from 'rxjs/operators';
@@ -107,19 +107,18 @@ export class UserSettingService {
         this.loaded = true;
       }),
       catchError((err) => {
-        if (err instanceof HttpErrorResponse) {
-          // The request reached the server (or failed at the network layer with
-          // status 0). This only happens for a logged-in user, since the
-          // interceptor never dispatches this endpoint anonymously. Surface it —
-          // preserves the current navigation-cancelling behavior for real errors.
-          return throwError(() => err);
+        // For a logged-out visitor the auth interceptor rethrows Auth0's
+        // missing-refresh-token error before dispatching the request. Treat
+        // *only* that as "no settings" so a public view still renders.
+        // Deliberately NOT cached (this branch bypasses the tap above, so
+        // `loaded` stays false) so a later authenticated call refetches — this
+        // is what makes an in-process (Cordova) login recover.
+        if (err?.error === 'missing_refresh_token') {
+          return of(new Map<UserSettingType, UserSetting>());
         }
-        // The request was never dispatched: the interceptor could not obtain a
-        // token for an anonymous visitor and rethrew the Auth0 token error.
-        // Treat as "no settings". Deliberately NOT cached (this branch bypasses
-        // the tap above, so `loaded` stays false) so a later authenticated call
-        // refetches — this is what makes an in-process (Cordova) login recover.
-        return of(new Map<UserSettingType, UserSetting>());
+        // Surface everything else: server errors (HttpErrorResponse), response-
+        // mapping/programming errors, and unexpected auth failures.
+        return throwError(() => err);
       })
     );
   }

--- a/src/app/core/utils/dev-anonymous.spec.ts
+++ b/src/app/core/utils/dev-anonymous.spec.ts
@@ -1,0 +1,25 @@
+import { isDevAnonymous } from './dev-anonymous';
+
+describe('isDevAnonymous', () => {
+  afterEach(() => {
+    sessionStorage.removeItem('devAnonymous');
+  });
+
+  it('returns false with no param and no stored flag', () => {
+    expect(isDevAnonymous('')).toBeFalse();
+  });
+
+  it('returns false for a normal devUserId', () => {
+    expect(isDevAnonymous('?devUserId=2')).toBeFalse();
+  });
+
+  it('returns true and persists the flag when devUserId=anonymous is present', () => {
+    expect(isDevAnonymous('?devUserId=anonymous')).toBeTrue();
+    expect(sessionStorage.getItem('devAnonymous')).toBe('true');
+  });
+
+  it('returns true from the stored flag after the param drops', () => {
+    isDevAnonymous('?devUserId=anonymous');
+    expect(isDevAnonymous('')).toBeTrue();
+  });
+});

--- a/src/app/core/utils/dev-anonymous.ts
+++ b/src/app/core/utils/dev-anonymous.ts
@@ -1,0 +1,27 @@
+const DEV_ANONYMOUS_KEY = 'devAnonymous';
+
+/**
+ * Dev-only: reports whether the current session should be treated as an
+ * unauthenticated visitor. Activated by visiting any URL with
+ * `?devUserId=anonymous`; the decision is persisted to sessionStorage for the
+ * tab so it survives in-app navigations that drop the query param.
+ *
+ * Only consulted when `environment.devAuthBypass` is true, so it never affects
+ * production, auth0-dev, or unittest builds.
+ */
+export function isDevAnonymous(search: string): boolean {
+  const params = new URLSearchParams(search);
+  if (params.get('devUserId') === 'anonymous') {
+    try {
+      sessionStorage.setItem(DEV_ANONYMOUS_KEY, 'true');
+    } catch {
+      // sessionStorage unavailable (e.g. prerender) — fall through.
+    }
+    return true;
+  }
+  try {
+    return sessionStorage.getItem(DEV_ANONYMOUS_KEY) === 'true';
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Fixes #66. Viewing a **public** print at `/prints/:id` while **logged out** redirected to `/` instead of rendering the print.

**Root cause:** the public `:id` view route resolves three user-settings sidecars (`CurrencySymbolResolverService`, `DefaultElectricityKwhRateSettingResolverService`, `DefaultElectricityWattageSettingResolverService`). All call `UserSettingService.getCurrentUsersSettingByType`, which for an anonymous visitor rejected (the auth interceptor rethrows Auth0's `missing_refresh_token` before dispatch) → Angular cancelled navigation → bounce to `/`. The same service is also called directly in `ViewPrintDetailComponent.ngOnInit`, throwing an unhandled rejection.

## The fix

`UserSettingService.fetchSettings()` now catches **only** the `missing_refresh_token` auth error and resolves to empty settings (returning `null` per type — the state the UI already handles via `?.value` / `?? '$'`). The fallback is **not cached** (`loaded` stays `false`), so a later authenticated call re-fetches — which is what makes an in-process (Cordova) login recover. Every other error — server/`HttpErrorResponse`, response-mapping/programming errors, unexpected auth failures — still propagates.

This single change fixes all three resolvers **and** the `ngOnInit` call. No production changes to resolvers, routes, the interceptor, `AuthService`, or the component.

## Dev-only anonymous simulation (E2E scaffolding)

To get an Auth0-free regression test, the `devAuthBypass` flow gains a `?devUserId=anonymous` sentinel (persisted to `sessionStorage` for the tab) that simulates a logged-out visitor: the interceptor dispatches `allow-anonymous-request` calls without a dev user and rethrows `missing_refresh_token` for auth-required calls, and `AuthService` renders the logged-out state. Gated entirely on `environment.devAuthBypass` (false in prod/auth0-dev/unittest) — never ships to production.

## Testing

- Unit tests in `user-setting.service.spec.ts`: anonymous fallback returns `null` and is uncached; `HttpErrorResponse` and response-mapping errors still reject; anonymous request routed through the real interceptor is never dispatched (`expectNone`).
- Unit tests for `isDevAnonymous`, the interceptor anonymous branch, and the `AuthService` logged-out state.
- New Cypress E2E (`public-print-anonymous.cy.ts`) — no `cy.login()`; discovers a public print via `GET /api/Prints/public`, visits it logged-out, asserts the URL stays `/prints/:id` and the title renders. Passes end-to-end against the dev server + API.

Full unit suite (664) green, lint clean. No API changes required (verified `DevAuthenticationHandler` returns `NoResult()` for header-less requests and the public print endpoints are `[AllowAnonymous]`).