### PR TITLE
Cover MCP and print data in the privacy policy

### DIFF
--- a/src/app/documentation/docs/docs-privacy-policy/docs-privacy-policy.component.html
+++ b/src/app/documentation/docs/docs-privacy-policy/docs-privacy-policy.component.html
@@ -1,6 +1,6 @@
 <div class="docs-markdown">
   <h1>Privacy Policy for 3D Print Log</h1>
-  <p>Last Updated: Feb 5, 2024</p>
+  <p>Last Updated: Jul 30, 2026</p>
 
   <p>
     At 3D Print Log, accessible from https://www.3dprintlog.com, one of our main
@@ -12,6 +12,117 @@
   <p>
     If you have additional questions or require more information about our
     Privacy Policy, do not hesitate to contact us.
+  </p>
+
+  <h2>The Data You Store in 3D Print Log</h2>
+
+  <p>
+    When you create an account, you give us the data you choose to record: your
+    prints, printers, materials and projects, along with any notes, comments and
+    images you attach to them, and your profile and account preferences.
+  </p>
+
+  <p>
+    We use this data to provide the service to you: to show you your own
+    records, calculate your statistics, and power features such as inventory
+    tracking. Your prints and projects are private by default; only records you
+    explicitly mark as public or unlisted are visible to anyone else.
+  </p>
+
+  <p>
+    We rely on a small number of service providers to run 3D Print Log. Sign-in
+    is handled by Auth0, so we never store your password. The application, its
+    database and your uploaded images are hosted on Microsoft Azure. These
+    providers process your data on our behalf in order to operate the service.
+  </p>
+
+  <h2>Connecting an AI Assistant (MCP)</h2>
+
+  <p>
+    3D Print Log can be connected to an AI assistant, such as Claude or ChatGPT,
+    using the Model Context Protocol (MCP). This is entirely optional and off
+    until you set it up. See
+    <a routerLink="/docs/mcp">Connect an AI Assistant (MCP)</a> for what the
+    feature does and how to enable it. Because connecting an assistant sends
+    your print data to another company, please read this section before you do.
+  </p>
+
+  <p>
+    <strong>You authorize the connection yourself.</strong> Connecting an
+    assistant requires you to sign in to 3D Print Log and approve the request.
+    You grant either read access to your print data, or read and write access.
+    We do not enable this for you and we do not share your data with any AI
+    provider unless you have connected one.
+  </p>
+
+  <p>
+    <strong>What is sent.</strong> Once connected, the assistant can request
+    your structured print data: your prints, printers, materials, projects and
+    the statistics derived from them, including notes. Photos, images and
+    comments are not available to it. Data is sent only in response to a request
+    the assistant makes while connected, which is normally the result of
+    something you asked it.
+  </p>
+
+  <p>
+    <strong>Only your own records.</strong> An assistant connected to your
+    account can only ever read or change records you created. It cannot reach
+    another user's data, including prints that user has made public.
+  </p>
+
+  <p>
+    <strong>What it can change.</strong> If you granted write access, the
+    assistant can create and edit prints, printers, materials and projects on
+    your behalf. It cannot delete anything: there is no way for a connected
+    assistant to delete a print, project or spool.
+  </p>
+
+  <p>
+    <strong
+      >Once your data reaches the AI provider, that provider's privacy policy
+      governs it.</strong
+    >
+    3D Print Log has no access to or control over how Anthropic, OpenAI or any
+    other AI provider stores, retains, or uses the data their assistant
+    receives, or whether it is used to train their models. This is the most
+    important thing to understand before connecting one. Please consult the
+    privacy policy and data-retention settings of the assistant you intend to
+    use.
+  </p>
+
+  <p>
+    <strong>You can disconnect at any time.</strong> Your
+    <a routerLink="/settings">Settings</a> page lists every connected assistant
+    under <strong>Connected AI Agents</strong>, and disconnecting takes effect
+    immediately. Revoking access stops any further data being sent, but it
+    cannot recall data an assistant already received.
+  </p>
+
+  <p>
+    <strong>What we record about MCP requests.</strong> To operate the service,
+    diagnose faults and enforce rate limits, we record limited technical
+    telemetry for each request an assistant makes: which tool was called,
+    whether it succeeded or failed, how long it took, and an irreversible hash
+    that distinguishes one account from another without identifying it. We do
+    not record the contents of the request or the print data returned.
+  </p>
+
+  <h2>Data Retention and Deletion</h2>
+
+  <p>
+    We keep the data you record for as long as your account is open, so that
+    your print history remains available to you.
+  </p>
+
+  <p>
+    You can delete your account at any time from the
+    <strong>Danger Zone</strong> section of your
+    <a routerLink="/settings">Settings</a> page. Deactivated accounts have all
+    of their data deleted 24 hours after deactivation, including recorded
+    prints, printers, filaments, comments, images and your profile. Deletion is
+    irreversible: once it occurs there is no way to recover your data. You are
+    welcome to create a new account later, but no previously deleted data can be
+    restored to it.
   </p>
 
   <h2>Log Files</h2>
