### PR TITLE
fix(filament): stop saving empty filament values as zero

### DIFF
--- a/src/app/filament/filament-detail/filament-detail.component.spec.ts
+++ b/src/app/filament/filament-detail/filament-detail.component.spec.ts
@@ -310,3 +310,168 @@ describe('FilamentDetailComponent - spool weight calculator', () => {
     expect(calcComponent.filamentAdjustments.length).toBe(before);
   });
 });
+
+describe('FilamentDetailComponent - value serialization', () => {
+  let serComponent: FilamentDetailComponent;
+  let serFixture: ComponentFixture<FilamentDetailComponent>;
+  let mockFilamentSvc: jasmine.SpyObj<FilamentService>;
+
+  const baseFilament = {
+    id: 'filament-1',
+    displayName: 'Test',
+    materialType: 'PLA',
+    materialDensityGramPerCubicCm: 1.24,
+    spoolWeightMg: 150000,
+    initialTotalWeightMg: 1150000,
+    initialNominalWeightMg: 1000000,
+    filamentAdjustments: [],
+    colors: [],
+  };
+
+  async function setupSerialization(
+    filamentOverrides: Record<string, unknown>
+  ) {
+    mockFilamentSvc = jasmine.createSpyObj<FilamentService>('FilamentService', {
+      getFilamentBrands: of({ brands: [] }),
+      getFilamentPurchaseLocations: of({ purchaseLocations: [] }),
+      getFilamentStorageLocations: of({ storageLocations: [] }),
+      addFilament: of({} as never),
+      updateFilament: of({} as never),
+    });
+    const mockToastr = jasmine.createSpyObj<ToastrService>('ToastrService', [
+      'success',
+    ]);
+    const mockUserSettings = jasmine.createSpyObj<UserSettingService>(
+      'UserSettingService',
+      ['updateUserSetting']
+    );
+    const mockLog = jasmine.createSpyObj<LoggingService>('LoggingService', [
+      'logException',
+      'logEvent',
+    ]);
+
+    await TestBed.configureTestingModule({
+      declarations: [FilamentDetailComponent],
+      imports: [
+        RouterTestingModule,
+        FormsModule,
+        ReactiveFormsModule,
+        MatInputModule,
+        MatSelectModule,
+        MatDatepickerModule,
+        MatCheckboxModule,
+        MatNativeDateModule,
+        MatAutocompleteModule,
+        MatButtonToggleModule,
+        MatChipsModule,
+        MatButtonModule,
+        MatTooltipModule,
+      ],
+      providers: [
+        { provide: FilamentService, useValue: mockFilamentSvc },
+        { provide: ToastrService, useValue: mockToastr },
+        { provide: UserSettingService, useValue: mockUserSettings },
+        { provide: LoggingService, useValue: mockLog },
+        { provide: MAT_DATE_LOCALE, useValue: 'en-US' },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            data: of({
+              filament: { ...baseFilament, ...filamentOverrides },
+              materials: [],
+              materialCategories: [],
+            }),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    serFixture = TestBed.createComponent(FilamentDetailComponent);
+    serComponent = serFixture.componentInstance;
+    serFixture.detectChanges();
+  }
+
+  // Returns the FilamentDetail passed to updateFilament on the most recent save.
+  function savedFilament(): any {
+    const spy = mockFilamentSvc.updateFilament as jasmine.Spy;
+    return spy.calls.mostRecent().args[0];
+  }
+
+  it('drops a new untouched adjustment row', async () => {
+    await setupSerialization({});
+    serComponent.addAdjustment();
+
+    serComponent.onSubmit();
+
+    expect(mockFilamentSvc.updateFilament).toHaveBeenCalled();
+    expect(savedFilament().filamentAdjustments.length).toBe(0);
+  });
+
+  it('keeps a notes-only adjustment row with null measurements', async () => {
+    await setupSerialization({});
+    serComponent.addAdjustment();
+    const row = serComponent.filamentAdjustments.at(0);
+    row.get('amountG')!.setValue(null);
+    row.get('notes')!.setValue('inspected, no change');
+
+    serComponent.onSubmit();
+
+    const adj = savedFilament().filamentAdjustments;
+    expect(adj.length).toBe(1);
+    expect(adj[0].amountMg).toBeNull();
+    expect(adj[0].lengthInM).toBeNull();
+    expect(adj[0].volumeMl).toBeNull();
+    expect(adj[0].notes).toBe('inspected, no change');
+  });
+
+  it('preserves an explicit zero amount entered by the user', async () => {
+    await setupSerialization({});
+    serComponent.addAdjustment();
+    serComponent.filamentAdjustments.at(0).get('amountG')!.setValue('0');
+
+    serComponent.onSubmit();
+
+    const adj = savedFilament().filamentAdjustments;
+    expect(adj.length).toBe(1);
+    expect(adj[0].amountMg).toBe(0);
+  });
+
+  it('drops whitespace-only length values instead of saving zero', async () => {
+    await setupSerialization({});
+    serComponent.addAdjustment();
+    const row = serComponent.filamentAdjustments.at(0);
+    row.get('amountG')!.setValue(null);
+    row.get('lengthInM')!.setValue('   ');
+
+    serComponent.onSubmit();
+
+    expect(savedFilament().filamentAdjustments.length).toBe(0);
+  });
+
+  it('drops a non-numeric length value instead of saving a phantom row', async () => {
+    await setupSerialization({});
+    serComponent.addAdjustment();
+    const row = serComponent.filamentAdjustments.at(0);
+    row.get('amountG')!.setValue(null);
+    row.get('lengthInM')!.setValue('abc');
+
+    serComponent.onSubmit();
+
+    expect(savedFilament().filamentAdjustments.length).toBe(0);
+  });
+
+  it('serializes a non-finite volume value as null', async () => {
+    await setupSerialization({});
+    serComponent.addAdjustment();
+    const row = serComponent.filamentAdjustments.at(0);
+    row.get('amountG')!.setValue(null);
+    row.get('volumeMl')!.setValue('Infinity');
+    row.get('notes')!.setValue('keep me');
+
+    serComponent.onSubmit();
+
+    const adj = savedFilament().filamentAdjustments;
+    expect(adj.length).toBe(1);
+    expect(adj[0].volumeMl).toBeNull();
+  });
+});

--- a/src/app/filament/filament-detail/filament-detail.component.spec.ts
+++ b/src/app/filament/filament-detail/filament-detail.component.spec.ts
@@ -474,4 +474,33 @@ describe('FilamentDetailComponent - value serialization', () => {
     expect(adj.length).toBe(1);
     expect(adj[0].volumeMl).toBeNull();
   });
+
+  it('serializes empty nominal weight/length/volume as null', async () => {
+    await setupSerialization({
+      initialNominalWeightMg: 0, // loads initialNominalWeightG as null (>0 guard)
+      initialNominalLengthM: null,
+      initialNominalVolumeMl: null,
+    });
+
+    serComponent.onSubmit();
+
+    const saved = savedFilament();
+    expect(saved.initialNominalWeightMg).toBeNull();
+    expect(saved.initialNominalLengthM).toBeNull();
+    expect(saved.initialNominalVolumeMl).toBeNull();
+  });
+
+  it('serializes populated nominal fields to rounded values', async () => {
+    await setupSerialization({});
+    serComponent.filamentForm.get('initialNominalWeightG')!.setValue(1);
+    serComponent.filamentForm.get('initialNominalLengthM')!.setValue(330);
+    serComponent.filamentForm.get('initialNominalVolumeMl')!.setValue(800);
+
+    serComponent.onSubmit();
+
+    const saved = savedFilament();
+    expect(saved.initialNominalWeightMg).toBe(1000);
+    expect(saved.initialNominalLengthM).toBe(330);
+    expect(saved.initialNominalVolumeMl).toBe(800);
+  });
 });

--- a/src/app/filament/filament-detail/filament-detail.component.spec.ts
+++ b/src/app/filament/filament-detail/filament-detail.component.spec.ts
@@ -503,4 +503,28 @@ describe('FilamentDetailComponent - value serialization', () => {
     expect(saved.initialNominalLengthM).toBe(330);
     expect(saved.initialNominalVolumeMl).toBe(800);
   });
+
+  it('preserves a null adjustment weight across load and re-save', async () => {
+    await setupSerialization({
+      filamentAdjustments: [
+        {
+          id: 'adj-1',
+          filamentId: 'filament-1',
+          source: FilamentAdjustmentSourceMeasurement.Length,
+          amountMg: null,
+          lengthInM: 100,
+          volumeMl: null,
+          notes: '',
+        },
+      ],
+    });
+
+    // Submit without editing the loaded adjustment.
+    serComponent.onSubmit();
+
+    const adj = savedFilament().filamentAdjustments;
+    expect(adj.length).toBe(1);
+    expect(adj[0].amountMg).toBeNull(); // was silently becoming 0 on load
+    expect(adj[0].lengthInM).toBe(100);
+  });
 });

