### PR TITLE
feat(analytics): Phase 2 Part A — Activity and Printers tabs

### DIFF
--- a/cypress/e2e/analytics/analytics-activity.cy.ts
+++ b/cypress/e2e/analytics/analytics-activity.cy.ts
@@ -1,0 +1,61 @@
+const VIEWPORTS: [number, number][] = [
+  [375, 667],
+  [768, 1024],
+  [1440, 900],
+];
+
+describe('Analytics — Activity tab', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  VIEWPORTS.forEach(([width, height]) => {
+    it(`renders without horizontal body scroll at ${width}x${height}`, () => {
+      cy.viewport(width, height);
+      cy.visit('/analytics');
+      cy.contains('.mat-mdc-tab', 'Activity').click();
+
+      cy.get('app-activity-tab').should('exist');
+
+      // The page body must never scroll sideways. Wide content scrolls inside its own box.
+      cy.document().then((doc) => {
+        expect(doc.documentElement.scrollWidth).to.be.at.most(
+          doc.documentElement.clientWidth + 1
+        );
+      });
+    });
+  });
+
+  it('keeps the calendar scroll inside its own container', () => {
+    cy.viewport(375, 667);
+    cy.visit('/analytics');
+    cy.contains('.mat-mdc-tab', 'Activity').click();
+
+    cy.get('.calendar-heatmap').should(($el) => {
+      expect($el[0].scrollWidth).to.be.greaterThan($el[0].clientWidth - 1);
+    });
+  });
+
+  it('switches the plotted metric without a page reload', () => {
+    cy.viewport(1440, 900);
+    cy.visit('/analytics');
+    cy.contains('.mat-mdc-tab', 'Activity').click();
+
+    cy.contains('mat-button-toggle', 'Filament').click();
+    cy.contains('Filament (grams) over time').should('exist');
+  });
+
+  it('clicking a calendar day opens a date-filtered print list', () => {
+    cy.viewport(1440, 900);
+    cy.visit('/analytics');
+    cy.contains('.mat-mdc-tab', 'Activity').click();
+
+    cy.get('rect.calendar-heatmap__hit').first().click({ force: true });
+
+    cy.location('pathname').should('eq', '/prints');
+    cy.location('search').should('include', 'fromDate=');
+    cy.location('search').should('include', 'toDate=');
+    // Click-through URLs must never carry userId — that would show only PUBLIC prints.
+    cy.location('search').should('not.include', 'userId=');
+  });
+});

--- a/cypress/e2e/analytics/analytics-printers.cy.ts
+++ b/cypress/e2e/analytics/analytics-printers.cy.ts
@@ -1,0 +1,41 @@
+describe('Analytics — Printers tab', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('renders the card layout on a phone and the table on desktop', () => {
+    cy.viewport(375, 667);
+    cy.visit('/analytics');
+    cy.contains('.mat-mdc-tab', 'Printers').click();
+
+    cy.get('.printer-comparison__card').should('exist');
+    cy.get('table.printer-comparison__table').should('not.exist');
+
+    cy.viewport(1440, 900);
+    cy.get('table.printer-comparison__table').should('exist');
+  });
+
+  it('never lets the comparison table scroll the page body', () => {
+    cy.viewport(375, 667);
+    cy.visit('/analytics');
+    cy.contains('.mat-mdc-tab', 'Printers').click();
+
+    cy.document().then((doc) => {
+      expect(doc.documentElement.scrollWidth).to.be.at.most(
+        doc.documentElement.clientWidth + 1
+      );
+    });
+  });
+
+  it('sorts the comparison table when a column header is clicked', () => {
+    cy.viewport(1440, 900);
+    cy.visit('/analytics');
+    cy.contains('.mat-mdc-tab', 'Printers').click();
+
+    cy.contains('th button', 'Prints').click();
+    cy.get('th button')
+      .contains('Prints')
+      .parents('th')
+      .should('have.attr', 'aria-sort', 'ascending');
+  });
+});

--- a/src/app/analytics/analytics-shell.component.html
+++ b/src/app/analytics/analytics-shell.component.html
@@ -10,5 +10,11 @@
         <app-overview-tab />
       }
     </mat-tab>
+
+    <mat-tab label="Activity">
+      @if (tabGroup.selectedIndex === 1) {
+        <app-activity-tab />
+      }
+    </mat-tab>
   </mat-tab-group>
 </section>

--- a/src/app/analytics/analytics-shell.component.html
+++ b/src/app/analytics/analytics-shell.component.html
@@ -3,22 +3,26 @@
 
   <app-analytics-filter-bar />
 
-  <mat-tab-group [mat-stretch-tabs]="false" #tabGroup>
+  <mat-tab-group
+    [mat-stretch-tabs]="false"
+    [selectedIndex]="selectedIndex()"
+    (selectedIndexChange)="onTabChange($event)"
+  >
     <mat-tab label="Overview">
       <!-- Guarded so later phases' tabs only build on first activation. -->
