### PR TITLE
fix(uploads): enforce per-print attachment limit under concurrent selection

### DIFF
--- a/src/app/shared/file-attachment-section/file-attachment-section.component.spec.ts
+++ b/src/app/shared/file-attachment-section/file-attachment-section.component.spec.ts
@@ -431,4 +431,49 @@ describe('FileAttachmentSectionComponent (upload limits)', () => {
     expect(mockPrintFileService.getUploadUrl).not.toHaveBeenCalled();
     expect(component.activeFileCount()).toBe(0);
   });
+
+  it('does not admit uploads until the initial load resolves', () => {
+    const getFiles$ = new Subject<FileAttachmentItem[]>();
+    mockPrintFileService.getFiles.and.returnValue(getFiles$);
+
+    // Re-create so ngOnInit subscribes to the pending getFiles$.
+    fixture.destroy();
+    fixture = TestBed.createComponent(FileAttachmentSectionComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('printId', 1);
+    fixture.componentRef.setInput('editable', true);
+    fixture.detectChanges();
+
+    // Load still pending -> a selection starts NO upload.
+    component.onFilesSelected([validFile('early.gcode')]);
+    expect(mockPrintFileService.getUploadUrl).not.toHaveBeenCalled();
+
+    // Load resolves with one server file (half of maxFiles=2).
+    getFiles$.next([uploaded(7, 'saved.gcode')]);
+    getFiles$.complete();
+
+    // Now uploads are allowed and capped against the real baseline.
+    component.onFilesSelected([validFile('a.gcode'), validFile('b.gcode')]);
+    expect(component.activeFileCount()).toBeLessThanOrEqual(
+      component.maxFiles()
+    );
+    expect(mockPrintFileService.getUploadUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows uploads if the initial load fails', () => {
+    const getFiles$ = new Subject<FileAttachmentItem[]>();
+    mockPrintFileService.getFiles.and.returnValue(getFiles$);
+
+    fixture.destroy();
+    fixture = TestBed.createComponent(FileAttachmentSectionComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('printId', 1);
+    fixture.componentRef.setInput('editable', true);
+    fixture.detectChanges();
+
+    getFiles$.error(new Error('load failed'));
+
+    component.onFilesSelected([validFile('a.gcode')]);
+    expect(mockPrintFileService.getUploadUrl).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/app/shared/file-attachment-section/file-attachment-section.component.spec.ts
+++ b/src/app/shared/file-attachment-section/file-attachment-section.component.spec.ts
@@ -11,7 +11,7 @@ import { SubscriptionService } from 'src/app/core/services/subscription.service'
 import { PrintFileService } from 'src/app/core/services/print-file.service';
 import { ToastrService } from 'ngx-toastr';
 import { signal } from '@angular/core';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { LoggingService } from 'src/app/core/services/logging.service';
 import { FileAttachmentItem } from '../file-attachment-list/file-attachment-list.component';
 
@@ -247,5 +247,188 @@ describe('FileAttachmentSectionComponent (free user)', () => {
     fixture.detectChanges();
     const el = fixture.nativeElement as HTMLElement;
     expect(el.textContent).toContain('Pro');
+  });
+});
+
+describe('FileAttachmentSectionComponent (upload limits)', () => {
+  let component: FileAttachmentSectionComponent;
+  let fixture: ComponentFixture<FileAttachmentSectionComponent>;
+
+  const maxFilesPerPrint = signal(2);
+
+  const mockSubscriptionService = jasmine.createSpyObj(
+    'SubscriptionService',
+    ['incrementUsedStorage', 'decrementUsedStorage'],
+    {
+      isPro: signal(true),
+      maxFilesPerPrint,
+      maxFileStorageBytes: signal(53687091200),
+      usedFileStorageBytes: signal(0),
+    }
+  );
+
+  const mockPrintFileService = jasmine.createSpyObj('PrintFileService', [
+    'getFiles',
+    'getUploadUrl',
+    'uploadToSasUrl',
+    'confirmUpload',
+    'deleteFile',
+    'getDownloadUrl',
+    'validateFile',
+  ]);
+
+  const mockToastrService = jasmine.createSpyObj<ToastrService>(
+    'ToastrService',
+    ['success', 'error', 'warning', 'info']
+  );
+
+  const validFile = (name: string) =>
+    new File(['x'], name, { type: 'application/octet-stream' });
+
+  const uploaded = (id: number, name: string): FileAttachmentItem => ({
+    id,
+    originalFileName: name,
+    sizeBytes: 10,
+    contentType: 'application/octet-stream',
+    status: 'uploaded',
+  });
+
+  beforeEach(async () => {
+    maxFilesPerPrint.set(2);
+    mockPrintFileService.getFiles.calls.reset();
+    mockPrintFileService.getUploadUrl.calls.reset();
+    mockToastrService.warning.calls.reset();
+    mockPrintFileService.getFiles.and.returnValue(of([]));
+    mockPrintFileService.validateFile.and.returnValue({ valid: true });
+    // Never completes: uploads stay in 'uploading' state so they hold a slot.
+    mockPrintFileService.getUploadUrl.and.returnValue(new Subject());
+
+    await TestBed.configureTestingModule({
+      imports: [
+        FileAttachmentSectionComponent,
+        NoopAnimationsModule,
+        RouterTestingModule,
+      ],
+      providers: [
+        { provide: SubscriptionService, useValue: mockSubscriptionService },
+        { provide: PrintFileService, useValue: mockPrintFileService },
+        { provide: ToastrService, useValue: mockToastrService },
+        {
+          provide: LoggingService,
+          useValue: jasmine.createSpyObj('LoggingService', [
+            'logEvent',
+            'logException',
+          ]),
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FileAttachmentSectionComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('printId', 1);
+    fixture.componentRef.setInput('editable', true);
+    fixture.detectChanges();
+  });
+
+  it('caps a single batch selection at maxFiles and warns once', () => {
+    component.onFilesSelected([
+      validFile('a.gcode'),
+      validFile('b.gcode'),
+      validFile('c.gcode'),
+      validFile('d.gcode'),
+    ]);
+
+    expect(mockPrintFileService.getUploadUrl).toHaveBeenCalledTimes(2);
+    expect(mockToastrService.warning).toHaveBeenCalledTimes(1);
+  });
+
+  it('caps two separate selections in aggregate', () => {
+    component.onFilesSelected([validFile('a.gcode')]);
+    component.onFilesSelected([validFile('b.gcode'), validFile('c.gcode')]);
+
+    expect(mockPrintFileService.getUploadUrl).toHaveBeenCalledTimes(2);
+  });
+
+  it('accounts for pre-existing uploaded files at the boundary', () => {
+    component.files.set([uploaded(1, 'existing.gcode')]);
+
+    component.onFilesSelected([validFile('a.gcode'), validFile('b.gcode')]);
+
+    // maxFiles=2, one slot already used -> only one new upload starts.
+    expect(mockPrintFileService.getUploadUrl).toHaveBeenCalledTimes(1);
+  });
+
+  it('frees a slot only when an upload errors, not while it is in progress', () => {
+    const u1 = new Subject();
+    const u2 = new Subject();
+    const u3 = new Subject();
+    mockPrintFileService.getUploadUrl.and.returnValues(u1, u2, u3);
+
+    // Fill both slots with in-progress uploads.
+    component.onFilesSelected([validFile('a.gcode'), validFile('b.gcode')]);
+    expect(mockPrintFileService.getUploadUrl).toHaveBeenCalledTimes(2);
+
+    // A third is rejected while both slots are occupied by 'uploading' items.
+    // (Red under the old completed-only count, which would admit it.)
+    component.onFilesSelected([validFile('c.gcode')]);
+    expect(mockPrintFileService.getUploadUrl).toHaveBeenCalledTimes(2);
+
+    // First upload fails -> its slot frees.
+    u1.error(new Error('boom'));
+    expect(component.files().filter((f) => f.status === 'error').length).toBe(
+      1
+    );
+
+    // Now a new selection is admitted into the freed slot.
+    component.onFilesSelected([validFile('d.gcode')]);
+    expect(mockPrintFileService.getUploadUrl).toHaveBeenCalledTimes(3);
+  });
+
+  it('counts pending-status files toward the slot count', () => {
+    component.files.set([
+      {
+        originalFileName: 'p1.gcode',
+        sizeBytes: 1,
+        contentType: 'application/octet-stream',
+        status: 'pending',
+      },
+      {
+        originalFileName: 'p2.gcode',
+        sizeBytes: 1,
+        contentType: 'application/octet-stream',
+        status: 'pending',
+      },
+    ]);
+
+    expect(component.activeFileCount()).toBe(2);
+    expect(component.canAddMore()).toBe(false);
+  });
+
+  it('keeps uploadedFileCount to completed uploads only', () => {
+    component.files.set([
+      uploaded(1, 'done.gcode'),
+      {
+        originalFileName: 'wip.gcode',
+        sizeBytes: 1,
+        contentType: 'application/octet-stream',
+        status: 'uploading',
+        trackingId: 't',
+      },
+    ]);
+
+    expect(component.uploadedFileCount()).toBe(1);
+    expect(component.activeFileCount()).toBe(2);
+  });
+
+  it('rejects an invalid file without consuming a slot', () => {
+    mockPrintFileService.validateFile.and.returnValue({
+      valid: false,
+      error: 'nope',
+    });
+
+    component.onFilesSelected([validFile('bad.xyz')]);
+
+    expect(mockPrintFileService.getUploadUrl).not.toHaveBeenCalled();
+    expect(component.activeFileCount()).toBe(0);
   });
 });

--- a/src/app/shared/file-attachment-section/file-attachment-section.component.spec.ts
+++ b/src/app/shared/file-attachment-section/file-attachment-section.component.spec.ts
@@ -298,6 +298,7 @@ describe('FileAttachmentSectionComponent (upload limits)', () => {
     mockPrintFileService.getFiles.calls.reset();
     mockPrintFileService.getUploadUrl.calls.reset();
     mockToastrService.warning.calls.reset();
+    mockToastrService.error.calls.reset();
     mockPrintFileService.getFiles.and.returnValue(of([]));
     mockPrintFileService.validateFile.and.returnValue({ valid: true });
     // Never completes: uploads stay in 'uploading' state so they hold a slot.
@@ -362,7 +363,8 @@ describe('FileAttachmentSectionComponent (upload limits)', () => {
     const u1 = new Subject();
     const u2 = new Subject();
     const u3 = new Subject();
-    mockPrintFileService.getUploadUrl.and.returnValues(u1, u2, u3);
+    const u4 = new Subject();
+    mockPrintFileService.getUploadUrl.and.returnValues(u1, u2, u3, u4);
 
     // Fill both slots with in-progress uploads.
     component.onFilesSelected([validFile('a.gcode'), validFile('b.gcode')]);
@@ -460,7 +462,7 @@ describe('FileAttachmentSectionComponent (upload limits)', () => {
     expect(mockPrintFileService.getUploadUrl).toHaveBeenCalledTimes(1);
   });
 
-  it('allows uploads if the initial load fails', () => {
+  it('keeps uploads blocked and surfaces an error if the initial load fails', () => {
     const getFiles$ = new Subject<FileAttachmentItem[]>();
     mockPrintFileService.getFiles.and.returnValue(getFiles$);
 
@@ -473,7 +475,10 @@ describe('FileAttachmentSectionComponent (upload limits)', () => {
 
     getFiles$.error(new Error('load failed'));
 
+    // Fail closed: no known baseline -> uploads stay blocked, error surfaced.
     component.onFilesSelected([validFile('a.gcode')]);
-    expect(mockPrintFileService.getUploadUrl).toHaveBeenCalledTimes(1);
+    expect(mockPrintFileService.getUploadUrl).not.toHaveBeenCalled();
+    expect(component.canAddMore()).toBe(false);
+    expect(mockToastrService.error).toHaveBeenCalled();
   });
 });

--- a/src/app/shared/file-attachment-section/file-attachment-section.component.ts
+++ b/src/app/shared/file-attachment-section/file-attachment-section.component.ts
@@ -120,7 +120,17 @@ export class FileAttachmentSectionComponent implements OnInit {
           );
           this.loaded.set(true);
         },
-        error: () => this.loaded.set(true),
+        error: (err) => {
+          // Fail closed: without a known server baseline we cannot safely
+          // enforce the per-print limit, so leave `loaded` false (uploads
+          // stay blocked) and surface the failure instead of silently
+          // showing an empty list.
+          this.toastr.error(
+            'Could not load attachments. Refresh to try again.',
+            'Load Failed'
+          );
+          this.loggingService.logException(err);
+        },
       });
   }
 

--- a/src/app/shared/file-attachment-section/file-attachment-section.component.ts
+++ b/src/app/shared/file-attachment-section/file-attachment-section.component.ts
@@ -60,6 +60,10 @@ export class FileAttachmentSectionComponent implements OnInit {
 
   readonly files = signal<TrackedFileItem[]>([]);
 
+  // True once the initial getFiles() load has resolved (or failed). Uploads are
+  // blocked until then so admissions are measured against the real baseline.
+  readonly loaded = signal(false);
+
   // Shown in the header ("N / max"): only fully-uploaded files.
   readonly uploadedFileCount = computed(
     () => this.files().filter((f) => f.status === 'uploaded').length
@@ -73,7 +77,7 @@ export class FileAttachmentSectionComponent implements OnInit {
   );
 
   readonly canAddMore = computed(
-    () => this.activeFileCount() < this.maxFiles()
+    () => this.loaded() && this.activeFileCount() < this.maxFiles()
   );
 
   readonly formattedQuotaUsage = computed(() => {
@@ -106,13 +110,17 @@ export class FileAttachmentSectionComponent implements OnInit {
     this.printFileService
       .getFiles(this.printId())
       .pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((files) => {
-        this.files.set(
-          files.map((f) => ({
-            ...f,
-            status: 'uploaded' as const,
-          }))
-        );
+      .subscribe({
+        next: (files) => {
+          this.files.set(
+            files.map((f) => ({
+              ...f,
+              status: 'uploaded' as const,
+            }))
+          );
+          this.loaded.set(true);
+        },
+        error: () => this.loaded.set(true),
       });
   }
 

--- a/src/app/shared/file-attachment-section/file-attachment-section.component.ts
+++ b/src/app/shared/file-attachment-section/file-attachment-section.component.ts
@@ -60,12 +60,20 @@ export class FileAttachmentSectionComponent implements OnInit {
 
   readonly files = signal<TrackedFileItem[]>([]);
 
+  // Shown in the header ("N / max"): only fully-uploaded files.
   readonly uploadedFileCount = computed(
     () => this.files().filter((f) => f.status === 'uploaded').length
   );
 
+  // Slot enforcement: any tracked file that is not in a terminal error state
+  // occupies a slot, so an in-progress upload reserves capacity and closes the
+  // batch-selection race. Errored uploads free their slot for a retry.
+  readonly activeFileCount = computed(
+    () => this.files().filter((f) => f.status !== 'error').length
+  );
+
   readonly canAddMore = computed(
-    () => this.uploadedFileCount() < this.maxFiles()
+    () => this.activeFileCount() < this.maxFiles()
   );
 
   readonly formattedQuotaUsage = computed(() => {


### PR DESCRIPTION
## Problem

The per-print attachment limit (`maxFilesPerPrint`, a Pro entitlement) could be bypassed by selecting/dropping several files at once. `onFilesSelected` checks `canAddMore()` per file in a synchronous loop, but the limit counted only files with `status === 'uploaded'`. Since uploads are async, every iteration saw the same completed count and admitted the file — over-admitting the whole batch.

A second, subtler window existed during the initial load: while `getFiles()` was in flight the list was empty, so uploads admitted then were measured against an empty baseline and could exceed the limit once the server files arrived.

## Fix

- **Slot-based counting.** New `activeFileCount` counts every tracked file not in `error` state (`uploaded` + `uploading` + `pending`), so an in-progress upload reserves a slot. `canAddMore` derives from it. Because each item is appended as `uploading` synchronously before the next loop iteration, the batch loop now admits at most `maxFiles`. The displayed `uploadedFileCount` ("N / max") is unchanged and still counts completed uploads only.
- **Load gate.** New `loaded` signal; `canAddMore` additionally requires `loaded()`. Uploads cannot begin until the initial `getFiles()` load resolves, so admissions are always measured against the real server baseline.
- **Fail closed on load error.** If `getFiles()` errors, uploads stay blocked, the exception is logged, and an error toast is shown (recovery is a page refresh). Enabling uploads without a known baseline would re-open the bypass.

## Scope

Client-side entitlement/UX guard only; the API remains the atomic authority for `maxFilesPerPrint`. Out of scope (noted, unchanged): delete-cancels-in-flight-upload (not reachable — delete is hidden while uploading), the storage-bytes quota, and the duplicate-filename `@for` track key.

## Tests

Added to `file-attachment-section.component.spec.ts` (controllable RxJS `Subject`s, no timers): batch cap + single warning, two separate selections capped in aggregate, pre-existing-uploaded boundary, error frees a slot (with a full-slots rejection first), `pending` counts toward slots, `uploadedFileCount` stays completed-only, invalid file consumes no slot, uploads gated until load resolves, and fail-closed on load error.

Full suite: 673 passing. Lint clean.