--- a/src/app/filament/filament-detail/filament-detail.component.ts
+++ b/src/app/filament/filament-detail/filament-detail.component.ts
@@ -411,7 +411,7 @@ export class FilamentDetailComponent
           adjustment.id,
           adjustment.filamentId,
           adjustment.source,
-          adjustment.amountMg / 1000,
+          adjustment.amountMg != null ? adjustment.amountMg / 1000 : null,
           adjustment.lengthInM,
           adjustment.volumeMl,
           adjustment.notes

--- a/src/app/filament/filament-detail/filament-detail.component.ts
+++ b/src/app/filament/filament-detail/filament-detail.component.ts
@@ -764,26 +764,19 @@ export class FilamentDetailComponent
       diameterMm: this.filamentForm.controls.diameterMm.value,
       displayName: this.filamentForm.controls.displayName.value,
       source: this.filamentForm.controls.source.value,
-      initialNominalWeightMg: !isNaN(
-        +this.filamentForm.controls.initialNominalWeightG.value
-      )
-        ? Math.round(
-            +this.filamentForm.controls.initialNominalWeightG.value * 1000
-          )
-        : null,
+      initialNominalWeightMg: this.toNullableRounded(
+        this.filamentForm.controls.initialNominalWeightG.value,
+        1000
+      ),
       initialTotalWeightMg: Math.round(
         this.filamentForm.controls.initialTotalWeightG.value * 1000
       ),