@@ -54,23 +165,18 @@
   <p>
     Google is one of a third-party vendor on our site. It also uses cookies,
     known as DART cookies, to serve ads to our site visitors based upon their
-    visit to www.website.com and other sites on the internet. However, visitors
-    may choose to decline the use of DART cookies by visiting the Google ad and
-    content network Privacy Policy at the following URL –
+    visit to www.3dprintlog.com and other sites on the internet. However,
+    visitors may choose to decline the use of DART cookies by visiting the
+    Google ad and content network Privacy Policy at the following URL –
     <a href="https://policies.google.com/technologies/ads"
       >https://policies.google.com/technologies/ads</a
     >
   </p>
 
-  <h2>Privacy Policies</h2>
-
-  <P
-    >You may consult this list to find the Privacy Policy for each of the
-    advertising partners of 3D Print Log.</P
-  >
+  <h2>Third Party Privacy Policies</h2>
 
   <p>
-    Third-party ad servers or ad networks uses technologies like cookies,
+    Third-party ad servers or ad networks use technologies like cookies,
     JavaScript, or Web Beacons that are used in their respective advertisements
     and links that appear on 3D Print Log, which are sent directly to users'
     browser. They automatically receive your IP address when this occurs. These
@@ -83,8 +189,6 @@
     Note that 3D Print Log has no access to or control over these cookies that
     are used by third-party advertisers.
   </p>
-
-  <h2>Third Party Privacy Policies</h2>
 
   <p>
     3D Print Log's Privacy Policy does not apply to other advertisers or
@@ -123,6 +227,20 @@
     visitors to our website with regards to the information that they shared
     and/or collect in 3D Print Log. This policy is not applicable to any
     information collected offline or via channels other than this website.
+  </p>
+
+  <h2>Contact Us</h2>
+
+  <p>
+    If you have a question about this Privacy Policy, about the data we hold for
+    you, or about a request to delete it, email us at
+    <a href="mailto:hello@3dprintlog.com">hello&#64;3dprintlog.com</a>.
+  </p>
+
+  <p>
+    If you already have an account, you can also reach us through the
+    <a routerLink="/feedback">feedback form</a> while signed in, and we will
+    respond to the email address on your account.
   </p>
 
   <h2>Consent</h2>

