### PR TITLE
Release 1.44.0 - Connect an AI Assistant (MCP)

### DIFF
--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -13,6 +13,14 @@ Create a new release with release notes.
    git log v{current_version}..HEAD --oneline
    ```
 4. If there's no tag for the current version, look for the most recent tag
+5. Get the PR number for each change (needed for the release notes links, see below):
+   ```bash
+   git log v{current_version}..HEAD --merges --oneline
+   ```
+   Merge commits read `Merge pull request #N from <branch>`, which maps each PR number to the
+   branch (and therefore to the changes) it delivered. Squash-merged PRs instead carry the number
+   in the commit subject as `(#N)`. For anything still unmatched, fall back to
+   `gh pr list --state merged --limit 20 --json number,title,mergedAt`.
 
 ### 2. Ask User for Release Type
 
@@ -48,12 +56,27 @@ Format for new release notes:
 <p>[Second paragraph for additional major features, if any. Each distinct feature gets its own paragraph.]</p>
 <h4>Full List of Changes:</h4>
 <ul>
-  <li><strong>[Feature/Fix Name]</strong> - [Description]</li>
+  <li><strong>[Feature/Fix Name]</strong> - [Description] (<a href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/[N]" rel="noreferrer noopener" target="_blank">PR #[N]</a>)</li>
   <!-- More list items as needed -->
 </ul>
 ```
 
 Place the new section after the `<hr />` and before the previous version's `<h3>`.
+
+**Always link the PR on every bullet where one exists.** Use the PR numbers gathered in step 1.
+
+- Link **every** bullet that has a PR, not just some. Partial coverage reads as though the
+  unlinked items are less real, which is worse than linking none.
+- One PR can back several bullets (a large feature PR often delivers more than one user-visible
+  change). Repeat the same link on each bullet it applies to.
+- If a change has no PR (committed straight to `main`), leave that bullet unlinked rather than
+  guessing at a number. Never invent or approximate a PR number.
+- Link the **UI** repo (`3d-print-log-ui`) by default, since these are the UI release notes. When a
+  feature is delivered mainly by the API, link the API PR too
+  (`https://github.com/HoffmanEngineering/3d-print-log-api/pull/[N]`) and label it `API PR #[N]` to
+  distinguish it.
+- Verify each PR is actually **merged** before linking it (`gh pr view [N] --json state`). Linking
+  an open or closed PR in shipped notes points users at something that isn't in the release.
 
 #### 4.3 Update Version Dialog Service
 
@@ -150,6 +173,9 @@ Remind the user:
 - Use separate `<p>` paragraphs for each distinct major feature — do not run multiple features together in one paragraph
 - The summary paragraph(s) should read as a narrative description, not a changelog list
 - The bullet list is where full detail lives; the paragraph(s) above are the "why it matters" summary
+- **Every bullet links its PR** where one exists (see 4.2). Keep PR links out of the summary paragraphs and the dialog body; they belong on the bullets only
+- Reference a prior **version** (not a PR) when it explains user-visible history, e.g. "an issue introduced in 1.43.9" — that means something to a user in a way a PR number does not
+- **Do not run `prettier --write` on this file.** It has pre-existing formatting drift, so a blanket rewrite reformats ~500 unrelated lines and buries the release diff. `prettier --check` also reports it as non-compliant for the same reason; that failure is expected and is not caused by your section. Hand-format your new section to match the surrounding style and confirm with `git diff --stat` that only your lines changed
 
 ### Dialog Body (`version-release-note-dialog.service.ts`)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "print-log-ui",
-  "version": "1.43.11",
+  "version": "1.44.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --ssl --host 0.0.0.0 ",

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -28,6 +28,34 @@ export class VersionReleaseNoteDialogService {
   private readonly LOCAL_STORAGE_KEY = 'LastLoggedInVersion';
 
   private releaseNotes: ReleaseNoteHistory = {
+    '1.44.0': {
+      title: '1.44.0 - Connect an AI Assistant',
+      body: `<p>
+<strong>Connect an AI Assistant</strong> is here! 3D Print Log now works with Claude, ChatGPT, and other AI assistants, so you can just ask: "how much blue PLA do I have left?", "do I have enough for a 300 g model?", or "log that Benchy I finished on the Bambu." Your assistant reads your prints, printers, and inventory, and with your permission it can log and update prints, projects, printers, and materials (it can never delete anything, and it only ever sees your own data).
+</p>
+<p>
+Setup takes a minute and you can disconnect at any time from <a href="/settings">Settings</a>. See <a href="/docs/mcp">Connect an AI Assistant</a> to get started.
+</p>
+<p>
+  <strong>Support development of 3D Print Log:</strong><br />
+  <a href="/subscription">Subscribe to Pro</a> for an ad-free experience and extra cloud storage,
+  buy me a coffee by <a
+    href="https://paypal.me/hoffmanengineering"
+    rel="noreferrer noopener"
+    target="_blank"
+    >donating via PayPal</a
+  >, or by becoming a
+  <a
+    href="https://www.patreon.com/HoffmanEngineering"
+    rel="noreferrer noopener"
+    target="_blank"
+  >
+    Patron of Hoffman Engineering</a
+  >
+  on Patreon.com
+  </p><p>Share <strong>3D Print Log</strong> with a friend, and Happy Printing!
+</p>`,
+    },
     '1.43.11': {
       redirect: '1.43.10',
     },

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -34,7 +34,7 @@ export class VersionReleaseNoteDialogService {
 <strong>Connect an AI Assistant</strong> is here! 3D Print Log now works with Claude, ChatGPT, and other AI assistants, so you can just ask: "how much blue PLA do I have left?", "do I have enough for a 300 g model?", or "log that Benchy I finished on the Bambu." Your assistant reads your prints, printers, and inventory, and with your permission it can log and update prints, projects, printers, and materials (it can never delete anything, and it only ever sees your own data).
 </p>
 <p>
-Setup takes a minute and you can disconnect at any time from <a href="/settings">Settings</a>. See <a href="/docs/mcp">Connect an AI Assistant</a> to get started.
+Connecting uses the <strong>Model Context Protocol (MCP)</strong>, an open standard supported by Claude, Claude Code, and ChatGPT. Setup takes a minute and you can disconnect at any time from <a href="/settings">Settings</a>. See <a href="/docs/mcp">Connect an AI Assistant (MCP)</a> to get started.
 </p>
 <p>
   <strong>Support development of 3D Print Log:</strong><br />

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -29,7 +29,7 @@ export class VersionReleaseNoteDialogService {
 
   private releaseNotes: ReleaseNoteHistory = {
     '1.44.0': {
-      title: '1.44.0 - Connect an AI Assistant',
+      title: '1.44.0 - Connect an AI Assistant (MCP)',
       body: `<p>
 <strong>Connect an AI Assistant</strong> is here! 3D Print Log now works with Claude, ChatGPT, and other AI assistants, so you can just ask: "how much blue PLA do I have left?", "do I have enough for a 300 g model?", or "log that Benchy I finished on the Bambu." Your assistant reads your prints, printers, and inventory, and with your permission it can log and update prints, projects, printers, and materials (it can never delete anything, and it only ever sees your own data).
 </p>

--- a/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
+++ b/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
@@ -2,6 +2,51 @@
   <h2>Release Notes</h2>
   <hr />
 
+  <h3 id="v1.44.0">1.44.0 - Connect an AI Assistant</h3>
+  <p>
+    3D Print Log now connects to AI assistants like Claude and ChatGPT. Once connected, you can ask
+    about your prints, printers, and material inventory in your own words ("how much blue PLA do I
+    have left?" or "do I have enough for a 300 g model?"), and with your permission the assistant can
+    log and update prints, organize projects, add printers, and keep your spool inventory current.
+    The assistant can never delete anything, only ever sees data you created, and never touches the
+    printer itself. See <a routerLink="/docs/mcp">Connect an AI Assistant</a> for setup
+    instructions, and manage or disconnect assistants at any time from your
+    <a routerLink="/settings">Settings</a> page.
+  </p>
+  <p>
+    This release also includes a handful of fixes for filament values, image uploads, and public
+    print pages.
+  </p>
+  <h4>Full List of Changes:</h4>
+  <ul>
+    <li>
+      <strong>Connect an AI Assistant</strong> - Link Claude, Claude Code, or ChatGPT to your account
+      so it can read your prints, printers, and materials, and log or update them on your behalf.
+    </li>
+    <li>
+      <strong>Connected AI Agents settings</strong> - Review which assistants have access and
+      disconnect them at any time from the Settings page.
+    </li>
+    <li>
+      <strong>Empty filament values no longer save as zero</strong> - Leaving nominal weight, length,
+      volume, or an adjustment weight blank now keeps the field empty instead of recording a zero.
+    </li>
+    <li>
+      <strong>Image upload limit fixed</strong> - The per-print image limit is now enforced correctly
+      while uploads are still in progress, and uploads wait until existing files have finished
+      loading.
+    </li>
+    <li>
+      <strong>Public prints for logged-out visitors</strong> - Fixed an issue where a public print
+      page could bounce anonymous visitors back to the home page instead of showing the print.
+    </li>
+    <li>
+      <strong>Faster perceived load</strong> - Pages now show a lightweight loading shell while the
+      app starts up.
+    </li>
+  </ul>
+  <hr />
+
   <h3 id="v1.43.11">1.43.11 - QR Label Printing Fix</h3>
   <p>
     Fixed a bug where the Print QR Labels dialog would get stuck on "Generating QR codes" and never

--- a/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
+++ b/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
@@ -2,7 +2,7 @@
   <h2>Release Notes</h2>
   <hr />
 
-  <h3 id="v1.44.0">1.44.0 - Connect an AI Assistant</h3>
+  <h3 id="v1.44.0">1.44.0 - Connect an AI Assistant (MCP)</h3>
   <p>
     3D Print Log now connects to AI assistants like Claude and ChatGPT. Once connected, you can ask
     about your prints, printers, and material inventory in your own words ("how much blue PLA do I
@@ -22,27 +22,73 @@
     <li>
       <strong>Connect an AI Assistant</strong> - Link Claude, Claude Code, or ChatGPT to your account
       so it can read your prints, printers, and materials, and log or update them on your behalf.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/73"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #73</a
+      >)
     </li>
     <li>
       <strong>Connected AI Agents settings</strong> - Review which assistants have access and
       disconnect them at any time from the Settings page.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/73"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #73</a
+      >)
     </li>
     <li>
       <strong>Empty filament values no longer save as zero</strong> - Leaving nominal weight, length,
       volume, or an adjustment weight blank now keeps the field empty instead of recording a zero.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/72"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #72</a
+      >)
     </li>
     <li>
       <strong>Image upload limit fixed</strong> - The per-print image limit is now enforced correctly
       while uploads are still in progress, and uploads wait until existing files have finished
       loading.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/70"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #70</a
+      >)
+    </li>
+    <li>
+      <strong>Private print details kept out of error reports</strong> - Fixed an issue where the
+      full contents of a print could be included in an internal error report if saving failed.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/71"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #71</a
+      >)
     </li>
     <li>
       <strong>Public prints for logged-out visitors</strong> - Fixed an issue where a public print
       page could bounce anonymous visitors back to the home page instead of showing the print.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/68"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #68</a
+      >)
     </li>
     <li>
       <strong>Faster perceived load</strong> - Pages now show a lightweight loading shell while the
       app starts up.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/67"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #67</a
+      >)
     </li>
   </ul>
   <hr />


### PR DESCRIPTION
@
Cuts the 1.44.0 minor release. The headline feature is the MCP server, letting users connect Claude, Claude Code, or ChatGPT to their account.

## Changes

- `package.json` - version 1.43.11 -> 1.44.0
- `version-release-note-dialog.service.ts` - real release note for 1.44.0 (not a redirect), focused on MCP and encouraging users to connect an assistant
- `docs-release-notes.component.html` - full 1.44.0 notes, with a PR link on every bullet
- `.claude/commands/release.md` - release skill now harvests PR numbers from merge commits and requires a PR link on every bullet

## Release contents

| Change | PR |
| --- | --- |
| Connect an AI Assistant | #73 |
| Connected AI Agents settings | #73 |
| Empty filament values no longer save as zero | #72 |
| Image upload limit fixed | #70 |
| Private print details kept out of error reports | #71 |
| Public prints for logged-out visitors | #68 |
| Faster perceived load | #67 |

## Before merging

- The dialog fires for every user on 1.43.11 or earlier and points them at `/docs/mcp`, so the prod MCP endpoint and Auth0 client need to be live.
- The notes and dialog promise write capability. That landed in API PR #24 (merged 2026-07-16); API PR #21 was read-only. Confirm #24 is deployed to prod.

## Verification

- `npm run lint:brief` - clean
- `npm run test:brief` - 699 passing

Note: `docs-release-notes.component.html` has pre-existing prettier drift, so the new section is hand-formatted to keep the diff scoped. Running `prettier --write` on it reformats ~500 unrelated lines.

## After merge

`git tag v1.44.0 && git push origin v1.44.0`, then approve the deploy gate.
@