-      initialNominalLengthM: !isNaN(
-        +this.filamentForm.controls.initialNominalLengthM.value
-      )
-        ? Math.round(+this.filamentForm.controls.initialNominalLengthM.value)
-        : null,
-      initialNominalVolumeMl: !isNaN(
-        +this.filamentForm.controls.initialNominalVolumeMl.value
-      )
-        ? Math.round(+this.filamentForm.controls.initialNominalVolumeMl.value)
-        : null,
+      initialNominalLengthM: this.toNullableRounded(
+        this.filamentForm.controls.initialNominalLengthM.value
+      ),
+      initialNominalVolumeMl: this.toNullableRounded(
+        this.filamentForm.controls.initialNominalVolumeMl.value
+      ),
       materialDensityGramPerCubicCm:
         this.filamentForm.controls.materialDensityGramPerCubicCm.value,
       materialType: this.filamentForm.controls.materialType.value,

--- a/src/app/filament/filament-detail/filament-detail.component.ts
+++ b/src/app/filament/filament-detail/filament-detail.component.ts
@@ -517,7 +517,7 @@ export class FilamentDetailComponent
         EMPTY_GUID,
         this.filamentForm.get('id')?.value ?? EMPTY_GUID,
         FilamentAdjustmentSourceMeasurement.Weight,
-        0,
+        null,
         null,
         null,
         ''
@@ -702,14 +702,39 @@ export class FilamentDetailComponent
     this.location.back();
   }
 
