### PR TITLE
fix(print): stop leaking full print payload to telemetry on save error

### DIFF
--- a/src/app/print/edit-print-detail/edit-print-detail.component.ts
+++ b/src/app/print/edit-print-detail/edit-print-detail.component.ts
@@ -1631,7 +1631,22 @@ export class EditPrintDetailComponent
     newPrint: Omit<PrintDetail, 'comments'>
   ): void {
     this.saving = false;
-    this.loggingService.logTrace(`PrintErr: ${JSON.stringify(newPrint)}`);
+    // Log only an allowlisted, non-sensitive diagnostic summary. Never serialize
+    // the full print object: fields like notes, title, url and fileName can contain
+    // private user content and would otherwise leak into telemetry (#leak).
+    this.loggingService.logTrace('PrintErr: print save failed', {
+      operation: newPrint.id === null ? 'create' : 'update',
+      printId: newPrint.id,
+      printerId: newPrint.printerId,
+      status: newPrint.status,
+      viewStatus: newPrint.viewStatus,
+      filamentType: newPrint.filamentType,
+      filamentUsageCount: newPrint.filamentUsage?.length ?? 0,
+      imageCount: newPrint.images?.length ?? 0,
+      hasNotes: !!newPrint.notes,
+      hasUrl: !!newPrint.url,
+      hasFileName: !!newPrint.fileName,
+    });
     this.loggingService.logException(err);
   }
 


### PR DESCRIPTION
## Summary

Fixes a medium-severity sensitive-data exposure ([bughunt doc](docs/bughunt/medium-private-print-data-leaked-to-telemetry-on-save-error.md)).

`handleSaveError` in `edit-print-detail.component.ts` serialized the **entire** `newPrint` object via `JSON.stringify` and sent it to `logTrace`, which forwards to Azure Application Insights whenever telemetry is configured. That payload includes private user content — `notes`, `title`, `url`, `fileName`, filament/printer associations, cost data, visibility, and user identifiers — bypassing the print's visibility setting and creating a second copy of private content in telemetry on every failed save.

## Change

Replace the full object dump with an allowlisted, non-sensitive diagnostic summary passed as structured trace properties:

- `operation` (create/update), `printId`, `printerId`
- `status`, `viewStatus`, `filamentType`
- `filamentUsageCount`, `imageCount`
- `hasNotes` / `hasUrl` / `hasFileName` (presence booleans, not values)

This keeps enough signal to diagnose save failures without exporting private user data.

## Testing

- `npm run lint:brief` — clean