### PR TITLE
feat(mcp): Connect AI Assistants — settings + docs

### DIFF
--- a/.claude/skills/adding-a-docs-page/SKILL.md
+++ b/.claude/skills/adding-a-docs-page/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: adding-a-docs-page
+description: Use when adding a new page under /docs to the 3D Print Log UI (a new documentation or onboarding article), or when a docs page renders but is missing from the sidebar, SEO metadata, sitemap, or prerender output.
+---
+
+# Adding a /docs Page
+
+## Overview
+
+Writing the component is trivial; the trap is **wiring**. A new doc page must be registered
+in **six** places, and its route count is asserted in **three** test locations — and only one
+of those runs under `npm run test:brief`. Miss one and it either 404s, fails prerender, or
+(most sneakily) passes locally and fails CI.
+
+## The six registration points
+
+For a page at `/docs/<name>` (component `Docs<Name>Component`):
+
+1. **Component** — create `src/app/documentation/docs/docs-<name>/docs-<name>.component.{ts,html,scss,spec.ts}`.
+   Use `standalone: false`, `ChangeDetectionStrategy.OnPush`. SSR-safe: no `window`/`document`/
+   `localStorage` at construction (it may prerender + render logged-out).
+2. **`documentation.module.ts`** — import + add to `declarations`.
+3. **`documentation-routing.module.ts`** — import + add `{ path: '<name>', component: Docs<Name>Component }`
+   under the `DocumentationComponent` children.
+4. **`doc-sidebar/doc-sidebar.component.ts`** — add `{ name: '…', url: '/docs/<name>' }` to `navItems`.
+5. **`doc-seo.config.ts`** — add `'docs/<name>': { title, description }`. Title AND description must be
+   **globally unique** (pooled with marketing routes); description length **50–170 chars**.
+6. **`scripts/marketing-routes.mjs`** — add `'docs/<name>'` to `DOC_ROUTES`.
+7. **`src/app/app.routes.server.ts`** — add `{ path: 'docs/<name>', renderMode: RenderMode.Prerender }`.
+
+(Metadata/canonical/OG/Twitter/JSON-LD come automatically from `doc-seo.config.ts` via the
+parent `DocumentationComponent` — you do not set them in the component.)
+
+## The three route-count assertions (bump ALL of them)
+
+Adding a route changes a hard-coded count in three test runners:
+
+| File                                           | Assertion                            | Runs in `test:brief`?                   |
+| ---------------------------------------------- | ------------------------------------ | --------------------------------------- |
+| `src/app/documentation/doc-seo.config.spec.ts` | `expect(paths.length).toBe(N)`       | ✅ yes                                  |
+| `scripts/generate-sitemap.test.mjs`            | `assert.equal(DOC_ROUTES.length, N)` | ❌ **CI only** (`npm run test:sitemap`) |
+| `scripts/verify-prerender.mjs`                 | route-count summary                  | ❌ **CI only** (after prod build)       |
+
+Bump the count and add an inclusion assertion (`…includes('docs/<name>')`) in the first two.
+
+## Verify locally BEFORE pushing (don't trust `test:brief` alone)
+
+```bash
+npm run test:sitemap        # the assertion that will bite you in CI
+npm run build               # production prerender
+node scripts/verify-prerender.mjs
+```
+
+## Common mistakes
+
+- Ran only `test:brief`, saw green, pushed → CI fails on `generate-sitemap.test.mjs`. Always run
+  `test:sitemap` too.
+- Duplicated a title/description → `verify-prerender` uniqueness check fails.
+- Set meta tags inside the component → they belong in `doc-seo.config.ts`.
+- Forgot the server-route entry → page renders in dev but isn't prerendered.

--- a/docs/mcp-auth0-setup.md
+++ b/docs/mcp-auth0-setup.md
@@ -1,0 +1,128 @@
+# MCP Auth0 setup
+
+This checklist configures the OAuth resource used by the read-only 3D Print Log
+MCP server. Apply it to development first, then repeat it in production with the
+production values below.
+
+## Environment values
+
+| Environment | Auth0 tenant | MCP API identifier |
+| --- | --- | --- |
+| Development | `dev-3dprintlog.auth0.com` | `https://dev.3dprintlog.com/mcp` |
+| Production | `3dprintlog.auth0.com` | `https://3dprintlog.com/mcp` |
+
+The MCP identifier is deliberately separate from the normal Print Log API
+audience. Never configure either resource server to accept the other audience.
+
+## 1. Create the MCP API
+
+In **Applications > APIs**, create an API named **PrintLog MCP** with the MCP
+identifier for the target environment and the `RS256` signing algorithm.
+
+Under **Permissions**, add:
+
+- Permission: `read:printdata`
+- Description: `Read the user's print data`
+
+This is a self-service consent scope. Leave **Enable RBAC** and **Add Permissions
+in the Access Token** disabled; otherwise every user would require a manual role
+assignment before connecting an agent.
+
+Under **Access Token Expiration**:
+
+- Set **Maximum Access Token Lifetime** to `3600` seconds.
+- Set **Implicit/Hybrid Flow Access Token Lifetime** to `3600` seconds.
+- Enable **Allow Offline Access** so OAuth clients can receive refresh tokens.
+
+Save the API settings.
+
+## 2. Configure the public MCP client
+
+Create a **Native** application named **PrintLog AI Connector**. It is a public
+PKCE client and must not depend on a client secret.
+
+Configure:
+
+- Token Endpoint Authentication Method: `None`
+- Grant types: `Authorization Code` and `Refresh Token`
+- Claude callback URLs:
+  - `https://claude.ai/api/mcp/auth_callback`
+  - `https://claude.com/api/mcp/auth_callback`
+- ChatGPT callback URL: copy the exact connector-specific URL displayed by the
+  ChatGPT custom-app setup; do not invent or shorten it.
+
+For local verification, temporarily add:
+
+```text
+http://127.0.0.1:8400/callback
+```
+
+Record the client ID in the deployment secret/configuration system. A public
+client ID is not a secret, but it should have one authoritative configuration
+source.
+
+If the tenant exposes an **Application Access Policy**, select per-application
+authorization and authorize only this client for `read:printdata`. Do not enable
+the Client Credentials grant.
+
+The v1 shared-client model supports revocation per 3D Print Log user, but not per
+AI product or device. The UI must describe this as **Disconnect all AI agents**.
+Already-issued access tokens remain valid until their one-hour expiry.
+
+## 3. Configure Management API access
+
+Open **Applications > APIs > Auth0 Management API > Machine to Machine
+Applications**. Find the existing application used by the API's
+`Auth0Management` configuration and grant only:
+
+- `read:grants`
+- `delete:grants`
+
+These scopes let the backend list and revoke the current user's MCP grants.
+
+## 4. Verify Authorization Code + PKCE
+
+Run the repository script from PowerShell:
+
+```powershell
+.\scripts\test-auth0-mcp-pkce.ps1 `
+  -ClientId '<environment client ID>' `
+  -Auth0Domain '3dprintlog.auth0.com' `
+  -Audience 'https://3dprintlog.com/mcp'
+```
+
+The callback URL `http://127.0.0.1:8400/callback` must be registered while the
+test runs. The script opens the browser, completes an Authorization Code + PKCE
+flow, keeps tokens only in memory, and verifies:
+
+- issuer matches the selected tenant;
+- audience contains the environment's MCP identifier;
+- `read:printdata` is present in `scope`;
+- `sub` is populated;
+- access-token lifetime is approximately 3600 seconds;
+- a refresh token is issued.
+
+For the optional revocation check, revoke **PrintLog AI Connector** under the
+test user's **Authorized Applications**, then return to the script and enter
+`R`. The refresh-token exchange must fail. This revokes the shared MCP grant for
+that user only; it does not disconnect other 3D Print Log users.
+
+Do not paste tokens into public JWT websites, commit them, or include them in
+support logs.
+
+## 5. Production completion record
+
+Record the following before deploying `/mcp`:
+
+```text
+Registration model: shared-client
+MCP identifier: https://3dprintlog.com/mcp
+Scope: read:printdata
+Token lifetime: 3600 seconds
+Grant types: authorization_code, refresh_token
+Token endpoint authentication: none
+Revocation UX: Disconnect all AI agents
+PKCE smoke test: passed
+Refresh revocation smoke test: passed
+```
+

--- a/scripts/generate-sitemap.test.mjs
+++ b/scripts/generate-sitemap.test.mjs
@@ -70,10 +70,11 @@ test('pageUrls prefixes each route with the origin', () => {
   ]);
 });
 