+  private isBlank(value: unknown): boolean {
+    if (value === null || value === undefined) {
+      return true;
+    }
+    // Whitespace-only text is empty; without trimming, +'   ' coerces to 0
+    // and reintroduces the zero-vs-null bug on the unvalidated length/volume
+    // inputs.
+    if (typeof value === 'string') {
+      return value.trim() === '';
+    }
+    return false;
+  }
+
+  // null when blank, non-numeric, or non-finite; otherwise
+  // Math.round(value * multiplier). Number.isFinite rejects NaN AND Infinity,
+  // which would otherwise round to Infinity and serialize to null over the wire.
+  private toNullableRounded(value: unknown, multiplier = 1): number | null {
+    if (this.isBlank(value)) {
+      return null;
+    }
+    const n = +(value as number);
+    return Number.isFinite(n) ? Math.round(n * multiplier) : null;
+  }
+
   private getFilamentFromForm(): FilamentDetail {
     const adjustments = this.filamentAdjustments.controls
       .filter((adjustment) => {
         return (
-          adjustment.get('amountG').value !== 0 ||
-          adjustment.get('lengthInM').value !== 0 ||
-          adjustment.get('volumeMl').value !== 0 ||
-          adjustment.get('notes').value !== ''
+          this.toNullableRounded(adjustment.get('amountG').value, 1000) !==
+            null ||
+          this.toNullableRounded(adjustment.get('lengthInM').value) !== null ||
+          this.toNullableRounded(adjustment.get('volumeMl').value) !== null ||
+          !this.isBlank(adjustment.get('notes').value)
         );
       })
       .map((adjustment) => {
@@ -717,18 +742,12 @@ export class FilamentDetailComponent
           id: adjustment.get('id')?.value ?? EMPTY_GUID,
           filamentId: adjustment.get('filamentId')?.value ?? EMPTY_GUID,
           source: adjustment.get('source').value,
-          amountMg:
-            +adjustment.get('amountG').value !== null
-              ? Math.round(+adjustment.get('amountG').value * 1000)
-              : null,
-          lengthInM:
-            +adjustment.get('lengthInM').value !== null
-              ? Math.round(+adjustment.get('lengthInM').value)
-              : null,
-          volumeMl:
-            +adjustment.get('volumeMl').value !== null
-              ? Math.round(+adjustment.get('volumeMl').value)
-              : null,
+          amountMg: this.toNullableRounded(
+            adjustment.get('amountG').value,
+            1000
+          ),
+          lengthInM: this.toNullableRounded(adjustment.get('lengthInM').value),
+          volumeMl: this.toNullableRounded(adjustment.get('volumeMl').value),
           notes: adjustment.get('notes').value,
         };
 


### PR DESCRIPTION
## Problem

`FilamentDetailComponent.getFilamentFromForm()` converted empty numeric form fields into `0` and persisted blank adjustment rows as real records. Three distinct defects:

1. **Phantom adjustment rows** — the filter kept any row where a value was `!== 0`. A freshly added row defaulted `amountG: 0` with `lengthInM`/`volumeMl: null`, and `null !== 0` is `true`, so untouched blank rows were saved.
2. **Empty adjustment fields became zero** — values were coerced with `+` *before* the `!== null` check. `+null`/`+''` are `0` and `0 !== null` is always `true`, making the `null` branch unreachable.
3. **Empty nominal fields became zero** — `initialNominalWeight/Length/Volume` used `!isNaN(+value)`; `+null === 0` passes, serializing empty as `0`.

Additionally, existing adjustments with `amountMg: null` loaded into the form as `0` (`null / 1000`), so simply opening and re-saving silently corrupted `null → 0`.

Downstream code (remaining-filament, cost, analytics) distinguishes `null` (unknown) from `0` (explicit), so these were real data-integrity bugs.

## Fix

- Add two helpers: `isBlank()` (treats `null`/`undefined`/whitespace-only strings as empty) and `toNullableRounded()` (returns `null` for blank/non-numeric/non-finite input, else `Math.round(value * multiplier)`).
- **Numeric-validity-aware row filter**: a row is kept only if a measurement produces a finite number (an explicit `0` counts) or notes are non-blank. This also drops non-numeric-only rows (e.g. `"abc"`) that a blank-only filter would have persisted as all-`null` phantom records.
- Route the adjustment map and the three nominal fields through `toNullableRounded`.
- Default a new adjustment row's `amountG` to `null` (was `0`), so an untouched row is genuinely blank and dropped.
- Null-guard the load-side `amountMg / 1000` conversion so existing `null` weights survive an open-and-resave round trip.

Out of scope (unchanged): `initialTotalWeightMg` and `spoolWeightMg` — not flagged and a separate total/spool-weight concern.

## Tests

Nine new specs in `filament-detail.component.spec.ts` driving `onSubmit()` and asserting on the serialized `FilamentService` payload: untouched row dropped; notes-only row kept with null measurements; explicit `0` preserved; whitespace-only and non-numeric length dropped; non-finite volume → null; empty nominal fields → null; populated nominal fields rounded; and a null-weight adjustment preserved across load and re-save.

All 673 unit tests pass; lint clean; dev build succeeds.