--- a/src/llms.txt
+++ b/src/llms.txt
@@ -6,6 +6,17 @@
 
 - [Home](https://www.3dprintlog.com/): Overview and free account signup.
 - [Documentation](https://www.3dprintlog.com/docs/getting-started): Getting started, features, and integrations.
+- [Connect an AI Assistant (MCP)](https://www.3dprintlog.com/docs/mcp): How to connect Claude, Claude Code, or ChatGPT to a 3D Print Log account.
+- [Privacy Policy](https://www.3dprintlog.com/docs/privacy-policy): What data is stored, what is shared with a connected AI assistant, and how to delete an account.
+
+## MCP server
+
+3D Print Log has a remote MCP (Model Context Protocol) server, so an AI assistant can read and update a user's own print data on their behalf.
+
+- Endpoint: `https://api.3dprintlog.com/mcp` (Streamable HTTP)
+- Auth: OAuth 2.1. The user signs in to 3D Print Log and authorizes access; there is no API key. Setup instructions and the public OAuth client id are on the [MCP documentation page](https://www.3dprintlog.com/docs/mcp).
+- Read tools cover prints, printers, material inventory, projects, and per-printer statistics. Write tools log and edit prints, manage projects, printers, and materials, and adjust remaining filament.
+- Scoped to the authenticated user's own records, and no tool can delete anything.
 
 ## Notes
 


### PR DESCRIPTION
## Why

The privacy policy was generator boilerplate from Feb 2024 — Log Files, Cookies, DoubleClick, ad networks, Children's Information, Consent. It said **nothing** about the data users actually store here, and nothing about the fact that connecting an AI assistant sends their prints to another company.

That's now a blocker: Anthropic's Connectors Directory treats an incomplete privacy policy as an **immediate rejection**, and its stated coverage bar is data collection, usage and storage, third-party sharing, retention, and contact information.

## What's added

Facts checked against the code rather than assumed:

- **The Data You Store in 3D Print Log** — what's collected, private-by-default, and the processors (Auth0 for sign-in so no passwords stored; Azure for app, database, images).
- **Connecting an AI Assistant (MCP)** — opt-in authorization, read vs read+write scopes, what is sent (structured records and notes, *not* photos or comments), creator-only scope, create/edit but **never delete**, and — called out as the most important point — that **the AI provider's own policy governs the data once it arrives**, including whether it trains their models. Plus revocation via Settings → Connected AI Agents and its limits.
- **What we record about MCP requests** — tool name, outcome, duration, and an irreversible account hash; never request contents or returned data. This mirrors exactly what `McpLoggingTests` pins in the API, which asserts the hash is 16 hex chars containing neither the Auth0 subject nor the internal id.
- **Data Retention and Deletion** — the real 24-hour deactivation behaviour, quoted from the Settings danger zone so the policy and the UI agree.
- **Contact Us** — `hello@3dprintlog.com`. The policy previously said "do not hesitate to contact us" while offering no way to do so.

## Pre-existing defects fixed

- A stray `www.website.com` left in the DoubleClick section by the generator.
- A "you may consult this list" reference to an advertising-partner list that **did not exist**. Its two ad-network paragraphs moved under the existing **Third Party Privacy Policies** heading, which already covered that topic — removing the broken cross-reference, a duplicate heading, and a stray uppercase `<P>` tag in one go. The ad content itself stayed, since Pro is marketed as ad-free.

## `llms.txt`

Already shipped as a build asset but didn't mention MCP at all. Now carries an **MCP server** section naming the endpoint, the OAuth-not-API-key model, the tool categories, and the creator-only/no-delete guarantees, plus links to `/docs/mcp` and `/docs/privacy-policy`. Agents increasingly find servers by search rather than registry lookup, so this is the cheapest discoverability win available.

## Notes for review

- `@` in the mailto link text is written `&#64;` — Angular 21 treats a bare `@` in templates as the control-flow sigil.
- The docs page at `/docs/mcp` needed no changes; it already covers setup thoroughly.
- **This is a legal page and I'm not a lawyer.** I described what the code does and deliberately made no commitments on your behalf — there's no "we never sell your data" line, for example. Worth a read-through before merge.

## Verification

- Prettier clean; `build:dev` compiles with no errors; `test:ci` **699 passing**, identical to the pre-change baseline.
- Confirmed `llms.txt` reaches `dist/` with the endpoint intact.