-      @if (tabGroup.selectedIndex === 0) {
+      @if (selectedIndex() === 0) {
         <app-overview-tab />
       }
     </mat-tab>
 
     <mat-tab label="Activity">
-      @if (tabGroup.selectedIndex === 1) {
+      @if (selectedIndex() === 1) {
         <app-activity-tab />
       }
     </mat-tab>
 
     <mat-tab label="Printers">
-      @if (tabGroup.selectedIndex === 2) {
+      @if (selectedIndex() === 2) {
         <app-printers-tab />
       }
     </mat-tab>

--- a/src/app/analytics/analytics-shell.component.html
+++ b/src/app/analytics/analytics-shell.component.html
@@ -16,5 +16,11 @@
         <app-activity-tab />
       }
     </mat-tab>
+
+    <mat-tab label="Printers">
+      @if (tabGroup.selectedIndex === 2) {
+        <app-printers-tab />
+      }
+    </mat-tab>
   </mat-tab-group>
 </section>

--- a/src/app/analytics/analytics-shell.component.ts
+++ b/src/app/analytics/analytics-shell.component.ts
@@ -9,6 +9,7 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { ActivatedRoute } from '@angular/router';
 import { AnalyticsFilterBarComponent } from './filters/analytics-filter-bar.component';
 import { AnalyticsFilterStore } from './filters/analytics-filter.store';
+import { ActivityTabComponent } from './tabs/activity/activity-tab.component';
 import { OverviewTabComponent } from './tabs/overview/overview-tab.component';
 
 /**
@@ -20,7 +21,12 @@ import { OverviewTabComponent } from './tabs/overview/overview-tab.component';
  */
 @Component({
   selector: 'app-analytics-shell',
-  imports: [AnalyticsFilterBarComponent, MatTabsModule, OverviewTabComponent],
+  imports: [
+    ActivityTabComponent,
+    AnalyticsFilterBarComponent,
+    MatTabsModule,
+    OverviewTabComponent,
+  ],
   providers: [AnalyticsFilterStore],
   templateUrl: './analytics-shell.component.html',
   styleUrls: ['./analytics-shell.component.scss'],

--- a/src/app/analytics/analytics-shell.component.ts
+++ b/src/app/analytics/analytics-shell.component.ts
@@ -11,6 +11,7 @@ import { AnalyticsFilterBarComponent } from './filters/analytics-filter-bar.comp
 import { AnalyticsFilterStore } from './filters/analytics-filter.store';
 import { ActivityTabComponent } from './tabs/activity/activity-tab.component';
 import { OverviewTabComponent } from './tabs/overview/overview-tab.component';
+import { PrintersTabComponent } from './tabs/printers/printers-tab.component';
 
 /**
  * Owns the single AnalyticsFilterStore instance for the page. The filter bar, the mobile
@@ -26,6 +27,7 @@ import { OverviewTabComponent } from './tabs/overview/overview-tab.component';
     AnalyticsFilterBarComponent,
     MatTabsModule,
     OverviewTabComponent,
+    PrintersTabComponent,
   ],
   providers: [AnalyticsFilterStore],
   templateUrl: './analytics-shell.component.html',

--- a/src/app/analytics/analytics-shell.component.ts
+++ b/src/app/analytics/analytics-shell.component.ts
@@ -3,10 +3,11 @@ import {
   Component,
   OnInit,
   inject,
+  signal,
 } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { MatTabsModule } from '@angular/material/tabs';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { AnalyticsFilterBarComponent } from './filters/analytics-filter-bar.component';
 import { AnalyticsFilterStore } from './filters/analytics-filter.store';
 import { ActivityTabComponent } from './tabs/activity/activity-tab.component';
@@ -36,12 +37,41 @@ import { PrintersTabComponent } from './tabs/printers/printers-tab.component';
 })
 export class AnalyticsShellComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
   private readonly store = inject(AnalyticsFilterStore);
   private readonly title = inject(Title);
+
+  /**
+   * Tab order is the URL contract. Slugs rather than the raw index so the link stays
+   * meaningful and survives a tab being inserted before another one.
+   */
+  private static readonly TABS = ['overview', 'activity', 'printers'] as const;
+
+  readonly selectedIndex = signal(0);
 
   ngOnInit(): void {
     this.title.setTitle('Analytics - 3D Print Log');
     // The URL is the store's serialization, so a shared or reloaded link restores the view.
     this.store.initFromUrl(this.route.snapshot.queryParams);
+
+    const slug = this.route.snapshot.queryParams['tab'];
+    const index = AnalyticsShellComponent.TABS.indexOf(slug);
+    if (index >= 0) this.selectedIndex.set(index);
+  }
+
+  /**
+   * The selected tab belongs in the URL for the same reason the filters do: drilling into a
+   * print from the Printers tab and pressing back, or simply reloading, otherwise silently
+   * returns to Overview and loses where the reader was.
+   */
+  onTabChange(index: number): void {
+    this.selectedIndex.set(index);
+
+    void this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { tab: AnalyticsShellComponent.TABS[index] ?? null },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
   }
 }

--- a/src/app/analytics/models/analytics.models.ts
+++ b/src/app/analytics/models/analytics.models.ts
@@ -26,6 +26,9 @@ export const ExclusionReason = {
   OutlierExcluded: 'OutlierExcluded',
   SampleTooSmall: 'SampleTooSmall',
   RowCapExceeded: 'RowCapExceeded',
+  DurationMissing: 'DurationMissing',
+  WindowTruncated: 'WindowTruncated',
+  UnattributedMaterial: 'UnattributedMaterial',
 } as const;
 
 export interface CoverageExclusion {

--- a/src/app/analytics/models/analytics.models.ts
+++ b/src/app/analytics/models/analytics.models.ts
@@ -99,3 +99,103 @@ export interface OverviewResponse {
     priciestPrint: HighlightRef | null;
   };
 }
+
+export interface ActivitySeriesBucket {
+  index: number;
+  localStart: string;
+  count: number;
+  durationSeconds: number;
+  materialMg: number;
+  /** Null for the whole series when the server's cost row cap was exceeded. */
+  cost: number | null;
+}
+
+export interface CalendarDay {
+  date: string;
+  count: number;
+}
+
+export interface StreakSummary {
+  currentDays: number;
+  longestDays: number;
+  longestStart: string | null;
+  longestEnd: string | null;
+  busiestDate: string | null;
+  busiestDateCount: number;
+  /** 0-6, Sunday = 0. */
+  busiestWeekday: number | null;
+  busiestWeekdayCount: number;
+}
+
+export interface HistogramBucket {
+  label: string;
+  lowerSeconds: number;
+  upperSeconds: number | null;
+  count: number;
+}
+
+export interface MatrixCell {
+  weekday: number;
+  hour: number;
+  count: number;
+}
+
+export interface ActivityResponse {
+  from: string | null;
+  to: string | null;
+  timeZone: string;
+  granularity: Exclude<AnalyticsGranularity, 'Auto'>;
+  currency: string | null;
+  series: ActivitySeriesBucket[];
+  calendar: CalendarDay[];
+  calendarFrom: string | null;
+  calendarTo: string | null;
+  streaks: StreakSummary;
+  durationHistogram: HistogramBucket[];
+  startTimeMatrix: MatrixCell[];
+  coverage: Coverage;
+}
+
+export interface PrinterRow {
+  printerId: number;
+  name: string | null;
+  isIdle: boolean;
+  printCount: number;
+  successRatePercent: number | null;
+  printTimeSeconds: number;
+  materialMg: number;
+  avgDurationSeconds: number | null;
+  cost: number | null;
+  maintenanceCost: number | null;
+  utilizationPercent: number | null;
+  costPerPrintHour: number | null;
+}
+
+export interface PrinterSeriesBucket {
+  index: number;
+  localStart: string;
+  /** Keyed by printer id as a string. */
+  printSecondsByPrinterId: Record<string, number>;
+}
+
+export interface MaintenanceEvent {
+  id: string;
+  printerId: number;
+  date: string;
+  category: string | null;
+  description: string | null;
+  cost: number | null;
+}
+
+export interface PrintersResponse {
+  from: string | null;
+  to: string | null;
+  timeZone: string;
+  granularity: Exclude<AnalyticsGranularity, 'Auto'>;
+  currency: string | null;
+  printers: PrinterRow[];
+  timeSeries: PrinterSeriesBucket[];
+  fleetUtilizationPercent: Metric;
+  maintenance: MaintenanceEvent[];
+  coverage: Coverage;
+}

--- a/src/app/analytics/services/analytics.service.spec.ts
+++ b/src/app/analytics/services/analytics.service.spec.ts
@@ -71,6 +71,30 @@ describe('AnalyticsService', () => {
     req.flush(null);
   });
 
+  it('requests activity with the same serialized filter as overview', () => {
+    const expected = service.toHttpParams(filter);
+
+    service.getActivity(filter).subscribe();
+
+    const req = http.expectOne(
+      (r) =>
+        r.url === `${environment.printLogApiUrl}/api/analytics/activity` &&
+        r.params.toString() === expected.toString()
+    );
+    expect(req.request.method).toBe('GET');
+    req.flush({});
+  });
+
+  it('requests printers from its own endpoint', () => {
+    service.getPrinters(filter).subscribe();
+
+    const req = http.expectOne(
+      (r) => r.url === `${environment.printLogApiUrl}/api/analytics/printers`
+    );
+    expect(req.request.method).toBe('GET');
+    req.flush({});
+  });
+
   it('omits empty id arrays entirely rather than sending blanks', () => {
     service
       .getOverview({ ...filter, printerIds: [], statuses: [] })

--- a/src/app/analytics/services/analytics.service.ts
+++ b/src/app/analytics/services/analytics.service.ts
@@ -3,8 +3,10 @@ import { Injectable, inject } from '@angular/core';
 import { Observable } from 'rxjs';
 import { environment } from 'src/environments/environment';
 import {
+  ActivityResponse,
   AnalyticsFilterValue,
   OverviewResponse,
+  PrintersResponse,
 } from '../models/analytics.models';
 
 @Injectable({ providedIn: 'root' })
@@ -14,6 +16,18 @@ export class AnalyticsService {
 
   getOverview(filter: AnalyticsFilterValue): Observable<OverviewResponse> {
     return this.http.get<OverviewResponse>(`${this.baseUrl}/overview`, {
+      params: this.toHttpParams(filter),
+    });
+  }
+
+  getActivity(filter: AnalyticsFilterValue): Observable<ActivityResponse> {
+    return this.http.get<ActivityResponse>(`${this.baseUrl}/activity`, {
+      params: this.toHttpParams(filter),
+    });
+  }
+
+  getPrinters(filter: AnalyticsFilterValue): Observable<PrintersResponse> {
+    return this.http.get<PrintersResponse>(`${this.baseUrl}/printers`, {
       params: this.toHttpParams(filter),
     });
   }

--- a/src/app/analytics/tabs/activity/activity-tab.component.html
+++ b/src/app/analytics/tabs/activity/activity-tab.component.html
@@ -1,0 +1,150 @@
+<div class="activity-tab">
+  <mat-button-toggle-group
+    class="activity-tab__metric"
+    aria-label="Metric to plot"
+    [value]="metric()"
+    (change)="setMetric($event.value)"
+  >
+    <mat-button-toggle value="count">Prints</mat-button-toggle>
+    <mat-button-toggle value="time">Print time</mat-button-toggle>
+    <mat-button-toggle value="filament">Filament</mat-button-toggle>
+    <mat-button-toggle value="cost" [disabled]="!costAvailable()"
+      >Cost</mat-button-toggle
+    >
+  </mat-button-toggle-group>
+
+  <div class="activity-tab__charts">
+    <app-chart-frame
+      class="activity-tab__chart activity-tab__chart--wide"
+      #seriesFrame
+      [title]="seriesLabels[metric()] + ' over time'"
+      [state]="state()"
+      [coverage]="data()?.coverage ?? null"
+      [ariaSummary]="seriesAriaSummary()"
+      emptyMessage="No prints in this date range yet."
+      (retry)="onRetry()"
+    >
+      <app-bar-chart
+        [data]="seriesData()"
+        [series]="series"
+        [width]="seriesFrame.width()"
+        [height]="seriesFrame.height()"
+      />
+      <table chartDataTable>
+        <caption>
+          {{ seriesLabels[metric()] }} per period
+        </caption>
+        <tbody>
+          @for (row of seriesData(); track row.fullLabel) {
+            <tr>
+              <th scope="row">{{ row.fullLabel }}</th>
+              <td>{{ row.values['value'] }}</td>
+            </tr>
+          }
+        </tbody>
+      </table>
+    </app-chart-frame>
+
+    <app-chart-frame
+      class="activity-tab__chart activity-tab__chart--wide"
+      #calendarFrame
+      title="Activity calendar"
+      [state]="state()"
+      [coverage]="data()?.coverage ?? null"
+      [ariaSummary]="streakSummary()"
+      emptyMessage="No prints in this date range yet."
+      (retry)="onRetry()"
+    >
+      <p class="activity-tab__streaks">{{ streakSummary() }}</p>
+      <app-calendar-heatmap
+        [days]="data()?.calendar ?? []"
+        [width]="calendarFrame.width()"
+        [height]="calendarFrame.height()"
+        (daySelect)="onDaySelect($event)"
+      />
+      <table chartDataTable>
+        <caption>
+          Prints per day
+        </caption>
+        <tbody>
+          @for (day of data()?.calendar ?? []; track day.date) {
+            <tr>
+              <th scope="row">{{ day.date }}</th>
+              <td>{{ day.count }}</td>
+            </tr>
+          }
+        </tbody>
+      </table>
+    </app-chart-frame>
+
+    <app-chart-frame
+      class="activity-tab__chart"
+      #histogramFrame
+      title="How long prints take"
+      [state]="state()"
+      [coverage]="data()?.coverage ?? null"
+      ariaSummary="Distribution of print durations"
+      emptyMessage="No prints with a recorded duration yet."
+      (retry)="onRetry()"
+    >
+      <app-bar-chart
+        [data]="histogramData()"
+        [series]="series"
+        [width]="histogramFrame.width()"
+        [height]="histogramFrame.height()"
+      />
+      <table chartDataTable>
+        <caption>
+          Prints by duration
+        </caption>
+        <tbody>
+          @for (bucket of data()?.durationHistogram ?? []; track bucket.label) {
+            <tr>
+              <th scope="row">{{ bucket.label }}</th>
+              <td>{{ bucket.count }}</td>
+            </tr>
+          }
+        </tbody>
+      </table>
+    </app-chart-frame>
+
+    <app-chart-frame
+      class="activity-tab__chart"
+      #matrixFrame
+      title="When you start prints"
+      [state]="state()"
+      [coverage]="data()?.coverage ?? null"
+      ariaSummary="Prints started by weekday and hour of day"
+      emptyMessage="No prints in this date range yet."
+      (retry)="onRetry()"
+    >
+      <app-matrix-heatmap
+        [cells]="data()?.startTimeMatrix ?? []"
+        [rowLabels]="weekdays"
+        [columnLabels]="hours"
+        [width]="matrixFrame.width()"
+        [height]="matrixFrame.height()"
+      />
+      <table chartDataTable>
+        <caption>
+          Prints started by weekday and hour
+        </caption>
+        <tbody>
+          @for (
+            cell of data()?.startTimeMatrix ?? [];
+            track cell.weekday + '-' + cell.hour
+          ) {
+            @if (cell.count > 0) {
+              <tr>
+                <th scope="row">
+                  {{ weekdays[cell.weekday] }} {{ cell.hour }}:00
+                </th>
+                <td>{{ cell.count }}</td>
+              </tr>
+            }
+          }
+        </tbody>
+      </table>
+    </app-chart-frame>
+  </div>
+</div>

--- a/src/app/analytics/tabs/activity/activity-tab.component.html
+++ b/src/app/analytics/tabs/activity/activity-tab.component.html
@@ -1,21 +1,7 @@
 <div class="activity-tab">
-  <mat-button-toggle-group
-    class="activity-tab__metric"
-    aria-label="Metric to plot"
-    [value]="metric()"
-    (change)="setMetric($event.value)"
-  >
-    <mat-button-toggle value="count">Prints</mat-button-toggle>
-    <mat-button-toggle value="time">Print time</mat-button-toggle>
-    <mat-button-toggle value="filament">Filament</mat-button-toggle>
-    <mat-button-toggle value="cost" [disabled]="!costAvailable()"
-      >Cost</mat-button-toggle
-    >
-  </mat-button-toggle-group>
-
   <div class="activity-tab__charts">
     <app-chart-frame
-      class="activity-tab__chart activity-tab__chart--wide"
+      class="activity-tab__chart"
       #seriesFrame
       [title]="seriesLabels[metric()] + ' over time'"
       [state]="state()"
@@ -24,6 +10,26 @@
       emptyMessage="No prints in this date range yet."
       (retry)="onRetry()"
     >
+      <!--
+        Projected into THIS panel's header rather than floating above the tab. Sitting at
+        the top of the page it read as a global switch, while it only ever re-plots this
+        one chart; inside the card the scope is obvious without a word of explanation.
+      -->
+      <mat-button-toggle-group
+        chartActions
+        class="activity-tab__metric"
+        aria-label="Metric to plot"
+        [value]="metric()"
+        (change)="setMetric($event.value)"
+      >
+        <mat-button-toggle value="count">Prints</mat-button-toggle>
+        <mat-button-toggle value="time">Print time</mat-button-toggle>
+        <mat-button-toggle value="filament">Filament</mat-button-toggle>
+        <mat-button-toggle value="cost" [disabled]="!costAvailable()"
+          >Cost</mat-button-toggle
+        >
+      </mat-button-toggle-group>
+
       <app-bar-chart
         [data]="seriesData()"
         [series]="series"
@@ -46,9 +52,10 @@
     </app-chart-frame>
 
     <app-chart-frame
-      class="activity-tab__chart activity-tab__chart--wide"
+      class="activity-tab__chart"
       #calendarFrame
       title="Activity calendar"
+      fit="natural"
       [state]="state()"
       [coverage]="data()?.coverage ?? null"
       [ariaSummary]="streakSummary()"

--- a/src/app/analytics/tabs/activity/activity-tab.component.scss
+++ b/src/app/analytics/tabs/activity/activity-tab.component.scss
@@ -1,0 +1,34 @@
+.activity-tab {
+  display: grid;
+  gap: 0.5rem;
+  container-type: inline-size;
+  min-inline-size: 0;
+}
+
+.activity-tab__metric {
+  justify-self: start;
+}
+
+.activity-tab__charts {
+  display: grid;
+  gap: 0.5rem;
+  // Container queries, not media queries: the side nav collapsing changes available width
+  // without a viewport change.
+  grid-template-columns: minmax(0, 1fr);
+}
+
+@container (min-width: 900px) {
+  .activity-tab__charts {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .activity-tab__chart--wide {
+    grid-column: 1 / -1;
+  }
+}
+
+.activity-tab__streaks {
+  margin: 0 0 0.5rem;
+  font-size: 0.875rem;
+  color: var(--chart-axis-text);
+}

--- a/src/app/analytics/tabs/activity/activity-tab.component.scss
+++ b/src/app/analytics/tabs/activity/activity-tab.component.scss
@@ -6,7 +6,8 @@
 }
 
 .activity-tab__metric {
-  justify-self: start;
+  // Sits in the panel header now, so it must not stretch the row.
+  flex: 0 0 auto;
 }
 
 .activity-tab__charts {
@@ -15,6 +16,10 @@
   // Container queries, not media queries: the side nav collapsing changes available width
   // without a viewport change.
   grid-template-columns: minmax(0, 1fr);
+  // Grid rows stretch by default, which dragged the naturally-short calendar panel up to
+  // the height of the tall chart beside it and reintroduced the empty space the natural
+  // fit exists to avoid.
+  align-items: start;
 }
 
 @container (min-width: 900px) {
@@ -22,9 +27,9 @@
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .activity-tab__chart--wide {
-    grid-column: 1 / -1;
-  }
+  // Nothing spans both columns any more. Full-width panels were what made a single chart
+  // taller than the viewport on a 1440px screen; the calendar pairs naturally beside the
+  // series chart at half width, and 53 weeks still fit there without scrolling.
 }
 
 .activity-tab__streaks {

--- a/src/app/analytics/tabs/activity/activity-tab.component.spec.ts
+++ b/src/app/analytics/tabs/activity/activity-tab.component.spec.ts
@@ -1,0 +1,193 @@
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { AnalyticsFilterStore } from '../../filters/analytics-filter.store';
+import { ActivityResponse } from '../../models/analytics.models';
+import { AnalyticsService } from '../../services/analytics.service';
+import { ActivityTabComponent } from './activity-tab.component';
+
+const response = (
+  overrides: Partial<ActivityResponse> = {}
+): ActivityResponse => ({
+  from: null,
+  to: null,
+  timeZone: 'UTC',
+  granularity: 'Day',
+  currency: 'USD',
+  series: [
+    {
+      index: 0,
+      localStart: '2026-07-01',
+      count: 2,
+      durationSeconds: 7200,
+      materialMg: 40000,
+      cost: 3.5,
+    },
+    {
+      index: 1,
+      localStart: '2026-07-02',
+      count: 1,
+      durationSeconds: 3600,
+      materialMg: 20000,
+      cost: 1.5,
+    },
+  ],
+  calendar: [
+    { date: '2026-07-01', count: 2 },
+    { date: '2026-07-02', count: 1 },
+  ],
+  calendarFrom: '2026-07-01',
+  calendarTo: '2026-07-02',
+  streaks: {
+    currentDays: 2,
+    longestDays: 2,
+    longestStart: '2026-07-01',
+    longestEnd: '2026-07-02',
+    busiestDate: '2026-07-01',
+    busiestDateCount: 2,
+    busiestWeekday: 3,
+    busiestWeekdayCount: 2,
+  },
+  durationHistogram: [
+    { label: '<30m', lowerSeconds: 0, upperSeconds: 1800, count: 0 },
+    { label: '1–2h', lowerSeconds: 3600, upperSeconds: 7200, count: 3 },
+  ],
+  startTimeMatrix: [{ weekday: 3, hour: 9, count: 3 }],
+  coverage: {
+    population: 'prints',
+    counted: 3,
+    total: 3,
+    undatedCount: 0,
+    exclusions: [],
+  },
+  ...overrides,
+});
+
+describe('ActivityTabComponent', () => {
+  let fixture: ComponentFixture<ActivityTabComponent>;
+  let component: ActivityTabComponent;
+  let analytics: jasmine.SpyObj<AnalyticsService>;
+
+  /**
+   * Synchronous on purpose, to be called inside fakeAsync: createTabData debounces by 250ms,
+   * and whenStable() only drains microtasks — it never advances a timer, so a promise-based
+   * setup would assert against an empty tab every time.
+   */
+  const setup = () => {
+    fixture = TestBed.createComponent(ActivityTabComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    tick(300);
+    fixture.detectChanges();
+  };
+
+  beforeEach(async () => {
+    analytics = jasmine.createSpyObj<AnalyticsService>('AnalyticsService', [
+      'getActivity',
+    ]);
+    analytics.getActivity.and.returnValue(of(response()));
+
+    await TestBed.configureTestingModule({
+      imports: [ActivityTabComponent, NoopAnimationsModule],
+      providers: [
+        provideRouter([]),
+        AnalyticsFilterStore,
+        { provide: AnalyticsService, useValue: analytics },
+      ],
+    }).compileComponents();
+  });
+
+  it('renders the series in chronological order regardless of response order', fakeAsync(() => {
+    analytics.getActivity.and.returnValue(
+      of(
+        response({
+          series: [
+            {
+              index: 1,
+              localStart: '2026-07-02',
+              count: 1,
+              durationSeconds: 3600,
+              materialMg: 20000,
+              cost: 1.5,
+            },
+            {
+              index: 0,
+              localStart: '2026-07-01',
+              count: 2,
+              durationSeconds: 7200,
+              materialMg: 40000,
+              cost: 3.5,
+            },
+          ],
+        })
+      )
+    );
+    setup();
+
+    expect(component.seriesData().map((d) => d.fullLabel)).toEqual(
+      component
+        .seriesData()
+        .map((d) => d.fullLabel)
+        .slice()
+        .sort()
+    );
+    expect(component.seriesData()[0].values['value']).toBe(2);
+  }));
+
+  it('switches the plotted metric without issuing another request', fakeAsync(() => {
+    setup();
+    expect(component.seriesData()[0].values['value']).toBe(2);
+
+    component.setMetric('time');
+    expect(component.seriesData()[0].values['value']).toBe(7200);
+
+    component.setMetric('filament');
+    expect(component.seriesData()[0].values['value']).toBe(40);
+
+    component.setMetric('cost');
+    expect(component.seriesData()[0].values['value']).toBe(3.5);
+
+    expect(analytics.getActivity).toHaveBeenCalledTimes(1);
+  }));
+
+  it('disables the cost metric when the server could not cost the range', fakeAsync(() => {
+    analytics.getActivity.and.returnValue(
+      of(
+        response({
+          series: [
+            {
+              index: 0,
+              localStart: '2026-07-01',
+              count: 2,
+              durationSeconds: 7200,
+              materialMg: 40000,
+              cost: null,
+            },
+          ],
+        })
+      )
+    );
+    setup();
+
+    expect(component.costAvailable()).toBeFalse();
+  }));
+
+  it('fails the whole tab on an error, with one retry affordance', fakeAsync(() => {
+    analytics.getActivity.and.returnValue(throwError(() => new Error('boom')));
+    setup();
+
+    expect(component.state()).toBe('error');
+  }));
+
+  it('renders the streak summary in plain language', fakeAsync(() => {
+    setup();
+
+    expect(component.streakSummary()).toContain('2');
+  }));
+});

--- a/src/app/analytics/tabs/activity/activity-tab.component.ts
+++ b/src/app/analytics/tabs/activity/activity-tab.component.ts
@@ -1,0 +1,181 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { Router } from '@angular/router';
+import {
+  BarChartComponent,
+  BarDatum,
+  BarSeries,
+} from 'src/app/shared/charts/bar-chart.component';
+import { CalendarHeatmapComponent } from 'src/app/shared/charts/calendar-heatmap.component';
+import {
+  formatTickDate,
+  parseLocalDate,
+} from 'src/app/shared/charts/chart-axis';
+import { ChartFrameComponent } from 'src/app/shared/charts/chart-frame.component';
+import { MatrixHeatmapComponent } from 'src/app/shared/charts/matrix-heatmap.component';
+import { AnalyticsFilterStore } from '../../filters/analytics-filter.store';
+import { ActivityResponse } from '../../models/analytics.models';
+import { AnalyticsService } from '../../services/analytics.service';
+import { createTabData } from '../tab-data';
+
+export type ActivityMetric = 'count' | 'time' | 'filament' | 'cost';
+
+const WEEKDAYS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const HOURS = Array.from({ length: 24 }, (_, hour) => `${hour}`);
+
+@Component({
+  selector: 'app-activity-tab',
+  imports: [
+    BarChartComponent,
+    CalendarHeatmapComponent,
+    ChartFrameComponent,
+    MatButtonToggleModule,
+    MatrixHeatmapComponent,
+  ],
+  templateUrl: './activity-tab.component.html',
+  styleUrls: ['./activity-tab.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ActivityTabComponent {
+  private readonly analytics = inject(AnalyticsService);
+  private readonly store = inject(AnalyticsFilterStore);
+  private readonly router = inject(Router);
+
+  private readonly tab = createTabData<ActivityResponse>(
+    this.store.filter,
+    (filter) => this.analytics.getActivity(filter),
+    (response) => response.series.every((bucket) => bucket.count === 0)
+  );
+
+  readonly data = this.tab.data;
+  readonly state = this.tab.state;
+
+  /**
+   * The metric toggle is a pure client-side switch: all four numbers ship in one payload, so
+   * switching is instant AND the four figures are guaranteed to describe the same prints.
+   */
+  readonly metric = signal<ActivityMetric>('count');
+
+  readonly weekdays = WEEKDAYS;
+  readonly hours = HOURS;
+
+  readonly seriesLabels: Record<ActivityMetric, string> = {
+    count: 'Prints',
+    time: 'Print time (seconds)',
+    filament: 'Filament (grams)',
+    cost: 'Cost',
+  };
+
+  readonly series: readonly BarSeries[] = [
+    { key: 'value', label: 'Value', seriesIndex: 1 },
+  ];
+
+  /** Cost is unavailable when the server hit its cost row cap and nulled the whole series. */
+  readonly costAvailable = computed(() =>
+    (this.data()?.series ?? []).some((bucket) => bucket.cost !== null)
+  );
+
+  readonly seriesData = computed<BarDatum[]>(() => {
+    const response = this.data();
+    if (!response) return [];
+
+    const metric = this.metric();
+    return (
+      [...response.series]
+        // API response order is not display order (spec §11). Sort by the civil localStart.
+        .sort(
+          (left, right) =>
+            left.localStart.localeCompare(right.localStart) ||
+            left.index - right.index
+        )
+        .map((bucket) => {
+          const date = parseLocalDate(bucket.localStart);
+          const value =
+            metric === 'count'
+              ? bucket.count
+              : metric === 'time'
+                ? bucket.durationSeconds
+                : metric === 'filament'
+                  ? bucket.materialMg / 1000
+                  : (bucket.cost ?? 0);
+
+          return {
+            label: formatTickDate(date, response.granularity, true),
+            fullLabel: formatTickDate(date, response.granularity, false),
+            values: { value },
+          };
+        })
+    );
+  });
+
+  readonly histogramData = computed<BarDatum[]>(() =>
+    (this.data()?.durationHistogram ?? []).map((bucket) => ({
+      label: bucket.label,
+      fullLabel: bucket.label,
+      values: { value: bucket.count },
+    }))
+  );
+
+  readonly streakSummary = computed(() => {
+    const streaks = this.data()?.streaks;
+    if (!streaks) return '';
+
+    const day = (n: number) => `${n} day${n === 1 ? '' : 's'}`;
+    const parts = [
+      `Current streak ${day(streaks.currentDays)}`,
+      `Longest streak ${day(streaks.longestDays)}`,
+    ];
+
+    if (streaks.busiestDate) {
+      parts.push(
+        `Busiest day ${parseLocalDate(streaks.busiestDate).toLocaleDateString(
+          undefined,
+          {
+            month: 'short',
+            day: 'numeric',
+            year: 'numeric',
+          }
+        )} (${streaks.busiestDateCount})`
+      );
+    }
+    if (streaks.busiestWeekday !== null) {
+      parts.push(`Busiest weekday ${WEEKDAYS[streaks.busiestWeekday]}`);
+    }
+
+    return parts.join(' · ');
+  });
+
+  readonly seriesAriaSummary = computed(() => {
+    const response = this.data();
+    if (!response) return '';
+    return `${this.seriesLabels[this.metric()]} across ${response.series.length} ${response.granularity.toLowerCase()} periods`;
+  });
+
+  setMetric(metric: ActivityMetric): void {
+    this.metric.set(metric);
+  }
+
+  onRetry(): void {
+    this.tab.retry();
+  }
+
+  /**
+   * A calendar day links to that day's prints. Never sends userId: /api/Prints/summary reads
+   * one as "show this user's PUBLIC prints", which would silently narrow the user's own list.
+   */
+  onDaySelect(event: { date: string }): void {
+    const from = parseLocalDate(event.date);
+    const to = new Date(from);
+    to.setDate(to.getDate() + 1); // half-open, matching the API contract
+
+    void this.router.navigate(['/prints'], {
+      queryParams: { fromDate: from.toISOString(), toDate: to.toISOString() },
+    });
+  }
+}

--- a/src/app/analytics/tabs/overview/overview-tab.component.ts
+++ b/src/app/analytics/tabs/overview/overview-tab.component.ts
@@ -5,19 +5,7 @@ import {
   inject,
   signal,
 } from '@angular/core';
-import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { Router } from '@angular/router';
-import {
-  EMPTY,
-  Subject,
-  catchError,
-  debounceTime,
-  map,
-  merge,
-  of,
-  switchMap,
-  tap,
-} from 'rxjs';
 import { PrintStatus } from 'src/app/core/services/print.service';
 import {
   BarChartComponent,
@@ -28,10 +16,7 @@ import {
   formatTickDate,
   parseLocalDate,
 } from 'src/app/shared/charts/chart-axis';
-import {
-  ChartFrameComponent,
-  ChartState,
-} from 'src/app/shared/charts/chart-frame.component';
+import { ChartFrameComponent } from 'src/app/shared/charts/chart-frame.component';
 import {
   DonutChartComponent,
   DonutSlice,
@@ -40,6 +25,7 @@ import { StatTileComponent } from 'src/app/shared/charts/stat-tile.component';
 import { AnalyticsFilterStore } from '../../filters/analytics-filter.store';
 import { OverviewResponse } from '../../models/analytics.models';
 import { AnalyticsService } from '../../services/analytics.service';
+import { createTabData } from '../tab-data';
 
 /**
  * Status ordering and colour assignment are fixed here so the donut, the stacked bars, and
@@ -106,44 +92,23 @@ export class OverviewTabComponent {
   private readonly store = inject(AnalyticsFilterStore);
   private readonly router = inject(Router);
 
-  readonly data = signal<OverviewResponse | null>(null);
-  readonly state = signal<ChartState>('loading');
+  // Field initializers run in an injection context, which is what takeUntilDestroyed inside
+  // createTabData needs. The debounce/cancel/discard-stale rules live in that one helper so
+  // six tabs cannot each get them subtly wrong.
+  private readonly tab = createTabData<OverviewResponse>(
+    this.store.filter,
+    (filter) => this.analytics.getOverview(filter),
+    (response) => (response.tiles.printCount.value ?? 0) === 0
+  );
 
-  readonly retry$ = new Subject<void>();
+  readonly data = this.tab.data;
+  readonly state = this.tab.state;
 
   readonly statusSeries: readonly BarSeries[] = STATUS_SERIES.map((s) => ({
     key: s.key,
     label: s.label,
     seriesIndex: s.seriesIndex,
   }));
-
-  constructor() {
-    // debounce + switchMap: switchMap cancels the in-flight request AND guarantees a late
-    // response from a superseded request can never be applied over a newer one.
-    toObservable(this.store.filter)
-      .pipe(
-        debounceTime(250),
-        switchMap((filter) =>
-          merge(of(filter), this.retry$.pipe(map(() => filter)))
-        ),
-        tap(() => this.state.set('loading')),
-        switchMap((filter) =>
-          this.analytics.getOverview(filter).pipe(
-            catchError(() => {
-              this.state.set('error');
-              return EMPTY;
-            })
-          )
-        ),
-        takeUntilDestroyed()
-      )
-      .subscribe((response) => {
-        this.data.set(response);
-        this.state.set(
-          (response.tiles.printCount.value ?? 0) === 0 ? 'empty' : 'ready'
-        );
-      });
-  }
 
   readonly barData = computed<BarDatum[]>(() => {
     const response = this.data();
@@ -199,7 +164,7 @@ export class OverviewTabComponent {
   });
 
   onRetry(): void {
-    this.retry$.next();
+    this.tab.retry();
   }
 
   /** Bar click-through: the bucket's status, within the current range. */

--- a/src/app/analytics/tabs/printers/printer-comparison.component.html
+++ b/src/app/analytics/tabs/printers/printer-comparison.component.html
@@ -1,0 +1,109 @@
+@if (layout() === 'table') {
+  <div class="printer-comparison__scroll">
+    <table class="printer-comparison__table">
+      <thead>
+        <tr>
+          @for (column of columns; track column.key) {
+            <th
+              scope="col"
+              [attr.aria-sort]="
+                sortColumn() === column.key
+                  ? sortAscending()
+                    ? 'ascending'
+                    : 'descending'
+                  : 'none'
+              "
+            >
+              <button mat-button type="button" (click)="sortBy(column.key)">
+                {{ column.label }}
+              </button>
+            </th>
+          }
+        </tr>
+      </thead>
+      <tbody>
+        @for (row of sorted(); track row.printerId) {
+          <tr (click)="onSelect(row)">
+            <th scope="row">{{ row.name }}</th>
+            @if (row.isIdle) {
+              <td [attr.colspan]="columns.length - 1">
+                No prints in this range
+              </td>
+            } @else {
+              <td>{{ row.printCount }}</td>
+              <td>
+                {{
+                  row.successRatePercent === null
+                    ? '—'
+                    : (row.successRatePercent | number: '1.0-0') + '%'
+                }}
+              </td>
+              <td>{{ hours(row.printTimeSeconds) | number: '1.0-1' }} h</td>
+              <td>{{ grams(row.materialMg) | number: '1.0-0' }} g</td>
+              <td>
+                {{
+                  row.avgDurationSeconds === null
+                    ? '—'
+                    : (hours(row.avgDurationSeconds) | number: '1.0-1') + ' h'
+                }}
+              </td>
+              <td>{{ row.cost === null ? '—' : (row.cost | number: '1.2-2') }}</td>
+              <td>
+                {{
+                  row.maintenanceCost === null
+                    ? '—'
+                    : (row.maintenanceCost | number: '1.2-2')
+                }}
+              </td>
+              <td>
+                {{
+                  row.utilizationPercent === null
+                    ? '—'
+                    : (row.utilizationPercent | number: '1.0-1') + '%'
+                }}
+              </td>
+            }
+          </tr>
+        }
+      </tbody>
+    </table>
+  </div>
+} @else {
+  <ul class="printer-comparison__cards">
+    @for (row of sorted(); track row.printerId) {
+      <li class="printer-comparison__card" (click)="onSelect(row)">
+        <h3 class="printer-comparison__card-title">{{ row.name }}</h3>
+        @if (row.isIdle) {
+          <p class="printer-comparison__idle">No prints in this range</p>
+        } @else {
+          <dl class="printer-comparison__pairs">
+            <dt>Prints</dt>
+            <dd>{{ row.printCount }}</dd>
+            <dt>Success</dt>
+            <dd>
+              {{
+                row.successRatePercent === null
+                  ? '—'
+                  : (row.successRatePercent | number: '1.0-0') + '%'
+              }}
+            </dd>
+            <dt>Print time</dt>
+            <dd>{{ hours(row.printTimeSeconds) | number: '1.0-1' }} h</dd>
+            <dt>Filament</dt>
+            <dd>{{ grams(row.materialMg) | number: '1.0-0' }} g</dd>
+            <dt>Cost</dt>
+            <dd>{{ row.cost === null ? '—' : (row.cost | number: '1.2-2') }}</dd>
+            <dt>Utilization</dt>
+            <dd>
+              {{
+                row.utilizationPercent === null
+                  ? '—'
+                  : (row.utilizationPercent | number: '1.0-1') + '%'
+              }}
+            </dd>
+          </dl>
+        }
+      </li>
+    }
+  </ul>
+}

--- a/src/app/analytics/tabs/printers/printer-comparison.component.scss
+++ b/src/app/analytics/tabs/printers/printer-comparison.component.scss
@@ -16,6 +16,34 @@
     white-space: nowrap;
   }
 
+  // Every numeric column is right-aligned in BOTH the header and the body. Left-aligned
+  // digits of differing width are unreadable as a column, and the header label drifting
+  // away from the figures under it is what made the table look misaligned.
+  th:not(:first-child),
+  td:not(:first-child) {
+    text-align: end;
+  }
+
+  // A mat-button brings its own horizontal padding and min-width, which pushed each header
+  // label off the grid its column's values sit on. Stripped so the label starts exactly
+  // where the cell padding puts it.
+  //
+  // justify-content, not just text-align: the button lays its label out with flex and
+  // centres it, so text-align alone left every header floating mid-column above
+  // right-aligned figures — which is the misalignment that shows up on screen.
+  thead button {
+    padding: 0;
+    min-inline-size: 0;
+    font: inherit;
+    font-weight: 500;
+    inline-size: 100%;
+    justify-content: flex-end;
+  }
+
+  thead th:first-child button {
+    justify-content: flex-start;
+  }
+
   tbody tr {
     cursor: pointer;
   }

--- a/src/app/analytics/tabs/printers/printer-comparison.component.scss
+++ b/src/app/analytics/tabs/printers/printer-comparison.component.scss
@@ -1,0 +1,63 @@
+.printer-comparison__scroll {
+  // The table scrolls inside its own box. The page body must never scroll horizontally.
+  overflow-x: auto;
+  max-inline-size: 100%;
+  min-inline-size: 0;
+}
+
+.printer-comparison__table {
+  inline-size: 100%;
+  border-collapse: collapse;
+
+  th,
+  td {
+    padding: 0.25rem 0.5rem;
+    text-align: start;
+    white-space: nowrap;
+  }
+
+  tbody tr {
+    cursor: pointer;
+  }
+}
+
+.printer-comparison__cards {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.printer-comparison__card {
+  padding: 0.5rem;
+  border: 1px solid var(--chart-grid);
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.printer-comparison__card-title {
+  margin: 0 0 0.25rem;
+  font-size: 1rem;
+}
+
+.printer-comparison__pairs {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.125rem 0.5rem;
+  margin: 0;
+
+  dt {
+    color: var(--chart-axis-text);
+  }
+
+  dd {
+    margin: 0;
+    text-align: end;
+  }
+}
+
+.printer-comparison__idle {
+  margin: 0;
+  color: var(--chart-empty-text);
+}

--- a/src/app/analytics/tabs/printers/printer-comparison.component.spec.ts
+++ b/src/app/analytics/tabs/printers/printer-comparison.component.spec.ts
@@ -1,0 +1,120 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { PrinterRow } from '../../models/analytics.models';
+import { PrinterComparisonComponent } from './printer-comparison.component';
+
+const row = (overrides: Partial<PrinterRow>): PrinterRow => ({
+  printerId: 1,
+  name: 'Ender 3',
+  isIdle: false,
+  printCount: 5,
+  successRatePercent: 80,
+  printTimeSeconds: 3600,
+  materialMg: 50000,
+  avgDurationSeconds: 720,
+  cost: 12.5,
+  maintenanceCost: 5,
+  utilizationPercent: 10,
+  costPerPrintHour: 5,
+  ...overrides,
+});
+
+describe('PrinterComparisonComponent', () => {
+  let fixture: ComponentFixture<PrinterComparisonComponent>;
+  let component: PrinterComparisonComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PrinterComparisonComponent, NoopAnimationsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PrinterComparisonComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('currency', 'USD');
+    fixture.componentRef.setInput('layout', 'table');
+  });
+
+  it('sorts descending by print count by default', () => {
+    fixture.componentRef.setInput('rows', [
+      row({ printerId: 1, printCount: 2 }),
+      row({ printerId: 2, printCount: 9 }),
+    ]);
+    fixture.detectChanges();
+
+    expect(component.sorted().map((r) => r.printerId)).toEqual([2, 1]);
+  });
+
+  it('toggles direction when the same column is chosen twice', () => {
+    fixture.componentRef.setInput('rows', [
+      row({ printerId: 1, printCount: 2 }),
+      row({ printerId: 2, printCount: 9 }),
+    ]);
+    fixture.detectChanges();
+
+    component.sortBy('printCount');
+    expect(component.sorted().map((r) => r.printerId)).toEqual([1, 2]);
+
+    component.sortBy('printCount');
+    expect(component.sorted().map((r) => r.printerId)).toEqual([2, 1]);
+  });
+
+  it('sorts nulls last in both directions', () => {
+    fixture.componentRef.setInput('rows', [
+      row({ printerId: 1, successRatePercent: null }),
+      row({ printerId: 2, successRatePercent: 50 }),
+    ]);
+    fixture.detectChanges();
+
+    component.sortBy('successRatePercent');
+    expect(component.sorted()[1].printerId).toBe(1);
+
+    component.sortBy('successRatePercent');
+    // Still last: "no success rate" is not "the worst success rate".
+    expect(component.sorted()[1].printerId).toBe(1);
+  });
+
+  it('renders a table when layout is table and a card list when it is cards', () => {
+    fixture.componentRef.setInput('rows', [row({})]);
+    fixture.detectChanges();
+    expect(
+      fixture.nativeElement.querySelector('table.printer-comparison__table')
+    ).toBeTruthy();
+
+    fixture.componentRef.setInput('layout', 'cards');
+    fixture.detectChanges();
+    expect(
+      fixture.nativeElement.querySelector('table.printer-comparison__table')
+    ).toBeNull();
+    expect(
+      fixture.nativeElement.querySelector('.printer-comparison__card')
+    ).toBeTruthy();
+  });
+
+  it('marks an idle printer explicitly rather than showing a row of zeroes', () => {
+    fixture.componentRef.setInput('rows', [
+      row({
+        printerId: 3,
+        isIdle: true,
+        printCount: 0,
+        successRatePercent: null,
+      }),
+    ]);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.textContent).toContain(
+      'No prints in this range'
+    );
+  });
+
+  it('emits the selected printer', () => {
+    fixture.componentRef.setInput('rows', [row({ printerId: 7 })]);
+    fixture.detectChanges();
+
+    let emitted: { printerId: number } | null = null;
+    component.printerSelect.subscribe((event) => (emitted = event));
+
+    component.onSelect(component.sorted()[0]);
+
+    expect(emitted).toEqual({ printerId: 7 });
+  });
+});

--- a/src/app/analytics/tabs/printers/printer-comparison.component.ts
+++ b/src/app/analytics/tabs/printers/printer-comparison.component.ts
@@ -1,0 +1,106 @@
+import { DecimalPipe } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  output,
+  signal,
+} from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { PrinterRow } from '../../models/analytics.models';
+
+export type PrinterSortColumn =
+  | 'name'
+  | 'printCount'
+  | 'successRatePercent'
+  | 'printTimeSeconds'
+  | 'materialMg'
+  | 'avgDurationSeconds'
+  | 'cost'
+  | 'maintenanceCost'
+  | 'utilizationPercent';
+
+/**
+ * One component for both layouts. Sorting, formatting and click-through are identical between
+ * the desktop table and the phone card list, and duplicating them into two components would
+ * duplicate exactly the part that can be wrong.
+ */
+@Component({
+  selector: 'app-printer-comparison',
+  imports: [DecimalPipe, MatButtonModule],
+  templateUrl: './printer-comparison.component.html',
+  styleUrls: ['./printer-comparison.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PrinterComparisonComponent {
+  readonly rows = input<PrinterRow[]>([]);
+  readonly currency = input<string | null>(null);
+  readonly layout = input<'table' | 'cards'>('table');
+
+  readonly printerSelect = output<{ printerId: number }>();
+
+  readonly sortColumn = signal<PrinterSortColumn>('printCount');
+  readonly sortAscending = signal(false);
+
+  readonly columns: readonly { key: PrinterSortColumn; label: string }[] = [
+    { key: 'name', label: 'Printer' },
+    { key: 'printCount', label: 'Prints' },
+    { key: 'successRatePercent', label: 'Success' },
+    { key: 'printTimeSeconds', label: 'Print time' },
+    { key: 'materialMg', label: 'Filament' },
+    { key: 'avgDurationSeconds', label: 'Avg print' },
+    { key: 'cost', label: 'Cost' },
+    { key: 'maintenanceCost', label: 'Maintenance' },
+    { key: 'utilizationPercent', label: 'Utilization' },
+  ];
+
+  readonly sorted = computed(() => {
+    const column = this.sortColumn();
+    const ascending = this.sortAscending();
+
+    return [...this.rows()].sort((left, right) => {
+      const a = left[column];
+      const b = right[column];
+
+      // Nulls last in BOTH directions. A printer with no success rate is not the worst
+      // printer; treating null as 0 would assert something the data does not say.
+      if (a === null || a === undefined)
+        return b === null || b === undefined ? 0 : 1;
+      if (b === null || b === undefined) return -1;
+
+      const comparison =
+        typeof a === 'string' || typeof b === 'string'
+          ? String(a).localeCompare(String(b))
+          : Number(a) - Number(b);
+
+      return (
+        (ascending ? comparison : -comparison) ||
+        left.printerId - right.printerId
+      );
+    });
+  });
+
+  sortBy(column: PrinterSortColumn): void {
+    if (this.sortColumn() === column) {
+      this.sortAscending.update((value) => !value);
+      return;
+    }
+    this.sortColumn.set(column);
+    // A newly chosen column starts descending except for the name, where A→Z is the
+    // expectation every table in the app already sets.
+    this.sortAscending.set(column === 'name');
+  }
+
+  onSelect(row: PrinterRow): void {
+    this.printerSelect.emit({ printerId: row.printerId });
+  }
+
+  hours(seconds: number | null): number | null {
+    return seconds === null ? null : seconds / 3600;
+  }
+
+  grams(mg: number): number {
+    return mg / 1000;
+  }
+}

--- a/src/app/analytics/tabs/printers/printers-tab.component.html
+++ b/src/app/analytics/tabs/printers/printers-tab.component.html
@@ -1,0 +1,121 @@
+<div class="printers-tab">
+  <div class="printers-tab__tiles">
+    <app-stat-tile
+      label="Fleet utilization"
+      format="percent"
+      [metric]="data()?.fleetUtilizationPercent ?? null"
+      [loading]="state() === 'loading'"
+    />
+  </div>
+
+  <app-chart-frame
+    class="printers-tab__chart printers-tab__chart--wide"
+    title="Printer comparison"
+    [state]="state()"
+    [coverage]="data()?.coverage ?? null"
+    ariaSummary="Per-printer prints, success rate, print time, filament, cost and utilization"
+    emptyMessage="None of your printers produced a print in this range."
+    (retry)="onRetry()"
+  >
+    <app-printer-comparison
+      [rows]="data()?.printers ?? []"
+      [currency]="data()?.currency ?? null"
+      [layout]="comparisonLayout()"
+      (printerSelect)="onPrinterSelect($event)"
+    />
+  </app-chart-frame>
+
+  <div class="printers-tab__charts">
+    <app-chart-frame
+      class="printers-tab__chart"
+      #successFrame
+      title="Success rate by printer"
+      [state]="state()"
+      [coverage]="data()?.coverage ?? null"
+      ariaSummary="Success rate for each printer"
+      emptyMessage="No resolved prints in this range yet."
+      (retry)="onRetry()"
+    >
+      <app-bar-chart
+        [data]="successRateData()"
+        [series]="singleSeries"
+        [width]="successFrame.width()"
+        [height]="successFrame.height()"
+        orientation="horizontal"
+      />
+      <table chartDataTable>
+        <caption>
+          Success rate by printer
+        </caption>
+        <tbody>
+          @for (row of successRateData(); track row.fullLabel) {
+            <tr>
+              <th scope="row">{{ row.fullLabel }}</th>
+              <td>{{ row.values['value'] }}%</td>
+            </tr>
+          }
+        </tbody>
+      </table>
+    </app-chart-frame>
+
+    <app-chart-frame
+      class="printers-tab__chart"
+      #timeFrame
+      title="Print time by printer"
+      [state]="state()"
+      [coverage]="data()?.coverage ?? null"
+      ariaSummary="Print hours per period, stacked by printer"
+      emptyMessage="No prints in this range yet."
+      (retry)="onRetry()"
+    >
+      <app-bar-chart
+        [data]="timeSeriesData()"
+        [series]="printerSeries()"
+        [width]="timeFrame.width()"
+        [height]="timeFrame.height()"
+      />
+      <table chartDataTable>
+        <caption>
+          Print hours per period by printer
+        </caption>
+        <tbody>
+          @for (row of timeSeriesData(); track row.fullLabel) {
+            <tr>
+              <th scope="row">{{ row.fullLabel }}</th>
+              @for (series of printerSeries(); track series.key) {
+                <td>{{ series.label }}: {{ row.values[series.key] ?? 0 }}</td>
+              }
+            </tr>
+          }
+        </tbody>
+      </table>
+    </app-chart-frame>
+  </div>
+
+  <app-chart-frame
+    class="printers-tab__chart printers-tab__chart--wide"
+    title="Maintenance"
+    [state]="state()"
+    [coverage]="data()?.coverage ?? null"
+    ariaSummary="Completed maintenance events and their cost"
+    emptyMessage="No completed maintenance in this range."
+    (retry)="onRetry()"
+  >
+    <table class="printers-tab__maintenance">
+      <caption>
+        Completed maintenance @if (maintenanceTotal() !== null) { — total
+        {{ maintenanceTotal() }} {{ data()?.currency }} }
+      </caption>
+      <tbody>
+        @for (event of data()?.maintenance ?? []; track event.id) {
+          <tr>
+            <th scope="row">{{ event.date }}</th>
+            <td>{{ event.category }}</td>
+            <td>{{ event.description }}</td>
+            <td>{{ event.cost === null ? '—' : event.cost }}</td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  </app-chart-frame>
+</div>

--- a/src/app/analytics/tabs/printers/printers-tab.component.html
+++ b/src/app/analytics/tabs/printers/printers-tab.component.html
@@ -11,6 +11,7 @@
   <app-chart-frame
     class="printers-tab__chart printers-tab__chart--wide"
     title="Printer comparison"
+    fit="natural"
     [state]="state()"
     [coverage]="data()?.coverage ?? null"
     ariaSummary="Per-printer prints, success rate, print time, filament, cost and utilization"
@@ -95,27 +96,39 @@
   <app-chart-frame
     class="printers-tab__chart printers-tab__chart--wide"
     title="Maintenance"
+    fit="natural"
     [state]="state()"
     [coverage]="data()?.coverage ?? null"
     ariaSummary="Completed maintenance events and their cost"
     emptyMessage="No completed maintenance in this range."
     (retry)="onRetry()"
   >
-    <table class="printers-tab__maintenance">
-      <caption>
-        Completed maintenance @if (maintenanceTotal() !== null) { — total
-        {{ maintenanceTotal() }} {{ data()?.currency }} }
-      </caption>
-      <tbody>
-        @for (event of data()?.maintenance ?? []; track event.id) {
-          <tr>
-            <th scope="row">{{ event.date }}</th>
-            <td>{{ event.category }}</td>
-            <td>{{ event.description }}</td>
-            <td>{{ event.cost === null ? '—' : event.cost }}</td>
-          </tr>
-        }
-      </tbody>
-    </table>
+    <!--
+      chart-frame's emptyMessage keys off the TAB's state, which is 'ready' whenever the
+      user owns a printer — so an empty maintenance log rendered as a bare table with no
+      rows and no explanation. This panel reports its own emptiness.
+    -->
+    @if ((data()?.maintenance ?? []).length === 0) {
+      <p class="printers-tab__maintenance-empty">
+        No completed maintenance in this range.
+      </p>
+    } @else {
+      <table class="printers-tab__maintenance">
+        <caption>
+          Completed maintenance @if (maintenanceTotal() !== null) { — total
+          {{ maintenanceTotal() }} {{ data()?.currency }} }
+        </caption>
+        <tbody>
+          @for (event of data()?.maintenance ?? []; track event.id) {
+            <tr>
+              <th scope="row">{{ event.date }}</th>
+              <td>{{ event.category }}</td>
+              <td>{{ event.description }}</td>
+              <td>{{ event.cost === null ? '—' : event.cost }}</td>
+            </tr>
+          }
+        </tbody>
+      </table>
+    }
   </app-chart-frame>
 </div>

--- a/src/app/analytics/tabs/printers/printers-tab.component.scss
+++ b/src/app/analytics/tabs/printers/printers-tab.component.scss
@@ -35,6 +35,15 @@
     padding: 0.25rem 0.5rem;
     text-align: start;
   }
+
+  td:last-child {
+    text-align: end;
+  }
+}
+
+.printers-tab__maintenance-empty {
+  margin: 0;
+  color: var(--chart-empty-text);
 }
 
 @container (min-width: 900px) {

--- a/src/app/analytics/tabs/printers/printers-tab.component.scss
+++ b/src/app/analytics/tabs/printers/printers-tab.component.scss
@@ -1,0 +1,39 @@
+.printers-tab {
+  display: grid;
+  gap: 0.5rem;
+  container-type: inline-size;
+  min-inline-size: 0;
+}
+
+.printers-tab__tiles {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.printers-tab__charts {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.printers-tab__maintenance {
+  inline-size: 100%;
+  border-collapse: collapse;
+
+  th,
+  td {
+    padding: 0.25rem 0.5rem;
+    text-align: start;
+  }
+}
+
+@container (min-width: 900px) {
+  .printers-tab__tiles {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+  }
+
+  .printers-tab__charts {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}

--- a/src/app/analytics/tabs/printers/printers-tab.component.scss
+++ b/src/app/analytics/tabs/printers/printers-tab.component.scss
@@ -1,3 +1,12 @@
+// The host is what the ResizeObserver in this component measures, and a component element
+// is `display: inline` by default — an inline box reports a contentRect width of 0, which
+// would pin comparisonLayout to 'cards' at every viewport. chart-frame sidesteps this by
+// measuring an inner block; here the host itself has to be a block.
+:host {
+  display: block;
+  min-inline-size: 0;
+}
+
 .printers-tab {
   display: grid;
   gap: 0.5rem;

--- a/src/app/analytics/tabs/printers/printers-tab.component.spec.ts
+++ b/src/app/analytics/tabs/printers/printers-tab.component.spec.ts
@@ -1,0 +1,161 @@
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { AnalyticsFilterStore } from '../../filters/analytics-filter.store';
+import { PrintersResponse } from '../../models/analytics.models';
+import { AnalyticsService } from '../../services/analytics.service';
+import { PrintersTabComponent } from './printers-tab.component';
+
+const emptyCoverage = {
+  population: 'printers',
+  counted: 0,
+  total: 0,
+  undatedCount: 0,
+  exclusions: [],
+};
+
+const response = (
+  overrides: Partial<PrintersResponse> = {}
+): PrintersResponse => ({
+  from: null,
+  to: null,
+  timeZone: 'UTC',
+  granularity: 'Day',
+  currency: 'USD',
+  printers: [
+    {
+      printerId: 1,
+      name: 'Ender 3',
+      isIdle: false,
+      printCount: 4,
+      successRatePercent: 75,
+      printTimeSeconds: 7200,
+      materialMg: 60000,
+      avgDurationSeconds: 1800,
+      cost: 10,
+      maintenanceCost: 4,
+      utilizationPercent: 12,
+      costPerPrintHour: 2,
+    },
+  ],
+  timeSeries: [
+    {
+      index: 0,
+      localStart: '2026-07-02',
+      printSecondsByPrinterId: { '1': 3600 },
+    },
+    {
+      index: 1,
+      localStart: '2026-07-01',
+      printSecondsByPrinterId: { '1': 3600 },
+    },
+  ],
+  fleetUtilizationPercent: {
+    value: 12,
+    previous: null,
+    coverage: emptyCoverage,
+  },
+  maintenance: [
+    {
+      id: 'm1',
+      printerId: 1,
+      date: '2026-07-01',
+      category: 'Nozzle',
+      description: 'Swap',
+      cost: 4,
+    },
+  ],
+  coverage: emptyCoverage,
+  ...overrides,
+});
+
+describe('PrintersTabComponent', () => {
+  let fixture: ComponentFixture<PrintersTabComponent>;
+  let component: PrintersTabComponent;
+  let analytics: jasmine.SpyObj<AnalyticsService>;
+
+  /** Synchronous, to be called inside fakeAsync: createTabData debounces the first load 250ms. */
+  const setup = () => {
+    fixture = TestBed.createComponent(PrintersTabComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    tick(300);
+    fixture.detectChanges();
+  };
+
+  beforeEach(async () => {
+    analytics = jasmine.createSpyObj<AnalyticsService>('AnalyticsService', [
+      'getPrinters',
+    ]);
+    analytics.getPrinters.and.returnValue(of(response()));
+
+    await TestBed.configureTestingModule({
+      imports: [PrintersTabComponent, NoopAnimationsModule],
+      providers: [
+        provideRouter([]),
+        AnalyticsFilterStore,
+        { provide: AnalyticsService, useValue: analytics },
+      ],
+    }).compileComponents();
+  });
+
+  it('sorts the time series chronologically, not by response order', fakeAsync(() => {
+    setup();
+
+    expect(component.timeSeriesData().map((d) => d.fullLabel)).toEqual(
+      component
+        .timeSeriesData()
+        .map((d) => d.fullLabel)
+        .slice()
+        .sort()
+    );
+  }));
+
+  it('builds one bar series per printer so the stack legend matches the table', fakeAsync(() => {
+    setup();
+
+    expect(component.printerSeries().map((s) => s.key)).toEqual(['1']);
+    expect(component.printerSeries()[0].label).toBe('Ender 3');
+  }));
+
+  it('reports empty when every printer is idle', fakeAsync(() => {
+    analytics.getPrinters.and.returnValue(
+      of(
+        response({
+          printers: [
+            {
+              printerId: 1,
+              name: 'Ender 3',
+              isIdle: true,
+              printCount: 0,
+              successRatePercent: null,
+              printTimeSeconds: 0,
+              materialMg: 0,
+              avgDurationSeconds: null,
+              cost: null,
+              maintenanceCost: null,
+              utilizationPercent: null,
+              costPerPrintHour: null,
+            },
+          ],
+        })
+      )
+    );
+    setup();
+
+    expect(component.state()).toBe('empty');
+  }));
+
+  it('fails the whole tab on an error', fakeAsync(() => {
+    analytics.getPrinters.and.returnValue(throwError(() => new Error('boom')));
+    setup();
+
+    expect(component.state()).toBe('error');
+  }));
+});

--- a/src/app/analytics/tabs/printers/printers-tab.component.spec.ts
+++ b/src/app/analytics/tabs/printers/printers-tab.component.spec.ts
@@ -152,6 +152,66 @@ describe('PrintersTabComponent', () => {
     expect(component.state()).toBe('empty');
   }));
 
+  it('totals maintenance from the per-printer figures, not the capped event list', fakeAsync(() => {
+    // The API caps the event LIST at 500 but computes maintenanceCost per printer from an
+    // uncapped read. Here the list shows one 4.00 event while the printer's real total is
+    // 900 — summing the list would report 4 and contradict the column beside it.
+    analytics.getPrinters.and.returnValue(
+      of(
+        response({
+          printers: [
+            {
+              printerId: 1,
+              name: 'Ender 3',
+              isIdle: false,
+              printCount: 4,
+              successRatePercent: 75,
+              printTimeSeconds: 7200,
+              materialMg: 60000,
+              avgDurationSeconds: 1800,
+              cost: 10,
+              maintenanceCost: 900,
+              utilizationPercent: 12,
+              costPerPrintHour: 2,
+            },
+          ],
+        })
+      )
+    );
+    setup();
+
+    expect(component.maintenanceTotal()).toBe(900);
+  }));
+
+  it('reports no maintenance total when no printer has a known cost', fakeAsync(() => {
+    analytics.getPrinters.and.returnValue(
+      of(
+        response({
+          printers: [
+            {
+              printerId: 1,
+              name: 'Ender 3',
+              isIdle: false,
+              printCount: 4,
+              successRatePercent: 75,
+              printTimeSeconds: 7200,
+              materialMg: 60000,
+              avgDurationSeconds: 1800,
+              cost: 10,
+              maintenanceCost: null,
+              utilizationPercent: 12,
+              costPerPrintHour: 2,
+            },
+          ],
+        })
+      )
+    );
+    setup();
+
+    // Null, not 0: "no readable price" is not "spent nothing".
+    expect(component.maintenanceTotal()).toBeNull();
+  }));
+
   it('fails the whole tab on an error', fakeAsync(() => {
     analytics.getPrinters.and.returnValue(throwError(() => new Error('boom')));
     setup();

--- a/src/app/analytics/tabs/printers/printers-tab.component.ts
+++ b/src/app/analytics/tabs/printers/printers-tab.component.ts
@@ -129,12 +129,22 @@ export class PrintersTabComponent implements OnDestroy {
     { key: 'value', label: 'Success rate', seriesIndex: 3 },
   ];
 
+  /**
+   * Summed from the PER-PRINTER totals, not from `maintenance`.
+   *
+   * `maintenance` is the display list, capped at 500 newest events; the API deliberately
+   * computes each printer's maintenanceCost from its own uncapped read for exactly this
+   * reason. Summing the capped list would quietly stop the headline total at 500 events
+   * while the per-printer column beside it kept counting — two numbers on one screen that
+   * disagree, with nothing on screen to explain why.
+   */
   readonly maintenanceTotal = computed(() => {
-    const events = this.data()?.maintenance ?? [];
-    const priced = events.filter((event) => event.cost !== null);
+    const priced = (this.data()?.printers ?? []).filter(
+      (printer) => printer.maintenanceCost !== null
+    );
     return priced.length === 0
       ? null
-      : priced.reduce((sum, e) => sum + (e.cost ?? 0), 0);
+      : priced.reduce((sum, p) => sum + (p.maintenanceCost ?? 0), 0);
   });
 
   onRetry(): void {

--- a/src/app/analytics/tabs/printers/printers-tab.component.ts
+++ b/src/app/analytics/tabs/printers/printers-tab.component.ts
@@ -1,0 +1,154 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  OnDestroy,
+  computed,
+  inject,
+  signal,
+} from '@angular/core';
+import { Router } from '@angular/router';
+import {
+  BarChartComponent,
+  BarDatum,
+  BarSeries,
+} from 'src/app/shared/charts/bar-chart.component';
+import {
+  formatTickDate,
+  parseLocalDate,
+} from 'src/app/shared/charts/chart-axis';
+import { ChartFrameComponent } from 'src/app/shared/charts/chart-frame.component';
+import { StatTileComponent } from 'src/app/shared/charts/stat-tile.component';
+import { AnalyticsFilterStore } from '../../filters/analytics-filter.store';
+import { PrintersResponse } from '../../models/analytics.models';
+import { AnalyticsService } from '../../services/analytics.service';
+import { createTabData } from '../tab-data';
+import { PrinterComparisonComponent } from './printer-comparison.component';
+
+/** Below this the comparison table becomes a card list rather than a horizontal scroll. */
+const CARD_LAYOUT_BELOW = 700;
+
+@Component({
+  selector: 'app-printers-tab',
+  imports: [
+    BarChartComponent,
+    ChartFrameComponent,
+    PrinterComparisonComponent,
+    StatTileComponent,
+  ],
+  templateUrl: './printers-tab.component.html',
+  styleUrls: ['./printers-tab.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PrintersTabComponent implements OnDestroy {
+  private readonly analytics = inject(AnalyticsService);
+  private readonly store = inject(AnalyticsFilterStore);
+  private readonly router = inject(Router);
+  private readonly host = inject(ElementRef<HTMLElement>);
+
+  private readonly tab = createTabData<PrintersResponse>(
+    this.store.filter,
+    (filter) => this.analytics.getPrinters(filter),
+    (response) => response.printers.every((printer) => printer.isIdle)
+  );
+
+  readonly data = this.tab.data;
+  readonly state = this.tab.state;
+
+  /**
+   * Measured from the host, not the window: the side nav collapsing changes the available
+   * width without a viewport change, exactly as chart-frame documents.
+   */
+  readonly comparisonLayout = signal<'table' | 'cards'>('table');
+
+  private observer?: ResizeObserver;
+
+  constructor() {
+    if (typeof ResizeObserver !== 'undefined') {
+      this.observer = new ResizeObserver((entries) => {
+        const width = entries[0]?.contentRect.width;
+        if (width === undefined) return;
+        this.comparisonLayout.set(
+          width < CARD_LAYOUT_BELOW ? 'cards' : 'table'
+        );
+      });
+      this.observer.observe(this.host.nativeElement);
+    }
+  }
+
+  /**
+   * One series per printer, colours cycling through the six theme tokens. The key is the
+   * printer id as a string, matching PrinterSeriesBucket.printSecondsByPrinterId, so the
+   * stacked chart and the table are looking at the same identity.
+   */
+  readonly printerSeries = computed<BarSeries[]>(() =>
+    (this.data()?.printers ?? []).map((printer, index) => ({
+      key: String(printer.printerId),
+      label: printer.name ?? `Printer ${printer.printerId}`,
+      seriesIndex: (index % 6) + 1,
+    }))
+  );
+
+  readonly timeSeriesData = computed<BarDatum[]>(() => {
+    const response = this.data();
+    if (!response) return [];
+
+    return [...response.timeSeries]
+      .sort(
+        (left, right) =>
+          left.localStart.localeCompare(right.localStart) ||
+          left.index - right.index
+      )
+      .map((bucket) => {
+        const date = parseLocalDate(bucket.localStart);
+        const values: Record<string, number> = {};
+        for (const [printerId, seconds] of Object.entries(
+          bucket.printSecondsByPrinterId
+        )) {
+          values[printerId] = seconds / 3600;
+        }
+        return {
+          label: formatTickDate(date, response.granularity, true),
+          fullLabel: formatTickDate(date, response.granularity, false),
+          values,
+        };
+      });
+  });
+
+  readonly successRateData = computed<BarDatum[]>(() =>
+    (this.data()?.printers ?? [])
+      .filter((printer) => printer.successRatePercent !== null)
+      .map((printer) => ({
+        label: printer.name ?? `Printer ${printer.printerId}`,
+        fullLabel: printer.name ?? `Printer ${printer.printerId}`,
+        values: { value: printer.successRatePercent as number },
+      }))
+  );
+
+  readonly singleSeries: readonly BarSeries[] = [
+    { key: 'value', label: 'Success rate', seriesIndex: 3 },
+  ];
+
+  readonly maintenanceTotal = computed(() => {
+    const events = this.data()?.maintenance ?? [];
+    const priced = events.filter((event) => event.cost !== null);
+    return priced.length === 0
+      ? null
+      : priced.reduce((sum, e) => sum + (e.cost ?? 0), 0);
+  });
+
+  onRetry(): void {
+    this.tab.retry();
+  }
+
+  /** Never sends userId — that would narrow the list to the user's PUBLIC prints. */
+  onPrinterSelect(event: { printerId: number }): void {
+    void this.router.navigate(['/prints'], {
+      queryParams: { filterByPrinterId: event.printerId },
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.observer?.disconnect();
+  }
+}

--- a/src/app/analytics/tabs/tab-data.spec.ts
+++ b/src/app/analytics/tabs/tab-data.spec.ts
@@ -1,0 +1,123 @@
+import { Injector, runInInjectionContext, signal } from '@angular/core';
+import { TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { Subject, of, throwError } from 'rxjs';
+import { AnalyticsFilterValue } from '../models/analytics.models';
+import { createTabData } from './tab-data';
+
+const filterValue = (timeZone: string): AnalyticsFilterValue => ({
+  fromDate: null,
+  toDate: null,
+  timeZone,
+  printerIds: [],
+  filamentIds: [],
+  projectIds: [],
+  statuses: [],
+  granularity: 'Auto',
+  comparePrevious: false,
+});
+
+describe('createTabData', () => {
+  let injector: Injector;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    injector = TestBed.inject(Injector);
+  });
+
+  it('starts loading and becomes ready with the response', fakeAsync(() => {
+    const filter = signal(filterValue('UTC'));
+    const responses = new Subject<{ count: number }>();
+
+    const tab = runInInjectionContext(injector, () =>
+      createTabData(
+        filter,
+        () => responses,
+        (r) => r.count === 0
+      )
+    );
+
+    tick(250);
+    expect(tab.state()).toBe('loading');
+
+    responses.next({ count: 3 });
+    expect(tab.state()).toBe('ready');
+    expect(tab.data()).toEqual({ count: 3 });
+  }));
+
+  it('reports empty when the response has no data', fakeAsync(() => {
+    const filter = signal(filterValue('UTC'));
+    const responses = new Subject<{ count: number }>();
+
+    const tab = runInInjectionContext(injector, () =>
+      createTabData(
+        filter,
+        () => responses,
+        (r) => r.count === 0
+      )
+    );
+
+    tick(250);
+    responses.next({ count: 0 });
+
+    expect(tab.state()).toBe('empty');
+  }));
+
+  it('fails the whole tab on an error and recovers on retry', fakeAsync(() => {
+    const filter = signal(filterValue('UTC'));
+    let attempt = 0;
+
+    const tab = runInInjectionContext(injector, () =>
+      createTabData(
+        filter,
+        () => {
+          attempt++;
+          // First load fails, second succeeds — so the test proves BOTH that an error
+          // surfaces and that retry actually clears it.
+          return attempt === 1
+            ? throwError(() => new Error('boom'))
+            : of({ count: 2 });
+        },
+        (r) => r.count === 0
+      )
+    );
+
+    tick(250);
+    expect(attempt).toBe(1);
+    expect(tab.state()).toBe('error');
+    expect(tab.data()).toBeNull();
+
+    tab.retry();
+    tick(250);
+    expect(attempt).toBe(2);
+    expect(tab.state()).toBe('ready');
+    expect(tab.data()).toEqual({ count: 2 });
+  }));
+
+  it('never applies a response from a superseded filter', fakeAsync(() => {
+    const filter = signal(filterValue('UTC'));
+    const byZone = new Map<string, Subject<{ zone: string }>>();
+
+    const tab = runInInjectionContext(injector, () =>
+      createTabData(
+        filter,
+        (f) => {
+          const subject = new Subject<{ zone: string }>();
+          byZone.set(f.timeZone, subject);
+          return subject;
+        },
+        () => false
+      )
+    );
+
+    tick(250);
+    filter.set(filterValue('America/Chicago'));
+    tick(250);
+
+    // The FIRST request answers last. switchMap must have unsubscribed it, so the stale
+    // answer can never land on top of the newer one.
+    byZone.get('UTC')!.next({ zone: 'UTC' });
+    byZone.get('America/Chicago')!.next({ zone: 'America/Chicago' });
+
+    expect(tab.data()).toEqual({ zone: 'America/Chicago' });
+  }));
+});

--- a/src/app/analytics/tabs/tab-data.ts
+++ b/src/app/analytics/tabs/tab-data.ts
@@ -1,0 +1,72 @@
+import { Signal, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import {
+  EMPTY,
+  Observable,
+  Subject,
+  catchError,
+  debounceTime,
+  map,
+  merge,
+  of,
+  switchMap,
+  tap,
+} from 'rxjs';
+import { ChartState } from 'src/app/shared/charts/chart-frame.component';
+import { AnalyticsFilterValue } from '../models/analytics.models';
+
+export interface TabData<T> {
+  readonly data: Signal<T | null>;
+  readonly state: Signal<ChartState>;
+  retry(): void;
+}
+
+/**
+ * The request hygiene every analytics tab needs, written once.
+ *
+ * The outer switchMap is load-bearing twice over: it cancels the in-flight request when the
+ * filter changes, AND it guarantees a late response from a superseded request can never be
+ * applied over a newer one. Replacing it with mergeMap or a manual subscription reintroduces
+ * exactly the bug the spec calls out. Errors fail the WHOLE tab (spec §6.3) — the per-tab
+ * endpoint choice means individual widgets do not fail independently.
+ *
+ * Must be called in an injection context (a component constructor or field initializer),
+ * because it uses takeUntilDestroyed.
+ */
+export function createTabData<T>(
+  filter: Signal<AnalyticsFilterValue>,
+  load: (filter: AnalyticsFilterValue) => Observable<T>,
+  isEmpty: (response: T) => boolean
+): TabData<T> {
+  const data = signal<T | null>(null);
+  const state = signal<ChartState>('loading');
+  const retry$ = new Subject<void>();
+
+  toObservable(filter)
+    .pipe(
+      debounceTime(250),
+      switchMap((current) =>
+        merge(of(current), retry$.pipe(map(() => current)))
+      ),
+      tap(() => state.set('loading')),
+      switchMap((current) =>
+        load(current).pipe(
+          catchError(() => {
+            state.set('error');
+            return EMPTY;
+          })
+        )
+      ),
+      takeUntilDestroyed()
+    )
+    .subscribe((response) => {
+      data.set(response);
+      state.set(isEmpty(response) ? 'empty' : 'ready');
+    });
+
+  return {
+    data: data.asReadonly(),
+    state: state.asReadonly(),
+    retry: () => retry$.next(),
+  };
+}

--- a/src/app/core/services/print.service.spec.ts
+++ b/src/app/core/services/print.service.spec.ts
@@ -1,5 +1,8 @@
 import { TestBed } from '@angular/core/testing';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import {
+  HttpTestingController,
+  provideHttpClientTesting,
+} from '@angular/common/http/testing';
 import {
   provideHttpClient,
   withInterceptorsFromDi,
@@ -22,6 +25,70 @@ describe('PrintService', () => {
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  // Scoped so httpMock.verify() applies only to the requests these specs make; the rest of the
+  // file exercises pure calculation helpers that issue none.
+  describe('getPrintSummaries', () => {
+    let httpMock: HttpTestingController;
+
+    beforeEach(() => {
+      httpMock = TestBed.inject(HttpTestingController);
+    });
+
+    afterEach(() => httpMock.verify());
+
+    const emptyPage = {
+      items: [],
+      pageNumber: 1,
+      totalPages: 0,
+      totalCount: 0,
+    };
+
+    it('sends a half-open date range when one is supplied', () => {
+      service
+        .getPrintSummaries(
+          1,
+          10,
+          '',
+          null,
+          [],
+          [],
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          {
+            fromDate: '2026-07-01T00:00:00.000Z',
+            toDate: '2026-07-02T00:00:00.000Z',
+          }
+        )
+        .subscribe();
+
+      const request = httpMock.expectOne((candidate) =>
+        candidate.url.endsWith('/api/Prints/summary')
+      );
+
+      expect(request.request.params.get('fromDate')).toBe(
+        '2026-07-01T00:00:00.000Z'
+      );
+      expect(request.request.params.get('toDate')).toBe(
+        '2026-07-02T00:00:00.000Z'
+      );
+      request.flush(emptyPage);
+    });
+
+    it('omits the range parameters entirely when none is supplied', () => {
+      service.getPrintSummaries(1, 10).subscribe();
+
+      const request = httpMock.expectOne((candidate) =>
+        candidate.url.endsWith('/api/Prints/summary')
+      );
+
+      expect(request.request.params.has('fromDate')).toBeFalse();
+      expect(request.request.params.has('toDate')).toBeFalse();
+      request.flush(emptyPage);
+    });
   });
 
   describe('calculateElectricityCost', () => {

--- a/src/app/core/services/print.service.ts
+++ b/src/app/core/services/print.service.ts
@@ -282,7 +282,13 @@ export class PrintService {
     sortDirection = SortDirection.Desc,
     sortColumn = PrintSummarySortColumn.StartDate,
     userId?: number,
-    filterByProjectId?: string
+    filterByProjectId?: string,
+    /**
+     * Half-open [fromDate, toDate), matching the API and the analytics contract. Passed as an
+     * object rather than two more positional arguments: this signature already has ten, and the
+     * pair is meaningless split apart.
+     */
+    dateRange?: { fromDate: string; toDate: string }
   ): Observable<PagedList<PrintSummary>> {
     const url = `${this.baseApi}/api/Prints/summary`;
     const headers = new HttpHeaders().set('allow-anonymous-request', 'true');
@@ -319,6 +325,14 @@ export class PrintService {
 
     if (filterByProjectId) {
       params = params.set('filterByProjectId', filterByProjectId);
+    }
+
+    // Both ends or neither: the API rejects a half-supplied range with a 400, and sending one
+    // end alone would filter in a way the user never asked for.
+    if (dateRange?.fromDate && dateRange?.toDate) {
+      params = params
+        .set('fromDate', dateRange.fromDate)
+        .set('toDate', dateRange.toDate);
     }
 
     return this.http.get<PagedList<PrintSummary>>(url, { params, headers });

--- a/src/app/print/resolvers/print-list-resolver.service.spec.ts
+++ b/src/app/print/resolvers/print-list-resolver.service.spec.ts
@@ -1,14 +1,67 @@
 import { TestBed } from '@angular/core/testing';
-
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { of } from 'rxjs';
+import { PrintService } from 'src/app/core/services/print.service';
 import { PrintListResolverService } from './print-list-resolver.service';
 
-xdescribe('PrintListResolverService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+describe('PrintListResolverService', () => {
+  let resolver: PrintListResolverService;
+  let printService: jasmine.SpyObj<PrintService>;
+
+  const routeWith = (queryParams: Record<string, string>) =>
+    ({
+      queryParams,
+      queryParamMap: { getAll: () => [] },
+    }) as unknown as ActivatedRouteSnapshot;
+
+  beforeEach(() => {
+    printService = jasmine.createSpyObj<PrintService>('PrintService', [
+      'getPrintSummaries',
+    ]);
+    printService.getPrintSummaries.and.returnValue(of(null!));
+
+    TestBed.configureTestingModule({
+      providers: [
+        PrintListResolverService,
+        { provide: PrintService, useValue: printService },
+      ],
+    });
+    resolver = TestBed.inject(PrintListResolverService);
+  });
 
   it('should be created', () => {
-    const service: PrintListResolverService = TestBed.inject(
-      PrintListResolverService
+    expect(resolver).toBeTruthy();
+  });
+
+  it('forwards a fromDate/toDate pair from the URL', () => {
+    resolver.resolve(
+      routeWith({
+        fromDate: '2026-07-01T00:00:00.000Z',
+        toDate: '2026-07-02T00:00:00.000Z',
+      }),
+      {} as RouterStateSnapshot
     );
-    expect(service).toBeTruthy();
+
+    // Asserted positionally rather than with jasmine.anything(): that matcher rejects null,
+    // and filterByStatus legitimately defaults to null. What matters here is that the range
+    // arrives as the ELEVENTH argument — the slot getPrintSummaries reads it from — and that
+    // userId stays undefined, since sending one narrows the list to public prints.
+    const args = printService.getPrintSummaries.calls.mostRecent().args;
+    expect(args[8]).toBeUndefined();
+    expect(args[9]).toBeUndefined();
+    expect(args[10]).toEqual({
+      fromDate: '2026-07-01T00:00:00.000Z',
+      toDate: '2026-07-02T00:00:00.000Z',
+    });
+  });
+
+  it('passes no range when only one end is present', () => {
+    resolver.resolve(
+      routeWith({ fromDate: '2026-07-01T00:00:00.000Z' }),
+      {} as RouterStateSnapshot
+    );
+
+    const args = printService.getPrintSummaries.calls.mostRecent().args;
+    expect(args[10]).toBeUndefined();
   });
 });

--- a/src/app/print/resolvers/print-list-resolver.service.ts
+++ b/src/app/print/resolvers/print-list-resolver.service.ts
@@ -24,7 +24,14 @@ export class PrintListResolverService {
       filterByStatus = null,
       sortDirection = SortDirection.Desc,
       sortColumn = PrintSummarySortColumn.StartDate,
+      fromDate = null,
+      toDate = null,
     } = route.queryParams;
+
+    // Both ends or neither: a half-open range with one end open is not a range, and sending
+    // one alone would filter in a way the user never asked for. The API 400s on a half-supplied
+    // pair, so this also keeps a hand-edited URL from breaking the page.
+    const dateRange = fromDate && toDate ? { fromDate, toDate } : undefined;
 
     const printerIds = route.queryParamMap
       .getAll('filterByPrinterId')
@@ -40,7 +47,10 @@ export class PrintListResolverService {
       printerIds,
       filamentIds,
       sortDirection,
-      sortColumn
+      sortColumn,
+      undefined,
+      undefined,
+      dateRange
     );
   }
   constructor(private printService: PrintService) {}

--- a/src/app/shared/charts/bar-chart.component.ts
+++ b/src/app/shared/charts/bar-chart.component.ts
@@ -77,7 +77,24 @@ export class BarChartComponent {
     return 'vertical';
   });
 
-  private readonly margin = { top: 8, right: 12, bottom: 28, left: 44 };
+  /**
+   * The left gutter holds numeric value ticks when the bars are vertical, but the CATEGORY
+   * labels when they are horizontal — and a printer name does not fit in 44px, so it was
+   * being clipped. Widened to the longest label in horizontal mode, and capped so a long
+   * name cannot squeeze the plot itself out of existence.
+   */
+  private readonly margin = computed(() => {
+    const base = { top: 8, right: 12, bottom: 28, left: 44 };
+    if (this.resolvedOrientation() !== 'horizontal') return base;
+
+    const longest = this.data().reduce(
+      (max, datum) => Math.max(max, (datum.label ?? '').length),
+      0
+    );
+    // ~6.5px per character at the 10px axis font, plus padding off the edge.
+    const needed = Math.round(longest * 6.5) + 12;
+    return { ...base, left: Math.min(180, Math.max(base.left, needed)) };
+  });
   readonly tooltip = signal<ChartTooltip | null>(null);
 
   private readonly maxValue = computed(
@@ -97,11 +114,11 @@ export class BarChartComponent {
 
     const innerW = Math.max(
       0,
-      this.width() - this.margin.left - this.margin.right
+      this.width() - this.margin().left - this.margin().right
     );
     const innerH = Math.max(
       0,
-      this.height() - this.margin.top - this.margin.bottom
+      this.height() - this.margin().top - this.margin().bottom
     );
     const scale = d3
       .scaleLinear()
@@ -110,9 +127,9 @@ export class BarChartComponent {
 
     return scale.ticks(4).map((value) => ({
       value,
-      y: this.margin.top + scale(value),
-      x1: this.margin.left,
-      x2: this.margin.left + innerW,
+      y: this.margin().top + scale(value),
+      x1: this.margin().left,
+      x2: this.margin().left + innerW,
     }));
   });
 
@@ -127,11 +144,11 @@ export class BarChartComponent {
 
     const innerW = Math.max(
       0,
-      this.width() - this.margin.left - this.margin.right
+      this.width() - this.margin().left - this.margin().right
     );
     const innerH = Math.max(
       0,
-      this.height() - this.margin.top - this.margin.bottom
+      this.height() - this.margin().top - this.margin().bottom
     );
     const band = d3
       .scaleBand<string>()
@@ -140,11 +157,11 @@ export class BarChartComponent {
       .padding(0.2);
 
     return this.data().map((datum) => {
-      const x = this.margin.left + (band(datum.fullLabel) ?? 0);
+      const x = this.margin().left + (band(datum.fullLabel) ?? 0);
       return {
         datum,
         x,
-        y: this.margin.top,
+        y: this.margin().top,
         w: band.bandwidth(),
         h: innerH,
         crosshairX: x + band.bandwidth() / 2,
@@ -161,8 +178,8 @@ export class BarChartComponent {
     // Never draw before the container has been measured; scales would be degenerate.
     if (w <= 0 || h <= 0 || data.length === 0 || series.length === 0) return [];
 
-    const innerW = Math.max(0, w - this.margin.left - this.margin.right);
-    const innerH = Math.max(0, h - this.margin.top - this.margin.bottom);
+    const innerW = Math.max(0, w - this.margin().left - this.margin().right);
+    const innerH = Math.max(0, h - this.margin().top - this.margin().bottom);
     const max = this.maxValue();
     const total = max === 0 ? 1 : max;
 
@@ -184,8 +201,8 @@ export class BarChartComponent {
           const y0 = value(cursor);
           const y1 = value(cursor + v);
           out.push({
-            x: this.margin.left + (band(d.fullLabel) ?? 0),
-            y: this.margin.top + y1,
+            x: this.margin().left + (band(d.fullLabel) ?? 0),
+            y: this.margin().top + y1,
             w: band.bandwidth(),
             h: Math.max(1, y0 - y1),
             seriesIndex: s.seriesIndex,
@@ -210,8 +227,8 @@ export class BarChartComponent {
           const v = d.values[s.key] ?? 0;
           if (v <= 0) continue;
           out.push({
-            x: this.margin.left + value(cursor),
-            y: this.margin.top + (band(d.fullLabel) ?? 0),
+            x: this.margin().left + value(cursor),
+            y: this.margin().top + (band(d.fullLabel) ?? 0),
             w: Math.max(1, value(v)),
             h: band.bandwidth(),
             seriesIndex: s.seriesIndex,
@@ -233,8 +250,8 @@ export class BarChartComponent {
     const h = this.height();
     if (w <= 0 || h <= 0 || data.length === 0) return [];
 
-    const innerW = Math.max(0, w - this.margin.left - this.margin.right);
-    const innerH = Math.max(0, h - this.margin.top - this.margin.bottom);
+    const innerW = Math.max(0, w - this.margin().left - this.margin().right);
+    const innerH = Math.max(0, h - this.margin().top - this.margin().bottom);
     const vertical = this.resolvedOrientation() === 'vertical';
 
     const band = d3
@@ -255,11 +272,11 @@ export class BarChartComponent {
         key: d.fullLabel,
         text: d.label,
         x: vertical
-          ? this.margin.left + (band(d.fullLabel) ?? 0) + band.bandwidth() / 2
-          : this.margin.left - 6,
+          ? this.margin().left + (band(d.fullLabel) ?? 0) + band.bandwidth() / 2
+          : this.margin().left - 6,
         y: vertical
-          ? this.margin.top + innerH + 18
-          : this.margin.top +
+          ? this.margin().top + innerH + 18
+          : this.margin().top +
             (band(d.fullLabel) ?? 0) +
             band.bandwidth() / 2 +
             4,
@@ -282,7 +299,7 @@ export class BarChartComponent {
         }))
         .filter((line) => line.value > 0),
       x: bucket.crosshairX,
-      y: this.margin.top,
+      y: this.margin().top,
       crosshairX: bucket.crosshairX,
     });
   }
@@ -300,7 +317,7 @@ export class BarChartComponent {
         },
       ],
       x: segment.x + segment.w / 2,
-      y: Math.max(this.margin.top, segment.y),
+      y: Math.max(this.margin().top, segment.y),
       crosshairX: segment.x + segment.w / 2,
     });
   }

--- a/src/app/shared/charts/calendar-heatmap.component.html
+++ b/src/app/shared/charts/calendar-heatmap.component.html
@@ -1,10 +1,15 @@
-<div class="calendar-heatmap">
+<div class="calendar-heatmap" #calendarScroll>
   @if (cells().length > 0) {
+    <!--
+      Drawn at its natural size, NOT stretched to the container. The cells grow into the
+      available width via the pitch computed in the component, so a short range renders a
+      few normal-sized cells rather than a handful of enormous ones.
+    -->
     <svg
       class="calendar-heatmap__svg"
       [attr.width]="gridWidth()"
-      [attr.height]="gridHeight"
-      [attr.viewBox]="'0 0 ' + gridWidth() + ' ' + gridHeight"
+      [attr.height]="gridHeight()"
+      [attr.viewBox]="'0 0 ' + gridWidth() + ' ' + gridHeight()"
       role="img"
     >
       @for (label of monthLabels(); track label.x) {
@@ -19,16 +24,16 @@
             class="calendar-heatmap__cell chart-heat-{{ cell.level }}"
             [attr.x]="cell.x"
             [attr.y]="cell.y"
-            [attr.width]="cellSize"
-            [attr.height]="cellSize"
+            [attr.width]="cellSize()"
+            [attr.height]="cellSize()"
             rx="2"
           />
           <rect
             class="calendar-heatmap__hit"
-            [attr.x]="cell.x - (hitSize - cellSize) / 2"
-            [attr.y]="cell.y - (hitSize - cellSize) / 2"
-            [attr.width]="hitSize"
-            [attr.height]="hitSize"
+            [attr.x]="cell.x - (hitSize() - cellSize()) / 2"
+            [attr.y]="cell.y - (hitSize() - cellSize()) / 2"
+            [attr.width]="hitSize()"
+            [attr.height]="hitSize()"
             tabindex="0"
             role="button"
             [attr.aria-label]="cell.label"

--- a/src/app/shared/charts/calendar-heatmap.component.html
+++ b/src/app/shared/charts/calendar-heatmap.component.html
@@ -1,0 +1,45 @@
+<div class="calendar-heatmap">
+  @if (cells().length > 0) {
+    <svg
+      class="calendar-heatmap__svg"
+      [attr.width]="gridWidth()"
+      [attr.height]="gridHeight"
+      [attr.viewBox]="'0 0 ' + gridWidth() + ' ' + gridHeight"
+      role="img"
+    >
+      @for (label of monthLabels(); track label.x) {
+        <text class="calendar-heatmap__month" [attr.x]="label.x" [attr.y]="10">
+          {{ label.text }}
+        </text>
+      }
+
+      @for (cell of cells(); track cell.date) {
+        <g>
+          <rect
+            class="calendar-heatmap__cell chart-heat-{{ cell.level }}"
+            [attr.x]="cell.x"
+            [attr.y]="cell.y"
+            [attr.width]="cellSize"
+            [attr.height]="cellSize"
+            rx="2"
+          />
+          <rect
+            class="calendar-heatmap__hit"
+            [attr.x]="cell.x - (hitSize - cellSize) / 2"
+            [attr.y]="cell.y - (hitSize - cellSize) / 2"
+            [attr.width]="hitSize"
+            [attr.height]="hitSize"
+            tabindex="0"
+            role="button"
+            [attr.aria-label]="cell.label"
+            (click)="onSelect(cell)"
+            (keydown.enter)="onSelect(cell)"
+            (keydown.space)="onSelect(cell)"
+          >
+            <title>{{ cell.label }}</title>
+          </rect>
+        </g>
+      }
+    </svg>
+  }
+</div>

--- a/src/app/shared/charts/calendar-heatmap.component.scss
+++ b/src/app/shared/charts/calendar-heatmap.component.scss
@@ -1,0 +1,36 @@
+.calendar-heatmap {
+  // The SCROLL lives here, never on the page body. A phone shows the recent end and the user
+  // scrolls back; the page itself must not gain a horizontal scrollbar.
+  overflow-x: auto;
+  overflow-y: hidden;
+  max-inline-size: 100%;
+  min-inline-size: 0;
+  scroll-snap-type: x proximity;
+  direction: rtl; // start scrolled to the most recent week
+}
+
+.calendar-heatmap__svg {
+  direction: ltr; // undo the container trick for the content itself
+  display: block;
+}
+
+.calendar-heatmap__month {
+  font-size: 9px;
+  fill: var(--chart-axis-text);
+  scroll-snap-align: start;
+}
+
+.calendar-heatmap__cell {
+  stroke: var(--chart-swatch-outline);
+  stroke-width: 0.5;
+}
+
+.calendar-heatmap__hit {
+  fill: transparent;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid var(--chart-axis-text);
+    outline-offset: 1px;
+  }
+}

--- a/src/app/shared/charts/calendar-heatmap.component.scss
+++ b/src/app/shared/charts/calendar-heatmap.component.scss
@@ -6,11 +6,21 @@
   max-inline-size: 100%;
   min-inline-size: 0;
   scroll-snap-type: x proximity;
-  direction: rtl; // start scrolled to the most recent week
+
+  // Centred when the grid is narrower than the panel — a short date range is only a few
+  // week-columns wide, and left-aligning it in a wide card reads as a rendering fault
+  // rather than as "you filtered to a short range". `safe` keeps the start edge reachable
+  // when it DOES overflow, which plain centring would clip.
+  display: flex;
+  justify-content: safe center;
+
+  // Deliberately NOT `direction: rtl`. That started the scroll at the recent end, but on a
+  // panel wider than the grid it also right-aligned the whole calendar, stranding it in the
+  // corner of the card. The component scrolls to the recent end itself, which does the same
+  // job only when there is actually something to scroll.
 }
 
 .calendar-heatmap__svg {
-  direction: ltr; // undo the container trick for the content itself
   display: block;
 }
 

--- a/src/app/shared/charts/calendar-heatmap.component.spec.ts
+++ b/src/app/shared/charts/calendar-heatmap.component.spec.ts
@@ -1,0 +1,89 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CalendarHeatmapComponent } from './calendar-heatmap.component';
+
+describe('CalendarHeatmapComponent', () => {
+  let fixture: ComponentFixture<CalendarHeatmapComponent>;
+  let component: CalendarHeatmapComponent;
+
+  const days = (count: number) =>
+    Array.from({ length: count }, (_, i) => {
+      const date = new Date(2026, 0, 1 + i);
+      const iso = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`;
+      return { date: iso, count: i % 5 };
+    });
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CalendarHeatmapComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CalendarHeatmapComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('width', 800);
+    fixture.componentRef.setInput('height', 160);
+  });
+
+  it('renders one cell per day', () => {
+    fixture.componentRef.setInput('days', days(30));
+    fixture.detectChanges();
+
+    expect(component.cells().length).toBe(30);
+  });
+
+  it('renders nothing rather than throwing when there are no days', () => {
+    fixture.componentRef.setInput('days', []);
+    fixture.detectChanges();
+
+    expect(component.cells()).toEqual([]);
+    expect(
+      fixture.nativeElement.querySelectorAll('rect.calendar-heatmap__cell')
+        .length
+    ).toBe(0);
+  });
+
+  it('gives a zero-count day level 0 and a non-zero day at least level 1', () => {
+    fixture.componentRef.setInput('days', [
+      { date: '2026-01-01', count: 0 },
+      { date: '2026-01-02', count: 1 },
+    ]);
+    fixture.detectChanges();
+
+    const [empty, active] = component.cells();
+    expect(empty.level).toBe(0);
+    expect(active.level).toBeGreaterThanOrEqual(1);
+  });
+
+  it('places each day in the column for its week and the row for its weekday', () => {
+    // 2026-01-04 is a Sunday, so it opens a new column at weekday row 0.
+    fixture.componentRef.setInput('days', [
+      { date: '2026-01-03', count: 1 }, // Saturday
+      { date: '2026-01-04', count: 1 }, // Sunday
+    ]);
+    fixture.detectChanges();
+
+    const [saturday, sunday] = component.cells();
+    expect(sunday.x).toBeGreaterThan(saturday.x);
+    expect(sunday.y).toBeLessThan(saturday.y);
+  });
+
+  it('labels every cell for screen readers and tooltips', () => {
+    fixture.componentRef.setInput('days', [{ date: '2026-01-01', count: 3 }]);
+    fixture.detectChanges();
+
+    expect(component.cells()[0].label).toContain('3');
+  });
+
+  it('emits the clicked day so the parent can link to a filtered print list', () => {
+    fixture.componentRef.setInput('days', [{ date: '2026-01-01', count: 3 }]);
+    fixture.detectChanges();
+
+    let emitted: { date: string } | null = null;
+    component.daySelect.subscribe((event) => (emitted = event));
+
+    fixture.nativeElement
+      .querySelector('rect.calendar-heatmap__hit')
+      .dispatchEvent(new MouseEvent('click'));
+
+    expect(emitted).toEqual({ date: '2026-01-01' });
+  });
+});

--- a/src/app/shared/charts/calendar-heatmap.component.ts
+++ b/src/app/shared/charts/calendar-heatmap.component.ts
@@ -1,0 +1,141 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  output,
+} from '@angular/core';
+import { CalendarDay } from 'src/app/analytics/models/analytics.models';
+import { parseLocalDate } from './chart-axis';
+
+export interface CalendarCell {
+  date: string;
+  count: number;
+  x: number;
+  y: number;
+  /** 0 = nothing happened; 1-4 are quantile steps over the non-zero days. */
+  level: number;
+  label: string;
+}
+
+export interface CalendarMonthLabel {
+  x: number;
+  text: string;
+}
+
+const CELL = 11;
+const GAP = 2;
+const STEP = CELL + GAP;
+const TOP = 16; // room for the month labels
+
+/**
+ * A GitHub-style activity calendar: one column per week, one row per weekday with Sunday at the
+ * top, so reading left to right is reading forward in time.
+ *
+ * Levels are QUANTILE-based over the non-zero days. A linear ramp is unreadable on real data:
+ * one 40-print day and three hundred 1-print days would render as a single bright square in a
+ * field of identical faint ones. Level 0 is reserved for zero, so "nothing happened" can never
+ * be mistaken for "a little happened".
+ */
+@Component({
+  selector: 'app-calendar-heatmap',
+  templateUrl: './calendar-heatmap.component.html',
+  styleUrls: ['./calendar-heatmap.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class CalendarHeatmapComponent {
+  readonly days = input<CalendarDay[]>([]);
+  readonly width = input(0);
+  readonly height = input(0);
+
+  readonly daySelect = output<{ date: string }>();
+
+  /** Enlarged transparent hit area, so a 11px cell still meets the touch-target rule. */
+  readonly hitSize = 16;
+
+  private readonly thresholds = computed(() => {
+    const active = this.days()
+      .map((d) => d.count)
+      .filter((c) => c > 0)
+      .sort((a, b) => a - b);
+
+    if (active.length === 0) return [] as number[];
+
+    const at = (q: number) =>
+      active[Math.min(active.length - 1, Math.floor(q * active.length))];
+    return [at(0.25), at(0.5), at(0.75)];
+  });
+
+  readonly cells = computed<CalendarCell[]>(() => {
+    const days = this.days();
+    if (days.length === 0) return [];
+
+    const first = parseLocalDate(days[0].date);
+    // Column 0 is the week containing the first day, so a mid-week start does not shift
+    // every subsequent weekday row by one.
+    const offset = first.getDay();
+    const thresholds = this.thresholds();
+
+    return days.map((day, index) => {
+      const slot = index + offset;
+      const level =
+        day.count === 0
+          ? 0
+          : thresholds.length === 0
+            ? 4
+            : day.count <= thresholds[0]
+              ? 1
+              : day.count <= thresholds[1]
+                ? 2
+                : day.count <= thresholds[2]
+                  ? 3
+                  : 4;
+
+      const date = parseLocalDate(day.date);
+      return {
+        date: day.date,
+        count: day.count,
+        x: Math.floor(slot / 7) * STEP,
+        y: TOP + (slot % 7) * STEP,
+        level,
+        label: `${date.toLocaleDateString(undefined, {
+          weekday: 'short',
+          month: 'short',
+          day: 'numeric',
+          year: 'numeric',
+        })}: ${day.count} print${day.count === 1 ? '' : 's'}`,
+      };
+    });
+  });
+
+  readonly monthLabels = computed<CalendarMonthLabel[]>(() => {
+    const labels: CalendarMonthLabel[] = [];
+    let lastMonth = -1;
+
+    for (const cell of this.cells()) {
+      const date = parseLocalDate(cell.date);
+      if (date.getMonth() === lastMonth) continue;
+      lastMonth = date.getMonth();
+      labels.push({
+        x: cell.x,
+        text: date.toLocaleDateString(undefined, { month: 'short' }),
+      });
+    }
+
+    return labels;
+  });
+
+  /** The intrinsic width the grid needs. The container scrolls when it is narrower. */
+  readonly gridWidth = computed(() => {
+    const cells = this.cells();
+    return cells.length === 0 ? 0 : cells[cells.length - 1].x + CELL;
+  });
+
+  readonly gridHeight = TOP + 7 * STEP;
+
+  readonly cellSize = CELL;
+
+  onSelect(cell: CalendarCell): void {
+    this.daySelect.emit({ date: cell.date });
+  }
+}

--- a/src/app/shared/charts/calendar-heatmap.component.ts
+++ b/src/app/shared/charts/calendar-heatmap.component.ts
@@ -1,9 +1,12 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
   computed,
+  effect,
   input,
   output,
+  viewChild,
 } from '@angular/core';
 import { CalendarDay } from 'src/app/analytics/models/analytics.models';
 import { parseLocalDate } from './chart-axis';
@@ -23,10 +26,19 @@ export interface CalendarMonthLabel {
   text: string;
 }
 
-const CELL = 11;
 const GAP = 2;
-const STEP = CELL + GAP;
 const TOP = 16; // room for the month labels
+
+/**
+ * Cell size is clamped, not free.
+ *
+ * The minimum keeps a 53-week calendar legible on a phone (below this the container scrolls
+ * instead of shrinking further). The maximum is what stops a SHORT range — a week-long
+ * filter is five or six columns — from inflating a handful of cells to fill a desktop
+ * panel, which turns a calendar into a wall of enormous squares.
+ */
+const MIN_STEP = 13;
+const MAX_STEP = 22;
 
 /**
  * A GitHub-style activity calendar: one column per week, one row per weekday with Sunday at the
@@ -50,8 +62,27 @@ export class CalendarHeatmapComponent {
 
   readonly daySelect = output<{ date: string }>();
 
-  /** Enlarged transparent hit area, so a 11px cell still meets the touch-target rule. */
-  readonly hitSize = 16;
+  /**
+   * Transparent hit area, never smaller than the cell it covers. At the minimum pitch it is
+   * deliberately LARGER, so a small cell still meets the touch-target rule without the grid
+   * being drawn any bigger.
+   */
+  readonly hitSize = computed(() => Math.max(16, this.cellSize()));
+
+  private readonly scroller =
+    viewChild<ElementRef<HTMLElement>>('calendarScroll');
+
+  constructor() {
+    // Open on the most recent week, which is the end a reader cares about. Done here rather
+    // than with `direction: rtl` on the container: that also right-aligns the grid when the
+    // panel is wider than the calendar, which left it stranded in the corner of the card.
+    // Setting scrollLeft is inert when there is nothing to scroll.
+    effect(() => {
+      this.cells();
+      const el = this.scroller()?.nativeElement;
+      if (el) el.scrollLeft = el.scrollWidth;
+    });
+  }
 
   private readonly thresholds = computed(() => {
     const active = this.days()
@@ -66,6 +97,30 @@ export class CalendarHeatmapComponent {
     return [at(0.25), at(0.5), at(0.75)];
   });
 
+  /** Week columns the grid needs, including the partial first week. */
+  private readonly columns = computed(() => {
+    const days = this.days();
+    if (days.length === 0) return 0;
+    return Math.ceil((parseLocalDate(days[0].date).getDay() + days.length) / 7);
+  });
+
+  /**
+   * Grid pitch, derived from the measured panel width so the calendar grows into the space
+   * it is given instead of being scaled up as a whole image.
+   */
+  private readonly step = computed(() => {
+    const columns = this.columns();
+    const available = this.width();
+    if (columns === 0 || available <= 0) return MIN_STEP;
+
+    return Math.max(
+      MIN_STEP,
+      Math.min(MAX_STEP, Math.floor(available / columns))
+    );
+  });
+
+  readonly cellSize = computed(() => this.step() - GAP);
+
   readonly cells = computed<CalendarCell[]>(() => {
     const days = this.days();
     if (days.length === 0) return [];
@@ -75,6 +130,7 @@ export class CalendarHeatmapComponent {
     // every subsequent weekday row by one.
     const offset = first.getDay();
     const thresholds = this.thresholds();
+    const step = this.step();
 
     return days.map((day, index) => {
       const slot = index + offset;
@@ -95,8 +151,8 @@ export class CalendarHeatmapComponent {
       return {
         date: day.date,
         count: day.count,
-        x: Math.floor(slot / 7) * STEP,
-        y: TOP + (slot % 7) * STEP,
+        x: Math.floor(slot / 7) * step,
+        y: TOP + (slot % 7) * step,
         level,
         label: `${date.toLocaleDateString(undefined, {
           weekday: 'short',
@@ -125,15 +181,13 @@ export class CalendarHeatmapComponent {
     return labels;
   });
 
-  /** The intrinsic width the grid needs. The container scrolls when it is narrower. */
+  /** The width the grid needs at the current pitch. The container scrolls when narrower. */
   readonly gridWidth = computed(() => {
-    const cells = this.cells();
-    return cells.length === 0 ? 0 : cells[cells.length - 1].x + CELL;
+    const columns = this.columns();
+    return columns === 0 ? 0 : columns * this.step();
   });
 
-  readonly gridHeight = TOP + 7 * STEP;
-
-  readonly cellSize = CELL;
+  readonly gridHeight = computed(() => TOP + 7 * this.step());
 
   onSelect(cell: CalendarCell): void {
     this.daySelect.emit({ date: cell.date });

--- a/src/app/shared/charts/chart-frame.component.html
+++ b/src/app/shared/charts/chart-frame.component.html
@@ -1,4 +1,8 @@
-<mat-card appearance="outlined" class="chart-frame">
+<mat-card
+  appearance="outlined"
+  class="chart-frame"
+  [class.chart-frame--natural]="fit() === 'natural'"
+>
   <div class="chart-frame__header">
     <h3 class="chart-frame__title">{{ title() }}</h3>
     @if (coverageNote()) {

--- a/src/app/shared/charts/chart-frame.component.scss
+++ b/src/app/shared/charts/chart-frame.component.scss
@@ -39,10 +39,33 @@
 
     @container (min-width: 600px) {
       aspect-ratio: 3 / 2;
+      // A ratio alone runs away as the panel widens: at 680px, 3/2 is already 450px tall,
+      // and at 1400px 16/9 is 790px — one chart fills the screen and everything else is
+      // below the fold. The cap wins over the ratio and keeps a panel readable at any
+      // width. Deliberately from 600px, not 900px: the container here is the CARD, and a
+      // two-column desktop grid gives each card roughly 680px, so a 900px floor never
+      // matched the panels that actually needed capping.
+      max-block-size: 20rem;
     }
     @container (min-width: 900px) {
       aspect-ratio: 16 / 9;
     }
+  }
+
+  // Height comes from the content, for widgets whose size is intrinsic rather than
+  // proportional (the calendar heatmap, the comparison table, the maintenance list).
+  &--natural &__body {
+    aspect-ratio: auto;
+    max-block-size: none;
+    // Only while loading/empty, where the overlaid skeleton and message have nothing to
+    // give the box a height of its own.
+    min-block-size: 5rem;
+  }
+
+  // In natural mode the plot is in normal flow, so the content it wraps sets the height.
+  &--natural &__plot {
+    position: static;
+    inset: auto;
   }
 
   // The measured box. Fills the body exactly, and holds nothing but the plot, so its

--- a/src/app/shared/charts/chart-frame.component.ts
+++ b/src/app/shared/charts/chart-frame.component.ts
@@ -40,6 +40,17 @@ export class ChartFrameComponent implements OnDestroy {
   readonly coverage = input<Coverage | null>(null);
   readonly ariaSummary = input('');
 
+  /**
+   * How the body gets its height.
+   *
+   * 'aspect' (default) sizes the plot from an aspect ratio, which is right for charts that
+   * should scale with their container. 'natural' lets the projected content define the
+   * height, which is what an intrinsically-sized widget needs — a calendar heatmap is about
+   * 110px tall no matter how wide the panel is, and forcing 16/9 onto a full-width panel
+   * produced a 790px box with the content stranded in one corner.
+   */
+  readonly fit = input<'aspect' | 'natural'>('aspect');
+
   readonly retry = output<void>();
 
   private readonly body = viewChild<ElementRef<HTMLElement>>('chartBody');

--- a/src/app/shared/charts/chart-theme.scss
+++ b/src/app/shared/charts/chart-theme.scss
@@ -15,6 +15,14 @@
   --chart-tooltip-text: rgba(0, 0, 0, 0.87);
   --chart-swatch-outline: rgba(0, 0, 0, 0.45);
   --chart-empty-text: rgba(0, 0, 0, 0.54);
+
+  // Level 0 is "nothing happened" and is deliberately a surface tint, not the lightest step of
+  // the ramp — an empty day must never read as a quiet day.
+  --chart-heat-0: rgba(0, 0, 0, 0.06);
+  --chart-heat-1: #c6e48b;
+  --chart-heat-2: #7bc96f;
+  --chart-heat-3: #239a3b;
+  --chart-heat-4: #196127;
 }
 
 // ThemeService toggles `dark-theme` on <html>, before first paint (theme.service.ts:61).
@@ -32,6 +40,12 @@ html.dark-theme {
   --chart-tooltip-text: rgba(255, 255, 255, 0.92);
   --chart-swatch-outline: rgba(255, 255, 255, 0.6);
   --chart-empty-text: rgba(255, 255, 255, 0.6);
+
+  --chart-heat-0: rgba(255, 255, 255, 0.08);
+  --chart-heat-1: #0e4429;
+  --chart-heat-2: #006d32;
+  --chart-heat-3: #26a641;
+  --chart-heat-4: #39d353;
 }
 
 @for $i from 1 through 6 {
@@ -44,5 +58,11 @@ html.dark-theme {
   // For HTML legend swatches, which take background-color rather than SVG fill.
   .chart-bg-#{$i} {
     background-color: var(--chart-series-#{$i});
+  }
+}
+
+@for $i from 0 through 4 {
+  .chart-heat-#{$i} {
+    fill: var(--chart-heat-#{$i});
   }
 }

--- a/src/app/shared/charts/coverage-note.spec.ts
+++ b/src/app/shared/charts/coverage-note.spec.ts
@@ -1,0 +1,38 @@
+import { Coverage } from 'src/app/analytics/models/analytics.models';
+import { formatCoverageNote } from './coverage-note';
+
+const coverage = (
+  exclusions: { reason: string; count: number }[]
+): Coverage => ({
+  population: 'prints',
+  counted: 0,
+  total: 0,
+  undatedCount: 0,
+  exclusions,
+});
+
+describe('formatCoverageNote', () => {
+  it('returns null when nothing was excluded', () => {
+    expect(formatCoverageNote(coverage([]))).toBeNull();
+  });
+
+  it('renders the new reasons in plain language, never the enum name', () => {
+    const note = formatCoverageNote(
+      coverage([
+        { reason: 'DurationMissing', count: 2 },
+        { reason: 'WindowTruncated', count: 1 },
+      ])
+    );
+
+    expect(note).toBe(
+      '2 prints have no recorded duration · Showing the most recent 53 weeks'
+    );
+    expect(note).not.toContain('DurationMissing');
+  });
+
+  it('singularises a count of one', () => {
+    expect(
+      formatCoverageNote(coverage([{ reason: 'DurationMissing', count: 1 }]))
+    ).toBe('1 print has no recorded duration');
+  });
+});

--- a/src/app/shared/charts/coverage-note.ts
+++ b/src/app/shared/charts/coverage-note.ts
@@ -22,6 +22,11 @@ export function formatCoverageNote(
       `${count} outlier${count === 1 ? '' : 's'} excluded`,
     SampleTooSmall: () => 'Not enough data yet',
     Undated: (count) => `${printCount(count)} have no date`,
+    DurationMissing: (count) =>
+      `${printCount(count)} ${count === 1 ? 'has' : 'have'} no recorded duration`,
+    WindowTruncated: () => 'Showing the most recent 53 weeks',
+    UnattributedMaterial: (count) =>
+      `${printCount(count)} used filament that is not linked to a spool, so it is not in these groups`,
   };
 
   return coverage.exclusions

--- a/src/app/shared/charts/matrix-heatmap.component.html
+++ b/src/app/shared/charts/matrix-heatmap.component.html
@@ -1,0 +1,46 @@
+@if (rendered().length > 0) {
+  <svg
+    class="matrix-heatmap"
+    [attr.width]="width()"
+    [attr.height]="height()"
+    [attr.viewBox]="'0 0 ' + width() + ' ' + height()"
+    role="img"
+  >
+    @for (label of visibleColumnLabels(); track label.index) {
+      <text
+        class="matrix-heatmap__label"
+        [attr.x]="rowLabelWidth + label.index * cellWidth()"
+        [attr.y]="10"
+      >
+        {{ label.text }}
+      </text>
+    }
+
+    @for (label of rowLabels(); track label; let row = $index) {
+      <text
+        class="matrix-heatmap__label"
+        [attr.x]="0"
+        [attr.y]="columnLabelHeight + row * cellHeight() + cellHeight() / 2 + 3"
+      >
+        {{ label }}
+      </text>
+    }
+
+    @for (cell of rendered(); track cell.weekday + '-' + cell.hour) {
+      <rect
+        class="matrix-heatmap__cell chart-heat-{{ cell.level }}"
+        [attr.x]="cell.x"
+        [attr.y]="cell.y"
+        [attr.width]="cell.w"
+        [attr.height]="cell.h"
+        tabindex="0"
+        role="button"
+        [attr.aria-label]="cell.label"
+        (click)="onSelect(cell)"
+        (keydown.enter)="onSelect(cell)"
+      >
+        <title>{{ cell.label }}</title>
+      </rect>
+    }
+  </svg>
+}

--- a/src/app/shared/charts/matrix-heatmap.component.scss
+++ b/src/app/shared/charts/matrix-heatmap.component.scss
@@ -1,0 +1,18 @@
+.matrix-heatmap {
+  display: block;
+  max-inline-size: 100%;
+}
+
+.matrix-heatmap__label {
+  font-size: 10px;
+  fill: var(--chart-axis-text);
+}
+
+.matrix-heatmap__cell {
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid var(--chart-axis-text);
+    outline-offset: 1px;
+  }
+}

--- a/src/app/shared/charts/matrix-heatmap.component.spec.ts
+++ b/src/app/shared/charts/matrix-heatmap.component.spec.ts
@@ -1,0 +1,105 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatrixHeatmapComponent } from './matrix-heatmap.component';
+
+const fullGrid = (hot: { weekday: number; hour: number; count: number }[]) => {
+  const cells = [];
+  for (let weekday = 0; weekday < 7; weekday++) {
+    for (let hour = 0; hour < 24; hour++) {
+      const match = hot.find((h) => h.weekday === weekday && h.hour === hour);
+      cells.push({ weekday, hour, count: match?.count ?? 0 });
+    }
+  }
+  return cells;
+};
+
+describe('MatrixHeatmapComponent', () => {
+  let fixture: ComponentFixture<MatrixHeatmapComponent>;
+  let component: MatrixHeatmapComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MatrixHeatmapComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MatrixHeatmapComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('width', 700);
+    fixture.componentRef.setInput('height', 240);
+    fixture.componentRef.setInput('rowLabels', [
+      'Sun',
+      'Mon',
+      'Tue',
+      'Wed',
+      'Thu',
+      'Fri',
+      'Sat',
+    ]);
+    fixture.componentRef.setInput(
+      'columnLabels',
+      Array.from({ length: 24 }, (_, h) => `${h}`)
+    );
+  });
+
+  it('renders every cell it is given', () => {
+    fixture.componentRef.setInput('cells', fullGrid([]));
+    fixture.detectChanges();
+
+    expect(component.rendered().length).toBe(168);
+  });
+
+  it('scales the busiest cell to the top level and leaves zeroes at level 0', () => {
+    fixture.componentRef.setInput(
+      'cells',
+      fullGrid([{ weekday: 2, hour: 14, count: 9 }])
+    );
+    fixture.detectChanges();
+
+    const hot = component
+      .rendered()
+      .find((c) => c.weekday === 2 && c.hour === 14)!;
+    const cold = component
+      .rendered()
+      .find((c) => c.weekday === 0 && c.hour === 0)!;
+
+    expect(hot.level).toBe(4);
+    expect(cold.level).toBe(0);
+  });
+
+  it('renders nothing rather than throwing on an empty grid', () => {
+    fixture.componentRef.setInput('cells', []);
+    fixture.detectChanges();
+
+    expect(component.rendered()).toEqual([]);
+  });
+
+  it('labels each cell with its weekday, hour and count', () => {
+    fixture.componentRef.setInput(
+      'cells',
+      fullGrid([{ weekday: 1, hour: 9, count: 4 }])
+    );
+    fixture.detectChanges();
+
+    const cell = component
+      .rendered()
+      .find((c) => c.weekday === 1 && c.hour === 9)!;
+    expect(cell.label).toContain('Mon');
+    expect(cell.label).toContain('4');
+  });
+
+  it('emits the selected cell', () => {
+    fixture.componentRef.setInput(
+      'cells',
+      fullGrid([{ weekday: 1, hour: 9, count: 4 }])
+    );
+    fixture.detectChanges();
+
+    let emitted: { weekday: number; hour: number } | null = null;
+    component.cellSelect.subscribe((event) => (emitted = event));
+
+    component.onSelect(
+      component.rendered().find((c) => c.weekday === 1 && c.hour === 9)!
+    );
+
+    expect(emitted).toEqual({ weekday: 1, hour: 9 });
+  });
+});

--- a/src/app/shared/charts/matrix-heatmap.component.ts
+++ b/src/app/shared/charts/matrix-heatmap.component.ts
@@ -1,0 +1,115 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  output,
+} from '@angular/core';
+import { MatrixCell } from 'src/app/analytics/models/analytics.models';
+
+export interface RenderedMatrixCell {
+  weekday: number;
+  hour: number;
+  count: number;
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+  level: number;
+  label: string;
+}
+
+const ROW_LABEL_WIDTH = 34;
+const COLUMN_LABEL_HEIGHT = 14;
+
+/**
+ * A fixed row × column matrix that fills its container. Unlike the calendar heatmap this never
+ * scrolls and both axes are labelled, so the two are separate components rather than one with a
+ * mode flag controlling layout, labels, sizing and overflow.
+ *
+ * Levels are scaled against the busiest cell, which is the honest scale here: the question the
+ * chart answers is "when, relative to my own busiest hour, do I print?".
+ */
+@Component({
+  selector: 'app-matrix-heatmap',
+  templateUrl: './matrix-heatmap.component.html',
+  styleUrls: ['./matrix-heatmap.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MatrixHeatmapComponent {
+  readonly cells = input<MatrixCell[]>([]);
+  readonly width = input(0);
+  readonly height = input(0);
+  readonly rowLabels = input<string[]>([]);
+  readonly columnLabels = input<string[]>([]);
+
+  readonly cellSelect = output<{ weekday: number; hour: number }>();
+
+  readonly rowLabelWidth = ROW_LABEL_WIDTH;
+  readonly columnLabelHeight = COLUMN_LABEL_HEIGHT;
+
+  readonly rendered = computed<RenderedMatrixCell[]>(() => {
+    const cells = this.cells();
+    const rows = this.rowLabels().length;
+    const columns = this.columnLabels().length;
+    const width = this.width();
+    const height = this.height();
+
+    if (
+      cells.length === 0 ||
+      rows === 0 ||
+      columns === 0 ||
+      width <= 0 ||
+      height <= 0
+    ) {
+      return [];
+    }
+
+    const plotWidth = Math.max(0, width - ROW_LABEL_WIDTH);
+    const plotHeight = Math.max(0, height - COLUMN_LABEL_HEIGHT);
+    const cellWidth = plotWidth / columns;
+    const cellHeight = plotHeight / rows;
+
+    const max = cells.reduce((peak, c) => Math.max(peak, c.count), 0);
+
+    return cells.map((cell) => ({
+      weekday: cell.weekday,
+      hour: cell.hour,
+      count: cell.count,
+      x: ROW_LABEL_WIDTH + cell.hour * cellWidth,
+      y: COLUMN_LABEL_HEIGHT + cell.weekday * cellHeight,
+      w: Math.max(1, cellWidth - 1),
+      h: Math.max(1, cellHeight - 1),
+      level:
+        cell.count === 0 || max === 0
+          ? 0
+          : Math.max(1, Math.ceil((cell.count / max) * 4)),
+      label: `${this.rowLabels()[cell.weekday] ?? cell.weekday} ${this.columnLabels()[cell.hour] ?? cell.hour}: ${cell.count} print${cell.count === 1 ? '' : 's'}`,
+    }));
+  });
+
+  /** Every third hour, so labels never collide on a narrow container. */
+  readonly visibleColumnLabels = computed(() =>
+    this.columnLabels()
+      .map((text, index) => ({ text, index }))
+      .filter((c) => c.index % 3 === 0)
+  );
+
+  readonly cellWidth = computed(() => {
+    const columns = this.columnLabels().length;
+    return columns === 0
+      ? 0
+      : Math.max(0, this.width() - ROW_LABEL_WIDTH) / columns;
+  });
+
+  readonly cellHeight = computed(() => {
+    const rows = this.rowLabels().length;
+    return rows === 0
+      ? 0
+      : Math.max(0, this.height() - COLUMN_LABEL_HEIGHT) / rows;
+  });
+
+  onSelect(cell: RenderedMatrixCell): void {
+    this.cellSelect.emit({ weekday: cell.weekday, hour: cell.hour });
+  }
+}


### PR DESCRIPTION
Implements spec §15.2 (Part A) of the analytics redesign: the Activity and Printers tabs, two new chart components, and the shared request-hygiene helper the remaining tabs will use. Follows `docs/superpowers/plans/2026-07-30-analytics-phases-2-4.md`.

**Depends on HoffmanEngineering/3d-print-log-api#30** — merge that first.

## What's here

- **`createTabData`** — debounce, cancel-in-flight and discard-stale written once. The `switchMap` is load-bearing twice over: it cancels the superseded request *and* guarantees a late response can never overwrite a newer one. `OverviewTabComponent` was refactored onto it, so there is one copy of these rules rather than six.
- **Activity tab** — metric toggle (prints / time / filament / cost) served from a single payload, so switching is instant and the four figures describe the same prints; calendar heatmap, duration histogram, weekday×hour matrix.
- **Printers tab** — sortable comparison table that becomes a card list on narrow containers, success-rate and print-time charts, maintenance log.
- **`calendar-heatmap`** (quantile-scaled, so one busy day doesn't flatten the rest) and **`matrix-heatmap`**. Both declarative SVG — no d3 DOM mutation, so a resize is just a re-render.
- **Print list now honours a `fromDate`/`toDate` range** from the URL, which is what makes the calendar click-through actually filtered rather than merely looking filtered.

## Round 1 testing feedback, addressed

- Chart panels were taller than the viewport on desktop. The height cap keyed off a 900px *container*, but the container is the card — a two-column grid gives each ~680px, so the cap never applied to the panels that needed it.
- The calendar was stranded in a corner (an `rtl` scroll trick that also right-aligned it), then far too large when stretched. Cells are now sized from the measured width and clamped, so a short date range renders normal cells rather than a wall of enormous ones.
- The metric toggle sat above the tab and read as a global switch; it now lives in the header of the one panel it controls.
- Printer names were clipped on the horizontal bar chart — the left gutter holds category labels there, not value ticks, and 44px never fit a name.
- Comparison table headers floated mid-column above right-aligned figures (mat-button centres its label via flex, so `text-align` alone did nothing).
- The selected tab is now in the URL, so a refresh or a back navigation no longer drops you on Overview.
- An empty maintenance log says so instead of rendering a headerless table.

## Verification

- `npm run test:brief` — **829 passed.**
- `npm run lint:brief` — clean.
- `npx cypress run --spec "cypress/e2e/analytics/*.cy.ts"` — **16/16 passed** against the E2ETesting API, covering 375/768/1440 with no horizontal body scroll, the calendar click-through, and table sorting.

Note for anyone running the E2E suite: the API must be started with `--launch-profile "E2E Testing"`. Setting `ASPNETCORE_ENVIRONMENT` alone is silently overridden by `launchSettings.json`, and the suite then runs against an empty database and fails in ways that look like UI bugs.