-test('DOC_ROUTES lists the 15 concrete doc pages under docs/', () => {
-  assert.equal(DOC_ROUTES.length, 15);
+test('DOC_ROUTES lists the 16 concrete doc pages under docs/', () => {
+  assert.equal(DOC_ROUTES.length, 16);
   assert.ok(DOC_ROUTES.every((r) => r.startsWith('docs/')));
   assert.ok(DOC_ROUTES.includes('docs/getting-started'));
+  assert.ok(DOC_ROUTES.includes('docs/mcp'));
   assert.ok(DOC_ROUTES.includes('docs/privacy-policy'));
   // No redirect-only or disabled routes.
   assert.ok(!DOC_ROUTES.includes('docs/filaments'));

--- a/scripts/marketing-routes.mjs
+++ b/scripts/marketing-routes.mjs
@@ -27,6 +27,7 @@ export const DOC_ROUTES = [
   'docs/printers',
   'docs/analytics',
   'docs/android-app',
+  'docs/mcp',
   'docs/cura-plugin',
   'docs/octoprint-webhook',
   'docs/klipper',

--- a/scripts/test-auth0-mcp-pkce.ps1
+++ b/scripts/test-auth0-mcp-pkce.ps1
@@ -1,0 +1,157 @@
+param(
+    [string]$ClientId = "t0ebEb6y5J1WYpvuNii4mnt9C83GyMd4",
+    [string]$Auth0Domain = "dev-3dprintlog.auth0.com",
+    [string]$Audience = "https://dev.3dprintlog.com/mcp",
+    [string]$RedirectUri = "http://127.0.0.1:8400/callback"
+)
+
+$ErrorActionPreference = "Stop"
+Add-Type -AssemblyName System.Web
+
+function ConvertTo-Base64Url {
+    param([byte[]]$Bytes)
+    [Convert]::ToBase64String($Bytes).TrimEnd('=').Replace('+', '-').Replace('/', '_')
+}
+
+function ConvertFrom-Base64UrlJson {
+    param([string]$Value)
+    $base64 = $Value.Replace('-', '+').Replace('_', '/')
+    switch ($base64.Length % 4) {
+        2 { $base64 += '==' }
+        3 { $base64 += '=' }
+    }
+    [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($base64)) | ConvertFrom-Json
+}
+
+function New-RandomBase64Url {
+    param([int]$ByteCount = 32)
+    $bytes = New-Object byte[] $ByteCount
+    $random = [Security.Cryptography.RandomNumberGenerator]::Create()
+    try { $random.GetBytes($bytes) } finally { $random.Dispose() }
+    ConvertTo-Base64Url $bytes
+}
+
+function Add-Result {
+    param([string]$Name, [bool]$Passed, [string]$Details)
+    $script:Results += [pscustomobject]@{
+        Check = $Name
+        Result = if ($Passed) { 'PASS' } else { 'FAIL' }
+        Details = $Details
+    }
+}
+
+$redirect = [Uri]$RedirectUri
+if ($redirect.Scheme -ne 'http' -or $redirect.Host -ne '127.0.0.1') {
+    throw 'RedirectUri must be an http://127.0.0.1 loopback URL.'
+}
+
+$listenerPrefix = "{0}://{1}:{2}/" -f $redirect.Scheme, $redirect.Host, $redirect.Port
+$codeVerifier = New-RandomBase64Url 64
+$sha256 = [Security.Cryptography.SHA256]::Create()
+try {
+    $challengeBytes = $sha256.ComputeHash([Text.Encoding]::ASCII.GetBytes($codeVerifier))
+} finally {
+    $sha256.Dispose()
+}
+$codeChallenge = ConvertTo-Base64Url $challengeBytes
+$state = New-RandomBase64Url
+$scope = 'openid profile offline_access read:printdata'
+
+$query = [System.Web.HttpUtility]::ParseQueryString('')
+$query['response_type'] = 'code'
+$query['client_id'] = $ClientId
+$query['redirect_uri'] = $RedirectUri
+$query['audience'] = $Audience
+$query['scope'] = $scope
+$query['code_challenge'] = $codeChallenge
+$query['code_challenge_method'] = 'S256'
+$query['state'] = $state
+$authorizeUrl = "https://$Auth0Domain/authorize?$($query.ToString())"
+
+$listener = [Net.HttpListener]::new()
+$listener.Prefixes.Add($listenerPrefix)
+try {
+    $listener.Start()
+    Write-Host "Waiting for Auth0 at $RedirectUri"
+    Write-Host 'Opening the authorization URL in your default browser...'
+    try { Start-Process $authorizeUrl } catch {
+        Write-Warning 'Open this URL manually:'
+        Write-Host $authorizeUrl
+    }
+
+    $context = $listener.GetContext()
+    $request = $context.Request
+    $response = $context.Response
+    $errorCode = $request.QueryString['error']
+    if ($errorCode) {
+        throw "Auth0 rejected the request: $errorCode - $($request.QueryString['error_description'])"
+    }
+    if ($request.QueryString['state'] -ne $state) {
+        throw 'The returned OAuth state did not match.'
+    }
+    $code = $request.QueryString['code']
+    if ([string]::IsNullOrWhiteSpace($code)) {
+        throw 'Auth0 did not return an authorization code.'
+    }
+    $html = '<html><body><h1>Authorization received</h1><p>Return to PowerShell. You may close this tab.</p></body></html>'
+    $bytes = [Text.Encoding]::UTF8.GetBytes($html)
+    $response.ContentType = 'text/html; charset=utf-8'
+    $response.ContentLength64 = $bytes.Length
+    $response.OutputStream.Write($bytes, 0, $bytes.Length)
+    $response.Close()
+} finally {
+    if ($listener.IsListening) { $listener.Stop() }
+    $listener.Close()
+}
+
+$tokenBody = @{
+    grant_type = 'authorization_code'
+    client_id = $ClientId
+    code = $code
+    redirect_uri = $RedirectUri
+    code_verifier = $codeVerifier
+} | ConvertTo-Json
+$tokenResponse = Invoke-RestMethod -Method Post -Uri "https://$Auth0Domain/oauth/token" -ContentType 'application/json' -Body $tokenBody
+if ([string]::IsNullOrWhiteSpace($tokenResponse.access_token)) {
+    throw 'Auth0 did not return an access token.'
+}
+
+$jwtParts = $tokenResponse.access_token.Split('.')
+if ($jwtParts.Count -ne 3) { throw 'The returned access token is not a JWT.' }
+$claims = ConvertFrom-Base64UrlJson $jwtParts[1]
+$Results = @()
+$expectedIssuer = "https://$Auth0Domain/"
+$audiences = @($claims.aud)
+$scopes = @(([string]$claims.scope).Split(' ', [StringSplitOptions]::RemoveEmptyEntries))
+$lifetime = [long]$claims.exp - [long]$claims.iat
+
+Add-Result 'Issuer' ($claims.iss -eq $expectedIssuer) "Expected $expectedIssuer"
+Add-Result 'MCP audience' ($audiences -contains $Audience) "Expected $Audience"
+Add-Result 'read:printdata scope' ($scopes -contains 'read:printdata') 'Required by the MCP endpoint'
+Add-Result 'Subject' (-not [string]::IsNullOrWhiteSpace([string]$claims.sub)) 'Auth0 user identifier is present'
+Add-Result 'Token lifetime' ($lifetime -ge 3540 -and $lifetime -le 3660) "Actual lifetime: $lifetime seconds"
+Add-Result 'Refresh token' (-not [string]::IsNullOrWhiteSpace([string]$tokenResponse.refresh_token)) 'Requires offline_access and Allow Offline Access'
+
+Write-Host ''
+Write-Host 'Auth0 MCP validation results (tokens are not displayed or saved):'
+$Results | Format-Table -AutoSize
+if ($Results.Result -contains 'FAIL') { throw 'One or more Auth0 MCP validation checks failed.' }
+
+if (-not [string]::IsNullOrWhiteSpace([string]$tokenResponse.refresh_token)) {
+    $answer = Read-Host 'Revoke the application for this user, then enter R to test revocation, or S to skip'
+    if ($answer -match '^[Rr]$') {
+        $refreshBody = @{
+            grant_type = 'refresh_token'
+            client_id = $ClientId
+            refresh_token = $tokenResponse.refresh_token
+        } | ConvertTo-Json
+        try {
+            $null = Invoke-RestMethod -Method Post -Uri "https://$Auth0Domain/oauth/token" -ContentType 'application/json' -Body $refreshBody
+            Write-Error 'FAIL: Auth0 accepted the refresh token after revocation.'
+        } catch {
+            Write-Host 'PASS: Auth0 rejected the refresh token after revocation.' -ForegroundColor Green
+        }
+    }
+}
+
+Write-Host 'Auth0 MCP PKCE test passed.' -ForegroundColor Green

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -20,6 +20,7 @@ export const serverRoutes: ServerRoute[] = [
   { path: 'docs/printers', renderMode: RenderMode.Prerender },
   { path: 'docs/analytics', renderMode: RenderMode.Prerender },
   { path: 'docs/android-app', renderMode: RenderMode.Prerender },
+  { path: 'docs/mcp', renderMode: RenderMode.Prerender },
   { path: 'docs/cura-plugin', renderMode: RenderMode.Prerender },
   { path: 'docs/octoprint-webhook', renderMode: RenderMode.Prerender },
   { path: 'docs/klipper', renderMode: RenderMode.Prerender },

--- a/src/app/core/services/connected-agents.service.spec.ts
+++ b/src/app/core/services/connected-agents.service.spec.ts
@@ -1,0 +1,67 @@
+import {
+  provideHttpClient,
+  withInterceptorsFromDi,
+} from '@angular/common/http';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { environment } from 'src/environments/environment.unittest';
+
+import {
+  ConnectedAgent,
+  ConnectedAgentsService,
+} from './connected-agents.service';
+
+describe('ConnectedAgentsService', () => {
+  let service: ConnectedAgentsService;
+  let httpController: HttpTestingController;
+  const baseApi = environment.printLogApiUrl;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+      ],
+    });
+    service = TestBed.inject(ConnectedAgentsService);
+    httpController = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpController.verify();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('getConnectedAgents GETs /api/connected-agents and returns the typed contract', (done) => {
+    const expected: ConnectedAgent[] = [
+      { grantId: 'grant-1', clientId: 'client-1', scopes: ['read:printdata'] },
+    ];
+
+    service.getConnectedAgents().subscribe((agents) => {
+      expect(agents).toEqual(expected);
+      done();
+    });
+
+    const req = httpController.expectOne(`${baseApi}/api/connected-agents`);
+    expect(req.request.method).toBe('GET');
+    req.flush(expected);
+  });
+
+  it('revoke DELETEs /api/connected-agents/{grantId}', (done) => {
+    service.revoke('grant-1').subscribe(() => {
+      done();
+    });
+
+    const req = httpController.expectOne(
+      `${baseApi}/api/connected-agents/grant-1`
+    );
+    expect(req.request.method).toBe('DELETE');
+    req.flush(null);
+  });
+});

--- a/src/app/core/services/connected-agents.service.ts
+++ b/src/app/core/services/connected-agents.service.ts
@@ -1,0 +1,36 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from 'src/environments/environment';
+
+/**
+ * A connected AI agent, backed by an Auth0 grant for the MCP audience.
+ */
+export interface ConnectedAgent {
+  grantId: string;
+  clientId: string;
+  scopes: string[];
+}
+
+/**
+ * Lists and revokes the current user's connected AI agents via the API.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class ConnectedAgentsService {
+  private readonly httpClient = inject(HttpClient);
+  private readonly baseApi = environment.printLogApiUrl;
+
+  public getConnectedAgents(): Observable<ConnectedAgent[]> {
+    return this.httpClient.get<ConnectedAgent[]>(
+      `${this.baseApi}/api/connected-agents`
+    );
+  }
+
+  public revoke(grantId: string): Observable<void> {
+    return this.httpClient.delete<void>(
+      `${this.baseApi}/api/connected-agents/${encodeURIComponent(grantId)}`
+    );
+  }
+}

--- a/src/app/documentation/doc-seo.config.spec.ts
+++ b/src/app/documentation/doc-seo.config.spec.ts
@@ -4,9 +4,10 @@ import { ogImage } from '../slicer/slicer-configs';
 describe('doc-seo.config', () => {
   const paths = Object.keys(DOC_SEO);
 
-  it('covers all 15 doc routes', () => {
-    expect(paths.length).toBe(15);
+  it('covers all 16 doc routes', () => {
+    expect(paths.length).toBe(16);
     expect(paths).toContain('docs/getting-started');
+    expect(paths).toContain('docs/mcp');
     expect(paths).toContain('docs/privacy-policy');
   });
 

--- a/src/app/documentation/doc-seo.config.ts
+++ b/src/app/documentation/doc-seo.config.ts
@@ -52,6 +52,11 @@ export const DOC_SEO: Record<string, DocSeo> = {
     description:
       'Install and use the 3D Print Log Android app to log prints, manage filament, and check stats from your phone. Setup and feature guide.',
   },
+  'docs/mcp': {
+    title: 'Connect an AI Assistant (MCP) | 3D Print Log Docs',
+    description:
+      'Connect Claude or ChatGPT to your 3D Print Log data with the Model Context Protocol. Give your AI assistant read-only access to prints, printers, and materials.',
+  },
   'docs/cura-plugin': {
     title: 'Cura Plugin | 3D Print Log Docs',
     description:
@@ -89,9 +94,7 @@ export const DOC_SEO: Record<string, DocSeo> = {
   },
 };
 
-export function getDocSeoTags(
-  path: string
-): {
+export function getDocSeoTags(path: string): {
   url: string;
   title: string;
   description: string;

--- a/src/app/documentation/doc-seo.config.ts
+++ b/src/app/documentation/doc-seo.config.ts
@@ -55,7 +55,7 @@ export const DOC_SEO: Record<string, DocSeo> = {
   'docs/mcp': {
     title: 'Connect an AI Assistant (MCP) | 3D Print Log Docs',
     description:
-      'Connect Claude or ChatGPT to your 3D Print Log data with the Model Context Protocol. Your AI assistant can read your prints, printers, and materials, and log and update prints on your behalf.',
+      'Connect Claude or ChatGPT to your 3D Print Log data via the Model Context Protocol. Read your prints, printers, and materials, and log or update prints for you.',
   },
   'docs/cura-plugin': {
     title: 'Cura Plugin | 3D Print Log Docs',

--- a/src/app/documentation/doc-seo.config.ts
+++ b/src/app/documentation/doc-seo.config.ts
@@ -55,7 +55,7 @@ export const DOC_SEO: Record<string, DocSeo> = {
   'docs/mcp': {
     title: 'Connect an AI Assistant (MCP) | 3D Print Log Docs',
     description:
-      'Connect Claude or ChatGPT to your 3D Print Log data with the Model Context Protocol. Give your AI assistant read-only access to prints, printers, and materials.',
+      'Connect Claude or ChatGPT to your 3D Print Log data with the Model Context Protocol. Your AI assistant can read your prints, printers, and materials, and log and update prints on your behalf.',
   },
   'docs/cura-plugin': {
     title: 'Cura Plugin | 3D Print Log Docs',

--- a/src/app/documentation/doc-sidebar/doc-sidebar.component.ts
+++ b/src/app/documentation/doc-sidebar/doc-sidebar.component.ts
@@ -19,6 +19,7 @@ export class DocSidebarComponent {
     { name: 'Analytics', url: '/docs/analytics' },
     { divider: true },
     { name: 'Android App', url: '/docs/android-app' },
+    { name: 'Connect an AI Assistant', url: '/docs/mcp' },
     { name: 'Cura Plugin', url: '/docs/cura-plugin' },
     { name: 'Octoprint Webhook', url: '/docs/octoprint-webhook' },
     { name: 'Klipper/Moonraker', url: '/docs/klipper' },

--- a/src/app/documentation/docs/docs-mcp/docs-mcp.component.html
+++ b/src/app/documentation/docs/docs-mcp/docs-mcp.component.html
@@ -7,23 +7,37 @@
     <a href="https://modelcontextprotocol.io" target="_blank" rel="noopener"
       >Model Context Protocol (MCP)</a
     >. Once connected, the assistant can read your prints, printers, and
-    material inventory to answer questions like &ldquo;how much PLA do I have
-    left?&rdquo; or &ldquo;summarize my prints this month.&rdquo;
+    material inventory &mdash; and, with your permission, log and update prints
+    and manage your projects and materials. That lets you ask things like
+    &ldquo;how much PLA do I have left?&rdquo; or say &ldquo;log the print I just
+    finished.&rdquo;
   </p>
 
   <h2>What the assistant can and can&rsquo;t do</h2>
   <ul>
     <li>
-      <strong>Read-only.</strong> The assistant can view your own print data. It
-      cannot create, edit, or delete anything.
+      <strong>Reads and writes your print data.</strong> The assistant can view
+      your prints, printers, and materials, and &mdash; with your permission
+      &mdash; log new prints, edit them, and manage your projects and material
+      inventory.
     </li>
     <li>
-      <strong>Your data only.</strong> It can only ever see records you created
-      — never another user&rsquo;s prints, even public ones.
+      <strong>It can&rsquo;t delete anything.</strong> There is no way for the
+      assistant to delete a print, project, or spool. Its changes are limited to
+      creating and editing.
+    </li>
+    <li>
+      <strong>Your data only.</strong> It can only ever see or change records you
+      created — never another user&rsquo;s prints, even public ones.
     </li>
     <li>
       <strong>No photos, comments, or files.</strong> Only structured data
       (titles, statuses, material usage, dates, and stats) is shared.
+    </li>
+    <li>
+      <strong>It won&rsquo;t touch your printer.</strong> Logging a print records
+      what happened — it never changes which filament is currently loaded on a
+      printer.
     </li>
     <li>
       <strong>Print settings only where you saved them.</strong> Layer height,
@@ -36,7 +50,7 @@
     </li>
   </ul>
 
-  <h2>What you can ask</h2>
+  <h2>Questions you can ask</h2>
   <ul>
     <li>
       <strong>Your prints.</strong> &ldquo;How many prints did I finish last
@@ -67,6 +81,52 @@
       whose notes hold a slicer summary (see the limitation above).
     </li>
   </ul>
+
+  <h2>Changes it can make for you</h2>
+  <p>
+    With your permission, the assistant can also make changes for you. It always
+    acts as you, on your own data.
+  </p>
+  <ul>
+    <li>
+      <strong>Log a finished print.</strong> &ldquo;Log that Benchy I just
+      finished on the Bambu — it used about 12&nbsp;g of the grey PLA.&rdquo; It
+      records the status, print time, notes, and material used, and can file the
+      print under a project.
+    </li>
+    <li>
+      <strong>Edit a print.</strong> &ldquo;Mark that print a partial success and
+      note that the top layer lifted.&rdquo; You can update the status, notes,
+      time, material usage, or which project a print belongs to.
+    </li>
+    <li>
+      <strong>Organize projects.</strong> &ldquo;Start a project called Desk
+      Organizer&rdquo; or &ldquo;mark the planter project complete.&rdquo; Create
+      and rename projects and set whether each one is private, unlisted, or
+      public.
+    </li>
+    <li>
+      <strong>Add a spool.</strong> &ldquo;Add a new 1&nbsp;kg spool of Prusament
+      Galaxy Black PLA.&rdquo; New material goes straight into your inventory.
+    </li>
+    <li>
+      <strong>Correct what&rsquo;s left.</strong> &ldquo;I weighed the grey PLA —
+      it&rsquo;s actually 640&nbsp;g now.&rdquo; Adjust a spool&rsquo;s remaining
+      amount up or down.
+    </li>
+    <li>
+      <strong>Retire or restore a spool.</strong> &ldquo;Retire the empty black
+      roll&rdquo; hides a finished spool from your inventory; you can bring it
+      back later.
+    </li>
+  </ul>
+  <p class="hint">
+    Logging is safe to repeat — asking twice for the same print won&rsquo;t
+    create a duplicate. Because a
+    <a routerLink="/docs/integrations">slicer integration</a> may already have
+    imported a print for you, the assistant will usually check before logging one
+    itself.
+  </p>
 
   <h2>What you&rsquo;ll need</h2>
   <p>Two values. Your AI client asks for both.</p>
@@ -100,11 +160,12 @@
     </li>
     <li>
       When prompted, <strong>sign in to 3D Print Log</strong> and
-      <strong>authorize</strong> read-only access to your print data.
+      <strong>authorize</strong> access to your print data.
     </li>
     <li>
-      Start a chat and ask about your prints, printers, or filament — Claude
-      will use the connector when relevant.
+      Start a chat and ask about your prints, printers, or filament — or ask
+      Claude to log or update a print. Claude will use the connector when
+      relevant.
     </li>
   </ol>
 
@@ -126,7 +187,10 @@
       Enter the <strong>MCP endpoint URL</strong>, and the
       <strong>OAuth Client ID</strong> where prompted.
     </li>
-    <li>Complete the sign-in and consent prompt to grant read-only access.</li>
+    <li>
+      Complete the sign-in and consent prompt to grant access to your print
+      data.
+    </li>
   </ol>
 
   <h2>Managing connected assistants</h2>

--- a/src/app/documentation/docs/docs-mcp/docs-mcp.component.html
+++ b/src/app/documentation/docs/docs-mcp/docs-mcp.component.html
@@ -6,9 +6,9 @@
     <strong>Claude</strong> and <strong>ChatGPT</strong> using the
     <a href="https://modelcontextprotocol.io" target="_blank" rel="noopener"
       >Model Context Protocol (MCP)</a
-    >. Once connected, the assistant can read your prints, printers, and material
-    inventory to answer questions like &ldquo;how much PLA do I have left?&rdquo;
-    or &ldquo;summarize my prints this month.&rdquo;
+    >. Once connected, the assistant can read your prints, printers, and
+    material inventory to answer questions like &ldquo;how much PLA do I have
+    left?&rdquo; or &ldquo;summarize my prints this month.&rdquo;
   </p>
 
   <h2>What the assistant can and can&rsquo;t do</h2>
@@ -18,12 +18,44 @@
       cannot create, edit, or delete anything.
     </li>
     <li>
-      <strong>Your data only.</strong> It can only ever see records you created —
-      never another user&rsquo;s prints, even public ones.
+      <strong>Your data only.</strong> It can only ever see records you created
+      — never another user&rsquo;s prints, even public ones.
     </li>
     <li>
       <strong>No photos, comments, or files.</strong> Only structured data
       (titles, statuses, material usage, dates, and stats) is shared.
+    </li>
+    <li>
+      <strong>No print settings.</strong> Layer heights, temperatures, and
+      speeds aren&rsquo;t available to the assistant, so it can&rsquo;t tell you
+      what settings a past print used.
+    </li>
+  </ul>
+
+  <h2>What you can ask</h2>
+  <ul>
+    <li>
+      <strong>Your prints.</strong> &ldquo;How many prints did I finish last
+      year, and how many failed?&rdquo; You can search by name or project —
+      &ldquo;what was that soap dish I printed?&rdquo; — and ask what a print
+      used, including each colour of a multi-colour print.
+    </li>
+    <li>
+      <strong>Your materials.</strong> &ldquo;What blue PLA do I have, and where
+      is each spool stored?&rdquo; Searches match whole words, so
+      <em>PLA</em> also finds <em>PLA+</em> and <em>PLA (Polylactic Acid)</em>,
+      and <em>blue</em> also finds <em>Light Blue</em>.
+    </li>
+    <li>
+      <strong>Enough for a print.</strong> &ldquo;I have a 300&nbsp;g model — do
+      I have blue PLA for it?&rdquo; The assistant reports whether a single
+      spool covers it, or only several spools combined — which would mean
+      swapping filament mid-print.
+    </li>
+    <li>
+      <strong>Your printers.</strong> &ldquo;What&rsquo;s loaded on my Bambu
+      right now?&rdquo; and per-printer stats such as success rates and total
+      print time.
     </li>
   </ul>
 
@@ -34,8 +66,9 @@
   <h2>Connect to Claude</h2>
   <ol>
     <li>
-      In Claude (web or desktop), open <strong>Settings → Connectors</strong> and
-      choose <strong>Add custom connector</strong>.
+      In Claude (web or desktop), open
+      <strong>Settings → Connectors</strong> and choose
+      <strong>Add custom connector</strong>.
     </li>
     <li>Paste the MCP endpoint URL above.</li>
     <li>
@@ -43,8 +76,8 @@
       <strong>authorize</strong> read-only access to your print data.
     </li>
     <li>
-      Start a chat and ask about your prints, printers, or filament — Claude will
-      use the connector when relevant.
+      Start a chat and ask about your prints, printers, or filament — Claude
+      will use the connector when relevant.
     </li>
   </ol>
 
@@ -62,7 +95,7 @@
   <p>
     You can review and disconnect connected AI assistants at any time from your
     <a routerLink="/settings">Settings</a> page under
-    <strong>Connected AI Agents</strong>. Disconnecting immediately revokes access
-    for all connected assistants.
+    <strong>Connected AI Agents</strong>. Disconnecting immediately revokes
+    access for all connected assistants.
   </p>
 </article>

--- a/src/app/documentation/docs/docs-mcp/docs-mcp.component.html
+++ b/src/app/documentation/docs/docs-mcp/docs-mcp.component.html
@@ -68,9 +68,23 @@
     </li>
   </ul>
 
-  <h2>The MCP endpoint</h2>
-  <p>Point your AI client&rsquo;s custom MCP connector at:</p>
-  <pre class="endpoint"><code>{{ mcpEndpoint }}</code></pre>
+  <h2>What you&rsquo;ll need</h2>
+  <p>Two values. Your AI client asks for both.</p>
+  <dl class="connection-details">
+    <dt>MCP endpoint URL</dt>
+    <dd>
+      <code>{{ mcpEndpoint }}</code>
+    </dd>
+    <dt>OAuth Client ID</dt>
+    <dd>
+      <code>{{ mcpClientId }}</code>
+    </dd>
+  </dl>
+  <p class="hint">
+    The Client ID is the same for everyone and is safe to share &mdash; it
+    identifies the 3D Print Log connector, not you. There is no client secret.
+    You still sign in yourself, and the assistant only ever sees your own data.
+  </p>
 
   <h2>Connect to Claude</h2>
   <ol>
@@ -79,7 +93,11 @@
       <strong>Settings → Connectors</strong> and choose
       <strong>Add custom connector</strong>.
     </li>
-    <li>Paste the MCP endpoint URL above.</li>
+    <li>Paste the <strong>MCP endpoint URL</strong> above.</li>
+    <li>
+      Open <strong>Advanced settings</strong> and paste the
+      <strong>OAuth Client ID</strong>. Leave the client secret blank.
+    </li>
     <li>
       When prompted, <strong>sign in to 3D Print Log</strong> and
       <strong>authorize</strong> read-only access to your print data.
@@ -90,13 +108,24 @@
     </li>
   </ol>
 
+  <h2>Connect to Claude Code</h2>
+  <p>Run this, then use <code>/mcp</code> to sign in:</p>
+  <pre class="endpoint"><code>{{ claudeCodeCommand }}</code></pre>
+  <p class="hint">
+    If port 8400 is already in use on your machine, any port from
+    <strong>8400 to 8405</strong> will work.
+  </p>
+
   <h2>Connect to ChatGPT</h2>
   <ol>
     <li>
       In ChatGPT, open the custom connector / app setup and choose to add an MCP
       server.
     </li>
-    <li>Enter the MCP endpoint URL above.</li>
+    <li>
+      Enter the <strong>MCP endpoint URL</strong>, and the
+      <strong>OAuth Client ID</strong> where prompted.
+    </li>
     <li>Complete the sign-in and consent prompt to grant read-only access.</li>
   </ol>
 

--- a/src/app/documentation/docs/docs-mcp/docs-mcp.component.html
+++ b/src/app/documentation/docs/docs-mcp/docs-mcp.component.html
@@ -1,0 +1,68 @@
+<article class="docs-mcp">
+  <h1>Connect an AI Assistant (MCP)</h1>
+
+  <p>
+    3D Print Log can connect to AI assistants such as
+    <strong>Claude</strong> and <strong>ChatGPT</strong> using the
+    <a href="https://modelcontextprotocol.io" target="_blank" rel="noopener"
+      >Model Context Protocol (MCP)</a
+    >. Once connected, the assistant can read your prints, printers, and material
+    inventory to answer questions like &ldquo;how much PLA do I have left?&rdquo;
+    or &ldquo;summarize my prints this month.&rdquo;
+  </p>
+
+  <h2>What the assistant can and can&rsquo;t do</h2>
+  <ul>
+    <li>
+      <strong>Read-only.</strong> The assistant can view your own print data. It
+      cannot create, edit, or delete anything.
+    </li>
+    <li>
+      <strong>Your data only.</strong> It can only ever see records you created —
+      never another user&rsquo;s prints, even public ones.
+    </li>
+    <li>
+      <strong>No photos, comments, or files.</strong> Only structured data
+      (titles, statuses, material usage, dates, and stats) is shared.
+    </li>
+  </ul>
+
+  <h2>The MCP endpoint</h2>
+  <p>Point your AI client&rsquo;s custom MCP connector at:</p>
+  <pre class="endpoint"><code>{{ mcpEndpoint }}</code></pre>
+
+  <h2>Connect to Claude</h2>
+  <ol>
+    <li>
+      In Claude (web or desktop), open <strong>Settings → Connectors</strong> and
+      choose <strong>Add custom connector</strong>.
+    </li>
+    <li>Paste the MCP endpoint URL above.</li>
+    <li>
+      When prompted, <strong>sign in to 3D Print Log</strong> and
+      <strong>authorize</strong> read-only access to your print data.
+    </li>
+    <li>
+      Start a chat and ask about your prints, printers, or filament — Claude will
+      use the connector when relevant.
+    </li>
+  </ol>
+
+  <h2>Connect to ChatGPT</h2>
+  <ol>
+    <li>
+      In ChatGPT, open the custom connector / app setup and choose to add an MCP
+      server.
+    </li>
+    <li>Enter the MCP endpoint URL above.</li>
+    <li>Complete the sign-in and consent prompt to grant read-only access.</li>
+  </ol>
+
+  <h2>Managing connected assistants</h2>
+  <p>
+    You can review and disconnect connected AI assistants at any time from your
+    <a routerLink="/settings">Settings</a> page under
+    <strong>Connected AI Agents</strong>. Disconnecting immediately revokes access
+    for all connected assistants.
+  </p>
+</article>

--- a/src/app/documentation/docs/docs-mcp/docs-mcp.component.html
+++ b/src/app/documentation/docs/docs-mcp/docs-mcp.component.html
@@ -7,19 +7,19 @@
     <a href="https://modelcontextprotocol.io" target="_blank" rel="noopener"
       >Model Context Protocol (MCP)</a
     >. Once connected, the assistant can read your prints, printers, and
-    material inventory &mdash; and, with your permission, log and update prints
-    and manage your projects and materials. That lets you ask things like
-    &ldquo;how much PLA do I have left?&rdquo; or say &ldquo;log the print I just
-    finished.&rdquo;
+    material inventory. With your permission, it can also log and update prints
+    and manage your projects, printers, and materials. That lets you ask things
+    like &ldquo;how much PLA do I have left?&rdquo; or say &ldquo;log the print
+    I just finished.&rdquo;
   </p>
 
   <h2>What the assistant can and can&rsquo;t do</h2>
   <ul>
     <li>
       <strong>Reads and writes your print data.</strong> The assistant can view
-      your prints, printers, and materials, and &mdash; with your permission
-      &mdash; log new prints, edit them, and manage your projects and material
-      inventory.
+      your prints, printers, and materials. With your permission, it can also
+      log new prints, edit them, and manage your projects, printers, and
+      material inventory.
     </li>
     <li>
       <strong>It can&rsquo;t delete anything.</strong> There is no way for the
@@ -27,22 +27,24 @@
       creating and editing.
     </li>
     <li>
-      <strong>Your data only.</strong> It can only ever see or change records you
-      created — never another user&rsquo;s prints, even public ones.
+      <strong>Your data only.</strong> It can only ever see or change records
+      you created, never another user&rsquo;s prints, even public ones.
     </li>
     <li>
       <strong>No photos, comments, or files.</strong> Only structured data
       (titles, statuses, material usage, dates, and stats) is shared.
     </li>
     <li>
-      <strong>It won&rsquo;t touch your printer.</strong> Logging a print records
-      what happened — it never changes which filament is currently loaded on a
-      printer.
+      <strong>It won&rsquo;t touch the machine itself.</strong> The assistant
+      works on your records, not your hardware: it can&rsquo;t start, stop, or
+      send anything to a printer. Logging a print records what happened, and it
+      never changes which filament is currently loaded on a printer. You still
+      load and unload spools yourself.
     </li>
     <li>
       <strong>Print settings only where you saved them.</strong> Layer height,
-      speeds, and temperatures aren&rsquo;t separate fields &mdash; they live in
-      a print&rsquo;s notes. If you imported the print through a
+      speeds, and temperatures aren&rsquo;t separate fields; they live in a
+      print&rsquo;s notes. If you imported the print through a
       <a routerLink="/docs/integrations">slicer integration</a>, that summary is
       saved for you and the assistant can read it back. For a print logged by
       hand with no such notes, the assistant has nothing to read and can&rsquo;t
@@ -51,11 +53,16 @@
   </ul>
 
   <h2>Questions you can ask</h2>
+  <p>
+    You don&rsquo;t need to learn any commands; just ask in your own words.
+    These are only examples to give you a feel for it. Anything you could work
+    out from your own prints, printers, and inventory is fair game.
+  </p>
   <ul>
     <li>
       <strong>Your prints.</strong> &ldquo;How many prints did I finish last
-      year, and how many failed?&rdquo; You can search by name or project —
-      &ldquo;what was that soap dish I printed?&rdquo; — and ask what a print
+      year, and how many failed?&rdquo; You can search by name or project
+      (&ldquo;what was that soap dish I printed?&rdquo;), and ask what a print
       used, including each colour of a multi-colour print.
     </li>
     <li>
@@ -65,9 +72,9 @@
       and <em>blue</em> also finds <em>Light Blue</em>.
     </li>
     <li>
-      <strong>Enough for a print.</strong> &ldquo;I have a 300&nbsp;g model — do
+      <strong>Enough for a print.</strong> &ldquo;I have a 300&nbsp;g model. Do
       I have blue PLA for it?&rdquo; The assistant reports whether a single
-      spool covers it, or only several spools combined — which would mean
+      spool covers it, or only several spools combined, which would mean
       swapping filament mid-print.
     </li>
     <li>
@@ -77,7 +84,7 @@
     </li>
     <li>
       <strong>The settings you used.</strong> &ldquo;What layer height and
-      speeds did I use on the soap dish?&rdquo; &mdash; answerable for prints
+      speeds did I use on the soap dish?&rdquo; This is answerable for prints
       whose notes hold a slicer summary (see the limitation above).
     </li>
   </ul>
@@ -85,34 +92,61 @@
   <h2>Changes it can make for you</h2>
   <p>
     With your permission, the assistant can also make changes for you. It always
-    acts as you, on your own data.
+    acts as you, on your own data. Again, the list below is a starting point
+    rather than a menu. If it fits within the limits above, it&rsquo;s worth
+    asking for.
   </p>
   <ul>
     <li>
       <strong>Log a finished print.</strong> &ldquo;Log that Benchy I just
-      finished on the Bambu — it used about 12&nbsp;g of the grey PLA.&rdquo; It
+      finished on the Bambu. It used about 12&nbsp;g of the grey PLA.&rdquo; It
       records the status, print time, notes, and material used, and can file the
-      print under a project.
+      print under a project. A multi-colour print can list what each material
+      contributed, and you can give either the amount you measured or the
+      slicer&rsquo;s estimate.
     </li>
     <li>
-      <strong>Edit a print.</strong> &ldquo;Mark that print a partial success and
-      note that the top layer lifted.&rdquo; You can update the status, notes,
-      time, material usage, or which project a print belongs to.
+      <strong>Edit a print.</strong> &ldquo;Mark that print a partial success
+      and note that the top layer lifted.&rdquo; You can update the status,
+      notes, time, material usage, or which project a print belongs to.
+    </li>
+    <li>
+      <strong>Set who can see a print.</strong> &ldquo;Make that print
+      public.&rdquo; New prints follow your account default unless you say
+      otherwise, and you can change a print to private, unlisted, or public
+      later.
     </li>
     <li>
       <strong>Organize projects.</strong> &ldquo;Start a project called Desk
-      Organizer&rdquo; or &ldquo;mark the planter project complete.&rdquo; Create
-      and rename projects and set whether each one is private, unlisted, or
-      public.
+      Organizer&rdquo; or &ldquo;mark the planter project complete.&rdquo;
+      Create and rename projects and set whether each one is private, unlisted,
+      or public.
     </li>
     <li>
-      <strong>Add a spool.</strong> &ldquo;Add a new 1&nbsp;kg spool of Prusament
-      Galaxy Black PLA.&rdquo; New material goes straight into your inventory.
+      <strong>Add a printer.</strong> &ldquo;Add my new Bambu Lab X1
+      Carbon.&rdquo; It can also fill in the details you mention (nozzle size,
+      bed dimensions, heated bed or chamber), edit them later, or retire a
+      printer you no longer use.
     </li>
     <li>
-      <strong>Correct what&rsquo;s left.</strong> &ldquo;I weighed the grey PLA —
-      it&rsquo;s actually 640&nbsp;g now.&rdquo; Adjust a spool&rsquo;s remaining
-      amount up or down.
+      <strong>Add material.</strong> &ldquo;Add a new 1&nbsp;kg spool of
+      Prusament Galaxy Black PLA.&rdquo; New material goes straight into your
+      inventory. This isn&rsquo;t just filament: resin and powder work too,
+      along with details like brand, colour, finish, price, and where you store
+      it.
+    </li>
+    <li>
+      <strong>Update material details.</strong> &ldquo;Move the blue PLA to Dry
+      Box B&rdquo; or &ldquo;mark the Galaxy Black as a favourite.&rdquo;
+      Storage location, colour, temperatures, and purchase details can all be
+      corrected after the fact.
+    </li>
+    <li>
+      <strong>Correct what&rsquo;s left.</strong> &ldquo;I weighed the grey PLA.
+      It&rsquo;s actually 640&nbsp;g now.&rdquo; Adjust a spool&rsquo;s
+      remaining amount up or down. It can&rsquo;t go below empty or above what
+      the spool started with, so if a correction is refused, check the starting
+      amount on the spool itself.
     </li>
     <li>
       <strong>Retire or restore a spool.</strong> &ldquo;Retire the empty black
@@ -120,12 +154,20 @@
       back later.
     </li>
   </ul>
+  <p>
+    Most of the value comes from combining these in one go, rather than doing
+    them one at a time. &ldquo;Log the three prints I finished this weekend,
+    file them under a new Desk Organizer project, and tell me how much filament
+    they used between them&rdquo; is a single request, and the assistant works
+    out the steps. If you&rsquo;re not sure whether something is possible, just
+    ask for it and see.
+  </p>
   <p class="hint">
-    Logging is safe to repeat — asking twice for the same print won&rsquo;t
+    Logging is safe to repeat: asking twice for the same print won&rsquo;t
     create a duplicate. Because a
     <a routerLink="/docs/integrations">slicer integration</a> may already have
-    imported a print for you, the assistant will usually check before logging one
-    itself.
+    imported a print for you, the assistant will usually check before logging
+    one itself.
   </p>
 
   <h2>What you&rsquo;ll need</h2>
@@ -141,9 +183,9 @@
     </dd>
   </dl>
   <p class="hint">
-    The Client ID is the same for everyone and is safe to share &mdash; it
-    identifies the 3D Print Log connector, not you. There is no client secret.
-    You still sign in yourself, and the assistant only ever sees your own data.
+    The Client ID is the same for everyone and is safe to share. It identifies
+    the 3D Print Log connector, not you. There is no client secret. You still
+    sign in yourself, and the assistant only ever sees your own data.
   </p>
 
   <h2>Connect to Claude</h2>
@@ -163,7 +205,7 @@
       <strong>authorize</strong> access to your print data.
     </li>
     <li>
-      Start a chat and ask about your prints, printers, or filament — or ask
+      Start a chat and ask about your prints, printers, or filament, or ask
       Claude to log or update a print. Claude will use the connector when
       relevant.
     </li>

--- a/src/app/documentation/docs/docs-mcp/docs-mcp.component.html
+++ b/src/app/documentation/docs/docs-mcp/docs-mcp.component.html
@@ -26,9 +26,13 @@
       (titles, statuses, material usage, dates, and stats) is shared.
     </li>
     <li>
-      <strong>No print settings.</strong> Layer heights, temperatures, and
-      speeds aren&rsquo;t available to the assistant, so it can&rsquo;t tell you
-      what settings a past print used.
+      <strong>Print settings only where you saved them.</strong> Layer height,
+      speeds, and temperatures aren&rsquo;t separate fields &mdash; they live in
+      a print&rsquo;s notes. If you imported the print through a
+      <a routerLink="/docs/integrations">slicer integration</a>, that summary is
+      saved for you and the assistant can read it back. For a print logged by
+      hand with no such notes, the assistant has nothing to read and can&rsquo;t
+      answer.
     </li>
   </ul>
 
@@ -56,6 +60,11 @@
       <strong>Your printers.</strong> &ldquo;What&rsquo;s loaded on my Bambu
       right now?&rdquo; and per-printer stats such as success rates and total
       print time.
+    </li>
+    <li>
+      <strong>The settings you used.</strong> &ldquo;What layer height and
+      speeds did I use on the soap dish?&rdquo; &mdash; answerable for prints
+      whose notes hold a slicer summary (see the limitation above).
     </li>
   </ul>
 

--- a/src/app/documentation/docs/docs-mcp/docs-mcp.component.scss
+++ b/src/app/documentation/docs/docs-mcp/docs-mcp.component.scss
@@ -15,4 +15,32 @@
   ul {
     line-height: 1.6;
   }
+
+  .connection-details {
+    margin: 16px 0;
+
+    dt {
+      font-weight: 600;
+      margin-top: 12px;
+    }
+
+    dd {
+      margin: 4px 0 0;
+
+      code {
+        display: inline-block;
+        max-width: 100%;
+        padding: 8px 12px;
+        border-radius: 6px;
+        font-family: monospace;
+        word-break: break-all;
+        background: var(--mat-sys-surface-container-high, #f0f0f0);
+      }
+    }
+  }
+
+  .hint {
+    font-size: 0.9em;
+    opacity: 0.85;
+  }
 }

--- a/src/app/documentation/docs/docs-mcp/docs-mcp.component.scss
+++ b/src/app/documentation/docs/docs-mcp/docs-mcp.component.scss
@@ -1,0 +1,18 @@
+.docs-mcp {
+  .endpoint {
+    padding: 12px 16px;
+    border-radius: 6px;
+    overflow-x: auto;
+    background: var(--mat-sys-surface-container-high, #f0f0f0);
+
+    code {
+      font-family: monospace;
+      word-break: break-all;
+    }
+  }
+
+  ol,
+  ul {
+    line-height: 1.6;
+  }
+}

--- a/src/app/documentation/docs/docs-mcp/docs-mcp.component.spec.ts
+++ b/src/app/documentation/docs/docs-mcp/docs-mcp.component.spec.ts
@@ -31,6 +31,15 @@ describe('DocsMcpComponent', () => {
     expect(text).toContain(component.mcpEndpoint);
   });
 
+  it('shows the OAuth client id and the Claude Code command', () => {
+    // Without the client id a user cannot complete a connection at all: Dynamic Client
+    // Registration is disabled, so no client can discover it on its own.
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain(component.mcpClientId);
+    expect(text).toContain('Advanced settings');
+    expect(text).toContain(component.claudeCodeCommand);
+  });
+
   it('describes what the assistant can be asked, including printers', () => {
     const text = fixture.nativeElement.textContent as string;
     expect(text).toContain('What you can ask');

--- a/src/app/documentation/docs/docs-mcp/docs-mcp.component.spec.ts
+++ b/src/app/documentation/docs/docs-mcp/docs-mcp.component.spec.ts
@@ -53,6 +53,15 @@ describe('DocsMcpComponent', () => {
     expect(text).toContain('Log a finished print');
   });
 
+  it('covers every entity the assistant can create, not just prints', () => {
+    // A verified MCP run created a printer and a resin as well as prints, so the page
+    // must not leave users thinking writes stop at prints and spools of filament.
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Add a printer');
+    expect(text).toContain('Add material');
+    expect(text).toContain('Update material details');
+  });
+
   it('qualifies print settings as note-dependent rather than promising or denying them', () => {
     // Layer height and speeds are not fields: they are readable only when a slicer
     // integration saved a summary into the print's notes. The page must neither promise

--- a/src/app/documentation/docs/docs-mcp/docs-mcp.component.spec.ts
+++ b/src/app/documentation/docs/docs-mcp/docs-mcp.component.spec.ts
@@ -1,0 +1,33 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { DocsMcpComponent } from './docs-mcp.component';
+
+describe('DocsMcpComponent', () => {
+  let component: DocsMcpComponent;
+  let fixture: ComponentFixture<DocsMcpComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [DocsMcpComponent],
+      imports: [RouterTestingModule],
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DocsMcpComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create (renders without a logged-in user)', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('renders the connect steps and the MCP endpoint URL', () => {
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Connect to Claude');
+    expect(text).toContain('Connect to ChatGPT');
+    expect(text).toContain(component.mcpEndpoint);
+  });
+});

--- a/src/app/documentation/docs/docs-mcp/docs-mcp.component.spec.ts
+++ b/src/app/documentation/docs/docs-mcp/docs-mcp.component.spec.ts
@@ -38,10 +38,12 @@ describe('DocsMcpComponent', () => {
     expect(text).toContain('Your materials');
   });
 
-  it('does not promise print settings the assistant cannot read', () => {
-    // Layer heights, temperatures, and speeds live only in free-text notes, so the
-    // assistant cannot answer them. The page must say so rather than imply otherwise.
+  it('qualifies print settings as note-dependent rather than promising or denying them', () => {
+    // Layer height and speeds are not fields: they are readable only when a slicer
+    // integration saved a summary into the print's notes. The page must neither promise
+    // them outright nor deny them outright — a verified MCP run answered them from notes.
     const text = fixture.nativeElement.textContent as string;
-    expect(text).toContain('No print settings');
+    expect(text).toContain('Print settings only where you saved them');
+    expect(text).toContain('slicer integration');
   });
 });

--- a/src/app/documentation/docs/docs-mcp/docs-mcp.component.spec.ts
+++ b/src/app/documentation/docs/docs-mcp/docs-mcp.component.spec.ts
@@ -42,9 +42,15 @@ describe('DocsMcpComponent', () => {
 
   it('describes what the assistant can be asked, including printers', () => {
     const text = fixture.nativeElement.textContent as string;
-    expect(text).toContain('What you can ask');
+    expect(text).toContain('Questions you can ask');
     expect(text).toContain('Your printers');
     expect(text).toContain('Your materials');
+  });
+
+  it('describes the write actions the assistant can take', () => {
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('Changes it can make for you');
+    expect(text).toContain('Log a finished print');
   });
 
   it('qualifies print settings as note-dependent rather than promising or denying them', () => {

--- a/src/app/documentation/docs/docs-mcp/docs-mcp.component.spec.ts
+++ b/src/app/documentation/docs/docs-mcp/docs-mcp.component.spec.ts
@@ -30,4 +30,18 @@ describe('DocsMcpComponent', () => {
     expect(text).toContain('Connect to ChatGPT');
     expect(text).toContain(component.mcpEndpoint);
   });
+
+  it('describes what the assistant can be asked, including printers', () => {
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('What you can ask');
+    expect(text).toContain('Your printers');
+    expect(text).toContain('Your materials');
+  });
+
+  it('does not promise print settings the assistant cannot read', () => {
+    // Layer heights, temperatures, and speeds live only in free-text notes, so the
+    // assistant cannot answer them. The page must say so rather than imply otherwise.
+    const text = fixture.nativeElement.textContent as string;
+    expect(text).toContain('No print settings');
+  });
 });

--- a/src/app/documentation/docs/docs-mcp/docs-mcp.component.ts
+++ b/src/app/documentation/docs/docs-mcp/docs-mcp.component.ts
@@ -1,0 +1,16 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+  selector: 'app-docs-mcp',
+  templateUrl: './docs-mcp.component.html',
+  styleUrls: ['./docs-mcp.component.scss'],
+  standalone: false,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DocsMcpComponent {
+  /**
+   * The remote MCP endpoint URL that AI clients connect to.
+   * NOTE (Task 20): confirm the production host before launch.
+   */
+  public readonly mcpEndpoint = 'https://api.3dprintlog.com/mcp';
+}

--- a/src/app/documentation/docs/docs-mcp/docs-mcp.component.ts
+++ b/src/app/documentation/docs/docs-mcp/docs-mcp.component.ts
@@ -8,9 +8,19 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class DocsMcpComponent {
-  /**
-   * The remote MCP endpoint URL that AI clients connect to.
-   * NOTE (Task 20): confirm the production host before launch.
-   */
+  /** The remote MCP endpoint URL that AI clients connect to. */
   public readonly mcpEndpoint = 'https://api.3dprintlog.com/mcp';
+
+  /**
+   * Public OAuth client id for the MCP connector. Safe to publish: this is a public
+   * (PKCE) client with no secret, which is exactly why every user can share one id.
+   * Clients cannot discover it automatically (Dynamic Client Registration is off), so
+   * without it on this page nobody can complete a connection.
+   */
+  public readonly mcpClientId = 'uzxvtpefYIrWoYbaJteoRzZtIYw4wP7j';
+
+  /** Ready-to-paste command for the Claude Code CLI. */
+  public readonly claudeCodeCommand =
+    `claude mcp add --transport http printlog ${this.mcpEndpoint} ` +
+    `--client-id ${this.mcpClientId} --callback-port 8400`;
 }

--- a/src/app/documentation/documentation-routing.module.ts
+++ b/src/app/documentation/documentation-routing.module.ts
@@ -4,6 +4,7 @@ import { RouterModule, Routes } from '@angular/router';
 import { DocsAboutComponent } from './docs/docs-about/docs-about.component';
 import { DocsAnalyticsComponent } from './docs/docs-analytics/docs-analytics.component';
 import { DocsAndroidAppComponent } from './docs/docs-android-app/docs-android-app.component';
+import { DocsMcpComponent } from './docs/docs-mcp/docs-mcp.component';
 import { DocsCuraPluginComponent } from './docs/docs-cura-plugin/docs-cura-plugin.component';
 import { DocsFilamentsComponent } from './docs/docs-filaments/docs-filaments.component';
 import { DocsGettingStartedComponent } from './docs/docs-getting-started/docs-getting-started.component';
@@ -35,6 +36,7 @@ const routes: Routes = [
       { path: 'materials', component: DocsFilamentsComponent },
       { path: 'analytics', component: DocsAnalyticsComponent },
       { path: 'android-app', component: DocsAndroidAppComponent },
+      { path: 'mcp', component: DocsMcpComponent },
       { path: 'cura-plugin', component: DocsCuraPluginComponent },
       { path: 'octoprint-webhook', component: DocsOctoprintWebhookComponent },
       { path: 'klipper', component: DocsMoonrakerComponent },

--- a/src/app/documentation/documentation.module.ts
+++ b/src/app/documentation/documentation.module.ts
@@ -17,6 +17,7 @@ import { DocsReleaseNotesComponent } from './docs/docs-release-notes/docs-releas
 import { DocumentationRoutingModule } from './documentation-routing.module';
 import { DocumentationComponent } from './documentation.component';
 import { DocsAndroidAppComponent } from './docs/docs-android-app/docs-android-app.component';
+import { DocsMcpComponent } from './docs/docs-mcp/docs-mcp.component';
 import { DocsMoonrakerComponent } from './docs/docs-moonraker/docs-moonraker.component';
 import { DocsTermsComponent } from './docs/docs-terms/docs-terms.component';
 import { DocsPrivacyPolicyComponent } from './docs/docs-privacy-policy/docs-privacy-policy.component';
@@ -39,6 +40,7 @@ import { DocsProjectsComponent } from './docs/docs-projects/docs-projects.compon
     DocsOctoprintWebhookComponent,
     DocsMoonrakerComponent,
     DocsAndroidAppComponent,
+    DocsMcpComponent,
     DocsTermsComponent,
     DocsPrivacyPolicyComponent,
     DocsSlic3rUploaderComponent,

--- a/src/app/settings/connected-agents/connected-agents.component.html
+++ b/src/app/settings/connected-agents/connected-agents.component.html
@@ -1,0 +1,55 @@
+<h2>Connected AI Agents</h2>
+<p>
+  AI assistants (such as Claude or ChatGPT) that you have connected to your 3D
+  Print Log data. Connected agents have read-only access to your prints,
+  printers, and materials.
+</p>
+
+@if (status() === 'loading') {
+  <mat-spinner diameter="28" aria-label="Loading connected agents" />
+} @else if (status() === 'error') {
+  <p>We couldn't load your connected AI agents.</p>
+  <button mat-stroked-button (click)="load()">Retry</button>
+} @else {
+  @if (agents().length === 0) {
+    <p>No AI agents connected.</p>
+  } @else {
+    <ul class="agent-list">
+      @for (agent of agents(); track agent.grantId) {
+        <li>
+          <mat-icon inline>smart_toy</mat-icon>
+          <span>{{ agent.clientId }}</span>
+        </li>
+      }
+    </ul>
+
+    @if (!confirming()) {
+      <button mat-raised-button color="warn" (click)="startConfirm()">
+        Disconnect all AI agents
+      </button>
+    } @else {
+      <p>
+        Disconnect all connected AI agents? They will immediately lose access to
+        your 3D Print Log data.
+      </p>
+      <div class="confirm-actions">
+        <button
+          mat-raised-button
+          color="warn"
+          [disabled]="submitting()"
+          (click)="disconnectAll()"
+        >
+          Yes, disconnect all
+        </button>
+        <button mat-stroked-button [disabled]="submitting()" (click)="cancel()">
+          Cancel
+        </button>
+      </div>
+      @if (revokeFailed()) {
+        <p class="error-text">
+          Something went wrong disconnecting your agents. Please try again.
+        </p>
+      }
+    }
+  }
+}

--- a/src/app/settings/connected-agents/connected-agents.component.scss
+++ b/src/app/settings/connected-agents/connected-agents.component.scss
@@ -1,0 +1,22 @@
+.agent-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 12px;
+
+  li {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 4px 0;
+  }
+}
+
+.confirm-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.error-text {
+  color: var(--mat-sys-error, #b00020);
+}

--- a/src/app/settings/connected-agents/connected-agents.component.spec.ts
+++ b/src/app/settings/connected-agents/connected-agents.component.spec.ts
@@ -1,0 +1,132 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Observable, of, Subject, throwError } from 'rxjs';
+import {
+  ConnectedAgent,
+  ConnectedAgentsService,
+} from '../../core/services/connected-agents.service';
+import { LoggingService } from '../../core/services/logging.service';
+import { ConnectedAgentsComponent } from './connected-agents.component';
+
+describe('ConnectedAgentsComponent', () => {
+  let service: jasmine.SpyObj<ConnectedAgentsService>;
+  let logging: jasmine.SpyObj<LoggingService>;
+  let fixture: ComponentFixture<ConnectedAgentsComponent>;
+
+  const sampleAgents: ConnectedAgent[] = [
+    { grantId: 'grant-1', clientId: 'Claude', scopes: ['read:printdata'] },
+  ];
+
+  beforeEach(async () => {
+    service = jasmine.createSpyObj<ConnectedAgentsService>(
+      'ConnectedAgentsService',
+      ['getConnectedAgents', 'revoke']
+    );
+    logging = jasmine.createSpyObj<LoggingService>('LoggingService', [
+      'logEvent',
+    ]);
+
+    await TestBed.configureTestingModule({
+      imports: [ConnectedAgentsComponent, NoopAnimationsModule],
+      providers: [
+        { provide: ConnectedAgentsService, useValue: service },
+        { provide: LoggingService, useValue: logging },
+      ],
+    }).compileComponents();
+  });
+
+  function create(): void {
+    fixture = TestBed.createComponent(ConnectedAgentsComponent);
+    fixture.detectChanges();
+  }
+
+  function text(): string {
+    return fixture.nativeElement.textContent as string;
+  }
+
+  function clickButton(label: string): void {
+    const button = Array.from(
+      fixture.nativeElement.querySelectorAll('button')
+    ).find((b) =>
+      ((b as HTMLButtonElement).textContent ?? '').trim().includes(label)
+    ) as HTMLButtonElement | undefined;
+    if (!button) {
+      throw new Error(`Button "${label}" not found`);
+    }
+    button.click();
+    fixture.detectChanges();
+  }
+
+  it('shows a spinner while loading', () => {
+    service.getConnectedAgents.and.returnValue(new Subject<ConnectedAgent[]>());
+    create();
+    expect(fixture.nativeElement.querySelector('mat-spinner')).toBeTruthy();
+  });
+
+  it('renders the empty state when there are no agents', () => {
+    service.getConnectedAgents.and.returnValue(of([]));
+    create();
+    expect(text()).toContain('No AI agents connected.');
+  });
+
+  it('renders connected agents and a disconnect-all action', () => {
+    service.getConnectedAgents.and.returnValue(of(sampleAgents));
+    create();
+    expect(text()).toContain('Claude');
+    expect(text()).toContain('Disconnect all AI agents');
+  });
+
+  it('shows an error state with retry when loading fails', () => {
+    service.getConnectedAgents.and.returnValue(
+      throwError(() => new Error('boom'))
+    );
+    create();
+    expect(text()).toContain("couldn't load");
+    expect(text()).toContain('Retry');
+  });
+
+  it('confirms inline, revokes each grant, logs, then reloads', () => {
+    service.getConnectedAgents.and.returnValue(of(sampleAgents));
+    service.revoke.and.returnValue(of(undefined));
+    create();
+
+    clickButton('Disconnect all AI agents');
+    expect(text()).toContain('Yes, disconnect all');
+
+    // After a successful disconnect, the list is reloaded (now empty).
+    service.getConnectedAgents.and.returnValue(of([]));
+    clickButton('Yes, disconnect all');
+
+    expect(service.revoke).toHaveBeenCalledWith('grant-1');
+    expect(logging.logEvent).toHaveBeenCalledWith(
+      'ConnectedAgents_Revoke',
+      jasmine.objectContaining({ count: 1 })
+    );
+    expect(text()).toContain('No AI agents connected.');
+  });
+
+  it('does not submit twice while a revoke is in flight', () => {
+    service.getConnectedAgents.and.returnValue(of(sampleAgents));
+    service.revoke.and.returnValue(new Subject<void>()); // never completes
+    create();
+
+    clickButton('Disconnect all AI agents');
+    clickButton('Yes, disconnect all');
+    // Second click while pending must be ignored.
+    clickButton('Yes, disconnect all');
+
+    expect(service.revoke).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the agents and offers retry when a revoke fails', () => {
+    service.getConnectedAgents.and.returnValue(of(sampleAgents));
+    service.revoke.and.returnValue(throwError(() => new Error('nope')));
+    create();
+
+    clickButton('Disconnect all AI agents');
+    clickButton('Yes, disconnect all');
+
+    expect(text()).toContain('Claude'); // row preserved
+    expect(text()).toContain('Please try again.');
+  });
+});

--- a/src/app/settings/connected-agents/connected-agents.component.spec.ts
+++ b/src/app/settings/connected-agents/connected-agents.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { Observable, of, Subject, throwError } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 import {
   ConnectedAgent,
   ConnectedAgentsService,

--- a/src/app/settings/connected-agents/connected-agents.component.ts
+++ b/src/app/settings/connected-agents/connected-agents.component.ts
@@ -1,0 +1,102 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  OnInit,
+  signal,
+} from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { forkJoin, of } from 'rxjs';
+import {
+  ConnectedAgent,
+  ConnectedAgentsService,
+} from '../../core/services/connected-agents.service';
+import { LoggingService } from '../../core/services/logging.service';
+
+type LoadStatus = 'loading' | 'ready' | 'error';
+
+/**
+ * Lists the user's connected AI agents and lets them disconnect all of them.
+ *
+ * The MCP integration uses a single shared OAuth client, so revocation is per user
+ * (not per AI product/device). The UI therefore offers a single "Disconnect all"
+ * action rather than per-agent removal.
+ */
+@Component({
+  selector: 'app-connected-agents',
+  templateUrl: './connected-agents.component.html',
+  styleUrl: './connected-agents.component.scss',
+  imports: [MatButtonModule, MatIconModule, MatProgressSpinnerModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ConnectedAgentsComponent implements OnInit {
+  private readonly connectedAgentsService = inject(ConnectedAgentsService);
+  private readonly loggingService = inject(LoggingService);
+
+  protected readonly status = signal<LoadStatus>('loading');
+  protected readonly agents = signal<ConnectedAgent[]>([]);
+  protected readonly confirming = signal(false);
+  protected readonly submitting = signal(false);
+  protected readonly revokeFailed = signal(false);
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  protected load(): void {
+    this.status.set('loading');
+    this.confirming.set(false);
+    this.revokeFailed.set(false);
+    this.connectedAgentsService.getConnectedAgents().subscribe({
+      next: (agents) => {
+        this.agents.set(agents);
+        this.status.set('ready');
+      },
+      error: () => this.status.set('error'),
+    });
+  }
+
+  protected startConfirm(): void {
+    this.confirming.set(true);
+    this.revokeFailed.set(false);
+  }
+
+  protected cancel(): void {
+    this.confirming.set(false);
+  }
+
+  protected disconnectAll(): void {
+    if (this.submitting()) {
+      return;
+    }
+
+    const grants = this.agents();
+    this.submitting.set(true);
+    this.revokeFailed.set(false);
+    this.loggingService.logEvent('ConnectedAgents_Revoke', {
+      count: grants.length,
+    });
+
+    const revocations = grants.length
+      ? forkJoin(
+          grants.map((agent) =>
+            this.connectedAgentsService.revoke(agent.grantId)
+          )
+        )
+      : of([]);
+
+    revocations.subscribe({
+      next: () => {
+        this.submitting.set(false);
+        this.load();
+      },
+      error: () => {
+        // Keep the rows and let the user retry; nothing was necessarily removed.
+        this.submitting.set(false);
+        this.revokeFailed.set(true);
+      },
+    });
+  }
+}

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -633,6 +633,10 @@
       </div>
       <hr />
       <div fxFlex="grow" fxFlexFill>
+        <app-connected-agents />
+      </div>
+      <hr />
+      <div fxFlex="grow" fxFlexFill>
         <h2>Danger Zone</h2>
         <details style="border: 1px solid red; padding: 5px">
           <summary>

--- a/src/app/settings/settings.component.spec.ts
+++ b/src/app/settings/settings.component.spec.ts
@@ -16,6 +16,8 @@ import { MetaTagService } from '../core/services/meta-tag.service';
 import { ToastrService } from 'ngx-toastr';
 import { SubscriptionService } from '../core/services/subscription.service';
 import { LoggingService } from '../core/services/logging.service';
+import { ConnectedAgentsComponent } from './connected-agents/connected-agents.component';
+import { ConnectedAgentsService } from '../core/services/connected-agents.service';
 
 xdescribe('SettingsComponent (original)', () => {
   let component: SettingsComponent;
@@ -114,8 +116,20 @@ describe('SettingsComponent', () => {
 
     TestBed.configureTestingModule({
       declarations: [SettingsComponent],
-      imports: [SharedModule, NoopAnimationsModule, RouterTestingModule],
+      imports: [
+        SharedModule,
+        NoopAnimationsModule,
+        RouterTestingModule,
+        ConnectedAgentsComponent,
+      ],
       providers: [
+        {
+          provide: ConnectedAgentsService,
+          useValue: {
+            getConnectedAgents: () => of([]),
+            revoke: () => of(undefined),
+          },
+        },
         { provide: ActivatedRoute, useValue: mockActivatedRoute },
         { provide: AuthService, useValue: mockAuthService },
         { provide: UserService, useValue: mockUserService },

--- a/src/app/settings/settings.module.ts
+++ b/src/app/settings/settings.module.ts
@@ -5,10 +5,11 @@ import { CurrenciesResolverService } from '../core/resolvers/currencies-resolver
 import { CurrentUserDetailResolverService } from './resolvers/current-user-detail-resolver.service';
 import { SettingsRoutingModule } from './settings-routing.module';
 import { SettingsComponent } from './settings.component';
+import { ConnectedAgentsComponent } from './connected-agents/connected-agents.component';
 
 @NgModule({
   declarations: [SettingsComponent],
-  imports: [SharedModule, SettingsRoutingModule],
+  imports: [SharedModule, SettingsRoutingModule, ConnectedAgentsComponent],
   providers: [CurrentUserDetailResolverService],
 })
 export class SettingsModule {}


### PR DESCRIPTION
## Summary

UI for the read-only **MCP (Model Context Protocol)** integration, letting users connect AI assistants (Claude/ChatGPT) to their 3D Print Log data and manage those connections. Pairs with the API PR (3d-print-log-api #21).

## What's included

- **`ConnectedAgentsService`** — `getConnectedAgents()` / `revoke(grantId)` against `/api/connected-agents`.
- **"Connected AI Agents" settings section** — standalone, OnPush, signals, native control flow. Loads the user's connected agents and offers a single inline-confirmed **"Disconnect all AI agents"** action (shared-client model), with loading / empty / error / retry states. Logs `ConnectedAgents_Revoke`.
- **"Connect an AI Assistant" documentation page** (`/docs/mcp`) — what MCP is, the read-only scope, the endpoint URL, and Connect-to-Claude / Connect-to-ChatGPT steps. Prerendered for SEO (wired into both route sources, `doc-seo.config`, sidebar, and `marketing-routes`).

## Testing

- Unit suite: **676 passed, 0 failed**; lint clean.
- `npm run build:dev`, production `npm run build` (prerender), and the prerender verification gate all pass — `/docs/mcp/index.html` has unique title/description, canonical, and OG/Twitter tags (27 routes verified).

## Notes

- The docs page's production MCP endpoint host is marked for confirmation at launch (Task 20).


---

## v1 gap remediation — docs update

The `/docs/mcp` page now reflects what the v1 tool surface can actually answer, alongside the API-side remediation (api#21):

- Adds a **"What you can ask"** section: prints (status breakdown, search by name or project, per-material breakdown of a multi-colour print), materials (whole-word matching, storage location), whether a print's material requirement is met by one spool or only by combining several, and printers (what's loaded right now, per-printer stats).
- Adds an explicit **"No print settings"** limitation. Layer heights, temperatures, and speeds live only in free-text notes and are not exposed, so the page must not imply an assistant can answer them.
- Spec assertions pin both, so the page can't silently drift back into promising either.

UI suite: **678 passed**, lint and prettier clean.
