### PR TITLE
feat(analytics): add the Materials tab and filament swatches in charts

### DIFF
--- a/cypress/e2e/analytics/analytics-materials.cy.ts
+++ b/cypress/e2e/analytics/analytics-materials.cy.ts
@@ -1,0 +1,49 @@
+const VIEWPORTS: [number, number][] = [
+  [375, 667],
+  [768, 1024],
+  [1440, 900],
+];
+
+describe('Analytics — Materials tab', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  VIEWPORTS.forEach(([width, height]) => {
+    it(`renders without horizontal body scroll at ${width}x${height}`, () => {
+      cy.viewport(width, height);
+      cy.visit('/analytics');
+      cy.contains('.mat-mdc-tab', 'Materials').click();
+
+      cy.get('app-materials-tab').should('exist');
+      cy.document().then((doc) => {
+        expect(doc.documentElement.scrollWidth).to.be.at.most(
+          doc.documentElement.clientWidth + 1
+        );
+      });
+    });
+  });
+
+  it('never emits a swatch gradient whose stop-color is not a hex colour', () => {
+    cy.viewport(1440, 900);
+    cy.visit('/analytics');
+    cy.contains('.mat-mdc-tab', 'Materials').click();
+
+    cy.get('app-materials-tab').should('exist');
+    cy.get('body').then(($body) => {
+      const stops = $body.find('stop');
+      stops.each((_, stop) => {
+        const color = stop.getAttribute('stop-color');
+        if (color) expect(color).to.match(/^#[0-9a-fA-F]{3,6}$/);
+      });
+    });
+  });
+
+  it('labels every swatch-filled bar with its material name, not colour alone', () => {
+    cy.viewport(1440, 900);
+    cy.visit('/analytics');
+    cy.contains('.mat-mdc-tab', 'Materials').click();
+
+    cy.get('app-materials-tab table[chartDataTable]').should('exist');
+  });
+});

--- a/cypress/e2e/analytics/analytics-materials.cy.ts
+++ b/cypress/e2e/analytics/analytics-materials.cy.ts
@@ -34,7 +34,10 @@ describe('Analytics — Materials tab', () => {
       const stops = $body.find('stop');
       stops.each((_, stop) => {
         const color = stop.getAttribute('stop-color');
-        if (color) expect(color).to.match(/^#[0-9a-fA-F]{3,6}$/);
+        // 3 or 6 digits exactly — {3,6} would also accept the 4- and 5-digit strings
+        // that the production validator (normalizeHex) rejects.
+        if (color)
+          expect(color).to.match(/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/);
       });
     });
   });

--- a/src/app/analytics/analytics-shell.component.html
+++ b/src/app/analytics/analytics-shell.component.html
@@ -26,5 +26,11 @@
         <app-printers-tab />
       }
     </mat-tab>
+
+    <mat-tab label="Materials">
+      @if (selectedIndex() === 3) {
+        <app-materials-tab />
+      }
+    </mat-tab>
   </mat-tab-group>
 </section>

--- a/src/app/analytics/analytics-shell.component.ts
+++ b/src/app/analytics/analytics-shell.component.ts
@@ -12,6 +12,7 @@ import { AnalyticsFilterBarComponent } from './filters/analytics-filter-bar.comp
 import { AnalyticsFilterStore } from './filters/analytics-filter.store';
 import { ActivityTabComponent } from './tabs/activity/activity-tab.component';
 import { OverviewTabComponent } from './tabs/overview/overview-tab.component';
+import { MaterialsTabComponent } from './tabs/materials/materials-tab.component';
 import { PrintersTabComponent } from './tabs/printers/printers-tab.component';
 
 /**
@@ -26,6 +27,7 @@ import { PrintersTabComponent } from './tabs/printers/printers-tab.component';
   imports: [
     ActivityTabComponent,
     AnalyticsFilterBarComponent,
+    MaterialsTabComponent,
     MatTabsModule,
     OverviewTabComponent,
     PrintersTabComponent,

--- a/src/app/analytics/models/analytics.models.ts
+++ b/src/app/analytics/models/analytics.models.ts
@@ -199,3 +199,62 @@ export interface PrintersResponse {
   maintenance: MaintenanceEvent[];
   coverage: Coverage;
 }
+
+export interface SwatchDto {
+  colors: string[];
+  colorPattern: number;
+  finishType: number;
+  effects: number[];
+}
+
+export interface MaterialGroup {
+  key: string;
+  label: string;
+  printCount: number;
+  materialMg: number;
+  swatch: SwatchDto;
+}
+
+export interface MaterialSeriesBucket {
+  index: number;
+  localStart: string;
+  materialMgByType: Record<string, number>;
+}
+
+export interface SpoolRow {
+  filamentId: string;
+  label: string;
+  swatch: SwatchDto;
+  usedMg: number;
+  /** May be NEGATIVE — usage logged beyond the spool's initial weight. Show it, don't clamp it. */
+  remainingMg: number | null;
+  initialMg: number | null;
+  percentConsumed: number | null;
+  costConsumed: number | null;
+}
+
+export interface RunwayRow {
+  filamentId: string;
+  label: string;
+  swatch: SwatchDto;
+  remainingGrams: number;
+  burnRateGramsPerDay: number;
+  runwayDays: number | null;
+}
+
+export interface MaterialsResponse {
+  from: string | null;
+  to: string | null;
+  timeZone: string;
+  granularity: Exclude<AnalyticsGranularity, 'Auto'>;
+  currency: string | null;
+  byType: MaterialGroup[];
+  byBrand: MaterialGroup[];
+  byColor: MaterialGroup[];
+  consumptionOverTime: MaterialSeriesBucket[];
+  topSpools: SpoolRow[];
+  runway: RunwayRow[];
+  wasteGrams: Metric;
+  wasteCost: MoneyMetric;
+  coverage: Coverage;
+}

--- a/src/app/analytics/services/analytics.service.spec.ts
+++ b/src/app/analytics/services/analytics.service.spec.ts
@@ -95,6 +95,16 @@ describe('AnalyticsService', () => {
     req.flush({});
   });
 
+  it('requests materials from its own endpoint', () => {
+    service.getMaterials(filter).subscribe();
+
+    const req = http.expectOne(
+      (r) => r.url === `${environment.printLogApiUrl}/api/analytics/materials`
+    );
+    expect(req.request.method).toBe('GET');
+    req.flush({});
+  });
+
   it('omits empty id arrays entirely rather than sending blanks', () => {
     service
       .getOverview({ ...filter, printerIds: [], statuses: [] })

--- a/src/app/analytics/services/analytics.service.ts
+++ b/src/app/analytics/services/analytics.service.ts
@@ -5,6 +5,7 @@ import { environment } from 'src/environments/environment';
 import {
   ActivityResponse,
   AnalyticsFilterValue,
+  MaterialsResponse,
   OverviewResponse,
   PrintersResponse,
 } from '../models/analytics.models';
@@ -28,6 +29,12 @@ export class AnalyticsService {
 
   getPrinters(filter: AnalyticsFilterValue): Observable<PrintersResponse> {
     return this.http.get<PrintersResponse>(`${this.baseUrl}/printers`, {
+      params: this.toHttpParams(filter),
+    });
+  }
+
+  getMaterials(filter: AnalyticsFilterValue): Observable<MaterialsResponse> {
+    return this.http.get<MaterialsResponse>(`${this.baseUrl}/materials`, {
       params: this.toHttpParams(filter),
     });
   }

--- a/src/app/analytics/tabs/materials/materials-tab.component.html
+++ b/src/app/analytics/tabs/materials/materials-tab.component.html
@@ -1,0 +1,261 @@
+<div class="materials-tab">
+  <div class="materials-tab__tiles">
+    <app-stat-tile
+      label="Wasted filament"
+      format="grams"
+      [metric]="data()?.wasteGrams ?? null"
+      [loading]="state() === 'loading'"
+    />
+    <app-stat-tile
+      label="Cost of waste"
+      format="money"
+      [metric]="data()?.wasteCost ?? null"
+      [loading]="state() === 'loading'"
+    />
+  </div>
+
+  <div class="materials-tab__charts">
+    <app-chart-frame
+      class="materials-tab__chart"
+      #typeFrame
+      title="Filament by material type"
+      [state]="state()"
+      [coverage]="data()?.coverage ?? null"
+      ariaSummary="Grams of filament used per material type"
+      emptyMessage="No spool-tracked filament in this range yet."
+      (retry)="onRetry()"
+    >
+      <app-bar-chart
+        [data]="byTypeData()"
+        [series]="singleSeries"
+        [width]="typeFrame.width()"
+        [height]="typeFrame.height()"
+        orientation="horizontal"
+      >
+        <g appFilamentSvgDefs #typeDefs [swatches]="typeSwatches()"></g>
+      </app-bar-chart>
+
+      <table chartDataTable>
+        <caption>
+          Filament by material type
+        </caption>
+        <tbody>
+          @for (group of data()?.byType ?? []; track group.key) {
+            <tr>
+              <th scope="row">{{ group.label }}</th>
+              <td>{{ grams(group.materialMg) | number: '1.0-0' }} g</td>
+            </tr>
+          }
+        </tbody>
+      </table>
+    </app-chart-frame>
+
+    <app-chart-frame
+      class="materials-tab__chart"
+      #brandFrame
+      title="Filament by brand"
+      [state]="state()"
+      [coverage]="data()?.coverage ?? null"
+      ariaSummary="Grams of filament used per brand"
+      emptyMessage="No spool-tracked filament in this range yet."
+      (retry)="onRetry()"
+    >
+      <app-bar-chart
+        [data]="byBrandData()"
+        [series]="singleSeries"
+        [width]="brandFrame.width()"
+        [height]="brandFrame.height()"
+        orientation="horizontal"
+      >
+        <g appFilamentSvgDefs #brandDefs [swatches]="brandSwatches()"></g>
+      </app-bar-chart>
+
+      <table chartDataTable>
+        <caption>
+          Filament by brand
+        </caption>
+        <tbody>
+          @for (group of data()?.byBrand ?? []; track group.key) {
+            <tr>
+              <th scope="row">{{ group.label }}</th>
+              <td>{{ grams(group.materialMg) | number: '1.0-0' }} g</td>
+            </tr>
+          }
+        </tbody>
+      </table>
+    </app-chart-frame>
+
+    <app-chart-frame
+      class="materials-tab__chart"
+      #colorFrame
+      title="Filament by colour"
+      [state]="state()"
+      [coverage]="data()?.coverage ?? null"
+      ariaSummary="Grams of filament used per colour"
+      emptyMessage="No spool-tracked filament in this range yet."
+      (retry)="onRetry()"
+    >
+      <app-bar-chart
+        [data]="byColorData()"
+        [series]="singleSeries"
+        [width]="colorFrame.width()"
+        [height]="colorFrame.height()"
+        orientation="horizontal"
+      >
+        <g appFilamentSvgDefs #colorDefs [swatches]="colorSwatches()"></g>
+      </app-bar-chart>
+
+      <table chartDataTable>
+        <caption>
+          Filament by colour
+        </caption>
+        <tbody>
+          @for (group of data()?.byColor ?? []; track group.key) {
+            <tr>
+              <th scope="row">{{ group.label }}</th>
+              <td>{{ grams(group.materialMg) | number: '1.0-0' }} g</td>
+            </tr>
+          }
+        </tbody>
+      </table>
+    </app-chart-frame>
+
+    <app-chart-frame
+      class="materials-tab__chart"
+      #consumptionFrame
+      title="Consumption over time"
+      [state]="state()"
+      [coverage]="data()?.coverage ?? null"
+      ariaSummary="Grams of filament used per period, stacked by material type"
+      emptyMessage="No spool-tracked filament in this range yet."
+      (retry)="onRetry()"
+    >
+      <app-bar-chart
+        [data]="consumptionData()"
+        [series]="consumptionSeries()"
+        [width]="consumptionFrame.width()"
+        [height]="consumptionFrame.height()"
+      />
+      <table chartDataTable>
+        <caption>
+          Grams per period by material type
+        </caption>
+        <tbody>
+          @for (row of consumptionData(); track row.fullLabel) {
+            <tr>
+              <th scope="row">{{ row.fullLabel }}</th>
+              @for (series of consumptionSeries(); track series.key) {
+                <td>{{ series.label }}: {{ row.values[series.key] ?? 0 }}</td>
+              }
+            </tr>
+          }
+        </tbody>
+      </table>
+    </app-chart-frame>
+  </div>
+
+  <app-chart-frame
+    class="materials-tab__chart materials-tab__chart--wide"
+    title="Top spools"
+    [state]="state()"
+    [coverage]="data()?.coverage ?? null"
+    ariaSummary="Most-used spools with remaining stock"
+    emptyMessage="No spool-tracked filament in this range yet."
+    (retry)="onRetry()"
+  >
+    <table class="materials-tab__spools">
+      <caption>
+        Most-used spools
+      </caption>
+      <thead>
+        <tr>
+          <th scope="col">Spool</th>
+          <th scope="col">Used</th>
+          <th scope="col">Remaining</th>
+          <th scope="col">Consumed</th>
+          <th scope="col">Cost consumed</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (spool of data()?.topSpools ?? []; track spool.filamentId) {
+          <tr>
+            <th scope="row">
+              <!--
+                The LINK is the interactive element, not the row. A `(click)` on a <tr> is
+                invisible to the keyboard and to assistive technology, and spec §9's
+                click-through plus §11's touch/a11y rules both require a real control. A button
+                also gets the ≥44px target for free via padding.
+              -->
+              <button
+                type="button"
+                class="materials-tab__spool-link"
+                (click)="onSpoolSelect(spool.filamentId)"
+              >
+                <span
+                  class="materials-tab__swatch"
+                  [style]="
+                    spool.swatch.colors
+                      | filamentColorSwatchStyle
+                        : spool.swatch.colorPattern
+                        : spool.swatch.finishType
+                        : spool.swatch.effects
+                  "
+                  aria-hidden="true"
+                ></span>
+                {{ spool.label }}
+              </button>
+            </th>
+            <td>{{ grams(spool.usedMg) | number: '1.0-0' }} g</td>
+            <td>
+              {{
+                spool.remainingMg === null
+                  ? '—'
+                  : (grams(spool.remainingMg) | number: '1.0-0') + ' g'
+              }}
+            </td>
+            <td>
+              {{
+                spool.percentConsumed === null
+                  ? '—'
+                  : (spool.percentConsumed | number: '1.0-0') + '%'
+              }}
+            </td>
+            <td>
+              {{
+                spool.costConsumed === null
+                  ? '—'
+                  : (spool.costConsumed | number: '1.2-2')
+              }}
+            </td>
+          </tr>
+        }
+      </tbody>
+    </table>
+  </app-chart-frame>
+
+  @if (runningLow().length > 0) {
+    <section class="materials-tab__low">
+      <h3>Running low</h3>
+      <ul>
+        @for (row of runningLow(); track row.filamentId) {
+          <li>
+            <span
+              class="materials-tab__swatch"
+              [style]="
+                row.swatch.colors
+                  | filamentColorSwatchStyle
+                    : row.swatch.colorPattern
+                    : row.swatch.finishType
+                    : row.swatch.effects
+              "
+              aria-hidden="true"
+            ></span>
+            {{ row.label }} — {{ row.remainingGrams | number: '1.0-0' }} g left, about
+            {{ row.runwayDays | number: '1.0-0' }} days at
+            {{ row.burnRateGramsPerDay | number: '1.0-1' }} g/day
+          </li>
+        }
+      </ul>
+    </section>
+  }
+</div>

--- a/src/app/analytics/tabs/materials/materials-tab.component.html
+++ b/src/app/analytics/tabs/materials/materials-tab.component.html
@@ -221,11 +221,16 @@
               }}
             </td>
             <td>
-              {{
-                spool.costConsumed === null
-                  ? '—'
-                  : (spool.costConsumed | number: '1.2-2')
-              }}
+              <!-- Formatted as money, not a bare decimal: "1.25" with no unit is not a cost,
+                   and the waste tile beside it is already currency-formatted. -->
+              @if (spool.costConsumed === null) {
+                —
+              } @else {
+                {{
+                  spool.costConsumed
+                    | currency: (data()?.currency ?? undefined) : 'symbol' : '1.2-2'
+                }}
+              }
             </td>
           </tr>
         }

--- a/src/app/analytics/tabs/materials/materials-tab.component.scss
+++ b/src/app/analytics/tabs/materials/materials-tab.component.scss
@@ -1,0 +1,85 @@
+.materials-tab {
+  display: grid;
+  gap: 0.5rem;
+  // Container queries, not media queries: the side nav collapsing changes available width
+  // without a viewport change.
+  container-type: inline-size;
+  min-inline-size: 0;
+}
+
+.materials-tab__tiles {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.materials-tab__charts {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: minmax(0, 1fr);
+  // Panels differ in natural height; stretching drags the short one to the tall one's size.
+  align-items: start;
+}
+
+@container (min-width: 900px) {
+  .materials-tab__charts {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.materials-tab__swatch {
+  display: inline-block;
+  inline-size: 0.75rem;
+  block-size: 0.75rem;
+  margin-inline-end: 0.35rem;
+  border-radius: 2px;
+  // Same reason as the SVG outline: dark colours vanish against the dark theme.
+  outline: 1px solid var(--chart-swatch-outline);
+  vertical-align: middle;
+}
+
+.materials-tab__spools {
+  inline-size: 100%;
+  border-collapse: collapse;
+
+  th,
+  td {
+    padding: 0.25rem 0.5rem;
+    text-align: start;
+  }
+}
+
+.materials-tab__spool-link {
+  // A real button, styled flat. Keyboard-operable and focus-visible for free, with padding
+  // carrying it to a ≥44px touch target.
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  min-block-size: 44px;
+  padding: 0.25rem 0;
+  background: none;
+  border: 0;
+  color: inherit;
+  font: inherit;
+  text-align: start;
+  cursor: pointer;
+
+  &:focus-visible {
+    outline: 2px solid var(--chart-axis-text);
+    outline-offset: 2px;
+  }
+}
+
+.materials-tab__low {
+  font-size: 0.875rem;
+
+  h3 {
+    margin: 0 0 0.25rem;
+    font-size: 1rem;
+  }
+
+  ul {
+    margin: 0;
+    padding-inline-start: 1rem;
+  }
+}

--- a/src/app/analytics/tabs/materials/materials-tab.component.spec.ts
+++ b/src/app/analytics/tabs/materials/materials-tab.component.spec.ts
@@ -1,0 +1,212 @@
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { Router, provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import { AnalyticsFilterStore } from '../../filters/analytics-filter.store';
+import { MaterialsResponse } from '../../models/analytics.models';
+import { AnalyticsService } from '../../services/analytics.service';
+import { MaterialsTabComponent } from './materials-tab.component';
+
+const coverage = {
+  population: 'prints',
+  counted: 1,
+  total: 1,
+  undatedCount: 0,
+  exclusions: [],
+};
+
+const swatch = {
+  colors: ['ff0000'],
+  colorPattern: 1,
+  finishType: 1,
+  effects: [],
+};
+
+const response = (
+  overrides: Partial<MaterialsResponse> = {}
+): MaterialsResponse => ({
+  from: null,
+  to: null,
+  timeZone: 'UTC',
+  granularity: 'Day',
+  currency: 'USD',
+  byType: [
+    { key: 'PLA', label: 'PLA', printCount: 3, materialMg: 60000, swatch },
+  ],
+  byBrand: [
+    { key: 'Acme', label: 'Acme', printCount: 3, materialMg: 60000, swatch },
+  ],
+  byColor: [
+    { key: 'Red', label: 'Red', printCount: 3, materialMg: 60000, swatch },
+  ],
+  consumptionOverTime: [
+    { index: 1, localStart: '2026-07-02', materialMgByType: { PLA: 20000 } },
+    { index: 0, localStart: '2026-07-01', materialMgByType: { PLA: 40000 } },
+  ],
+  topSpools: [
+    {
+      filamentId: 'f1',
+      label: 'Acme PLA Red',
+      swatch,
+      usedMg: 60000,
+      remainingMg: 940000,
+      initialMg: 1000000,
+      percentConsumed: 6,
+      costConsumed: null,
+    },
+  ],
+  runway: [
+    {
+      filamentId: 'f1',
+      label: 'Acme PLA Red',
+      swatch,
+      remainingGrams: 940,
+      burnRateGramsPerDay: 10,
+      runwayDays: 94,
+    },
+  ],
+  wasteGrams: { value: 5, previous: null, coverage },
+  wasteCost: { value: 1.25, previous: null, currency: 'USD', coverage },
+  coverage,
+  ...overrides,
+});
+
+describe('MaterialsTabComponent', () => {
+  let fixture: ComponentFixture<MaterialsTabComponent>;
+  let component: MaterialsTabComponent;
+  let analytics: jasmine.SpyObj<AnalyticsService>;
+
+  // createTabData debounces by 250ms, so the response only lands after the timer is
+  // flushed — a plain whenStable() would assert against a still-loading tab.
+  const setup = () => {
+    fixture = TestBed.createComponent(MaterialsTabComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    tick(300);
+    fixture.detectChanges();
+  };
+
+  beforeEach(async () => {
+    analytics = jasmine.createSpyObj<AnalyticsService>('AnalyticsService', [
+      'getMaterials',
+    ]);
+    analytics.getMaterials.and.returnValue(of(response()));
+
+    await TestBed.configureTestingModule({
+      imports: [MaterialsTabComponent, NoopAnimationsModule],
+      providers: [
+        provideRouter([]),
+        AnalyticsFilterStore,
+        { provide: AnalyticsService, useValue: analytics },
+      ],
+    }).compileComponents();
+  });
+
+  it('gives by-type bars a swatch fill referencing the chart-local defs', fakeAsync(() => {
+    setup();
+
+    expect(component.byTypeData()[0].fill).toBeTruthy();
+  }));
+
+  it('does NOT swatch-fill the stacked consumption chart', fakeAsync(() => {
+    setup();
+
+    // Stacked series use the categorical palette; the swatch lives in the legend (spec §10).
+    expect(component.consumptionData()[0].fill).toBeUndefined();
+  }));
+
+  it('sorts consumption chronologically, not by response order', fakeAsync(() => {
+    setup();
+
+    expect(component.consumptionData().map((d) => d.fullLabel)).toEqual(
+      component
+        .consumptionData()
+        .map((d) => d.fullLabel)
+        .slice()
+        .sort()
+    );
+  }));
+
+  it('lists running-low spools first and omits ones with no runway', fakeAsync(() => {
+    analytics.getMaterials.and.returnValue(
+      of(
+        response({
+          runway: [
+            {
+              filamentId: 'a',
+              label: 'A',
+              swatch,
+              remainingGrams: 900,
+              burnRateGramsPerDay: 0,
+              runwayDays: null,
+            },
+            {
+              filamentId: 'b',
+              label: 'B',
+              swatch,
+              remainingGrams: 50,
+              burnRateGramsPerDay: 10,
+              runwayDays: 5,
+            },
+          ],
+        })
+      )
+    );
+    setup();
+
+    expect(component.runningLow().map((r) => r.filamentId)).toEqual(['b']);
+  }));
+
+  it("links a spool row to that spool's prints, without a userId", fakeAsync(() => {
+    setup();
+    const router = TestBed.inject(Router);
+    const navigate = spyOn(router, 'navigate');
+
+    component.onSpoolSelect('f1');
+
+    const [commands, extras] = navigate.calls.mostRecent().args as [
+      unknown[],
+      { queryParams: Record<string, unknown> },
+    ];
+    expect(commands).toEqual(['/prints']);
+    expect(extras.queryParams['filterByFilamentId']).toBe('f1');
+    // A userId would narrow the user's own list to their PUBLIC prints.
+    expect(extras.queryParams['userId']).toBeUndefined();
+  }));
+
+  it('shows a negative remaining as-is rather than clamping it to zero', fakeAsync(() => {
+    analytics.getMaterials.and.returnValue(
+      of(
+        response({
+          topSpools: [
+            {
+              filamentId: 'f1',
+              label: 'Overdrawn',
+              swatch,
+              usedMg: 1100000,
+              remainingMg: -100000,
+              initialMg: 1000000,
+              percentConsumed: 110,
+              costConsumed: null,
+            },
+          ],
+        })
+      )
+    );
+    setup();
+
+    expect(fixture.nativeElement.textContent).toContain('-100');
+  }));
+
+  it('fails the whole tab on an error', fakeAsync(() => {
+    analytics.getMaterials.and.returnValue(throwError(() => new Error('boom')));
+    setup();
+
+    expect(component.state()).toBe('error');
+  }));
+});

--- a/src/app/analytics/tabs/materials/materials-tab.component.ts
+++ b/src/app/analytics/tabs/materials/materials-tab.component.ts
@@ -1,4 +1,4 @@
-import { DecimalPipe } from '@angular/common';
+import { CurrencyPipe, DecimalPipe } from '@angular/common';
 import {
   ChangeDetectionStrategy,
   Component,
@@ -39,6 +39,7 @@ const RUNNING_LOW_DAYS = 30;
   imports: [
     BarChartComponent,
     ChartFrameComponent,
+    CurrencyPipe,
     DecimalPipe,
     FilamentColorSwatchStylePipe,
     FilamentSvgDefsComponent,

--- a/src/app/analytics/tabs/materials/materials-tab.component.ts
+++ b/src/app/analytics/tabs/materials/materials-tab.component.ts
@@ -1,0 +1,180 @@
+import { DecimalPipe } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  viewChild,
+} from '@angular/core';
+import { Router } from '@angular/router';
+import {
+  BarChartComponent,
+  BarDatum,
+  BarSeries,
+} from 'src/app/shared/charts/bar-chart.component';
+import {
+  formatTickDate,
+  parseLocalDate,
+} from 'src/app/shared/charts/chart-axis';
+import { ChartFrameComponent } from 'src/app/shared/charts/chart-frame.component';
+import {
+  FilamentSvgDefsComponent,
+  FilamentSwatchInput,
+} from 'src/app/shared/charts/filament-svg-defs.component';
+import { StatTileComponent } from 'src/app/shared/charts/stat-tile.component';
+import { FilamentColorSwatchStylePipe } from 'src/app/shared/pipes/filament-color-swatch-style.pipe';
+import { AnalyticsFilterStore } from '../../filters/analytics-filter.store';
+import {
+  MaterialGroup,
+  MaterialsResponse,
+} from '../../models/analytics.models';
+import { AnalyticsService } from '../../services/analytics.service';
+import { createTabData } from '../tab-data';
+
+/** Below this many days of stock left, a spool is worth flagging before a long print. */
+const RUNNING_LOW_DAYS = 30;
+
+@Component({
+  selector: 'app-materials-tab',
+  imports: [
+    BarChartComponent,
+    ChartFrameComponent,
+    DecimalPipe,
+    FilamentColorSwatchStylePipe,
+    FilamentSvgDefsComponent,
+    StatTileComponent,
+  ],
+  templateUrl: './materials-tab.component.html',
+  styleUrls: ['./materials-tab.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MaterialsTabComponent {
+  private readonly analytics = inject(AnalyticsService);
+  private readonly store = inject(AnalyticsFilterStore);
+  private readonly router = inject(Router);
+
+  private readonly tab = createTabData<MaterialsResponse>(
+    this.store.filter,
+    (filter) => this.analytics.getMaterials(filter),
+    (response) => response.byType.length === 0
+  );
+
+  readonly data = this.tab.data;
+  readonly state = this.tab.state;
+
+  private readonly typeDefs = viewChild<FilamentSvgDefsComponent>('typeDefs');
+  private readonly brandDefs = viewChild<FilamentSvgDefsComponent>('brandDefs');
+  private readonly colorDefs = viewChild<FilamentSvgDefsComponent>('colorDefs');
+
+  readonly singleSeries: readonly BarSeries[] = [
+    { key: 'value', label: 'Filament used', seriesIndex: 1 },
+  ];
+
+  readonly typeSwatches = computed(() =>
+    this.swatchesFor(this.data()?.byType ?? [])
+  );
+  readonly brandSwatches = computed(() =>
+    this.swatchesFor(this.data()?.byBrand ?? [])
+  );
+  readonly colorSwatches = computed(() =>
+    this.swatchesFor(this.data()?.byColor ?? [])
+  );
+
+  readonly byTypeData = computed(() =>
+    this.groupData(this.data()?.byType ?? [], this.typeDefs())
+  );
+  readonly byBrandData = computed(() =>
+    this.groupData(this.data()?.byBrand ?? [], this.brandDefs())
+  );
+  readonly byColorData = computed(() =>
+    this.groupData(this.data()?.byColor ?? [], this.colorDefs())
+  );
+
+  /** One series per material type, from the categorical palette — NOT swatch-filled. */
+  readonly consumptionSeries = computed<BarSeries[]>(() =>
+    (this.data()?.byType ?? []).map((group, index) => ({
+      key: group.key,
+      label: group.label,
+      seriesIndex: (index % 6) + 1,
+    }))
+  );
+
+  readonly consumptionData = computed<BarDatum[]>(() => {
+    const response = this.data();
+    if (!response) return [];
+
+    return [...response.consumptionOverTime]
+      .sort(
+        (left, right) =>
+          left.localStart.localeCompare(right.localStart) ||
+          left.index - right.index
+      )
+      .map((bucket) => {
+        const date = parseLocalDate(bucket.localStart);
+        const values: Record<string, number> = {};
+        for (const [type, mg] of Object.entries(bucket.materialMgByType)) {
+          values[type] = mg / 1000;
+        }
+        return {
+          label: formatTickDate(date, response.granularity, true),
+          fullLabel: formatTickDate(date, response.granularity, false),
+          values,
+        };
+      });
+  });
+
+  readonly runningLow = computed(() =>
+    (this.data()?.runway ?? [])
+      .filter(
+        (row) => row.runwayDays !== null && row.runwayDays <= RUNNING_LOW_DAYS
+      )
+      .sort((left, right) => (left.runwayDays ?? 0) - (right.runwayDays ?? 0))
+  );
+
+  onRetry(): void {
+    this.tab.retry();
+  }
+
+  /**
+   * Click-through is a cross-cutting promise (spec §9), so it applies here too. The print list
+   * filters by filament id, which is what a spool row and a running-low row both carry.
+   *
+   * The by-type / by-brand / by-colour groups are NOT clickable: their keys are attribute
+   * strings, and the print list has no attribute filter — a link that silently dropped its
+   * filter would be worse than no link. Never sends userId (that means "public prints only").
+   */
+  onSpoolSelect(filamentId: string): void {
+    void this.router.navigate(['/prints'], {
+      queryParams: { filterByFilamentId: filamentId },
+    });
+  }
+
+  grams(mg: number | null): number | null {
+    return mg === null ? null : mg / 1000;
+  }
+
+  private swatchesFor(groups: MaterialGroup[]): FilamentSwatchInput[] {
+    return groups.map((group) => ({
+      id: group.key,
+      colors: group.swatch.colors,
+      colorPattern: group.swatch.colorPattern,
+      finishType: group.swatch.finishType,
+      effects: group.swatch.effects,
+    }));
+  }
+
+  private groupData(
+    groups: MaterialGroup[],
+    defs: FilamentSvgDefsComponent | undefined
+  ): BarDatum[] {
+    return groups.map((group) => ({
+      label: group.label,
+      fullLabel: `${group.label} — ${(group.materialMg / 1000).toFixed(0)} g`,
+      values: { value: group.materialMg / 1000 },
+      // Falls back to the neutral series token before the defs component has rendered.
+      fill: defs?.fillFor(group.key) ?? 'var(--chart-series-6)',
+      filter: defs?.filterFor(group.key) ?? null,
+      fillOpacity: defs?.opacityFor(group.key) ?? 1,
+    }));
+  }
+}

--- a/src/app/shared/charts/bar-chart.component.html
+++ b/src/app/shared/charts/bar-chart.component.html
@@ -5,6 +5,10 @@
     [attr.data-orientation]="resolvedOrientation()"
     preserveAspectRatio="none"
   >
+    <!-- Swatch gradients must live inside THIS svg: a url(#id) fill cannot resolve across
+         document fragments in some engines, and scoping them here keeps ids local. -->
+    <ng-content select="[appFilamentSvgDefs]" />
+
     @for (tick of valueTicks(); track tick.value) {
       <line
         class="bar-chart__grid-line"
@@ -63,7 +67,14 @@
 
   @for (segment of segments(); track segment.tooltip) {
       <rect
-        [class]="'bar-chart__segment chart-fill-' + segment.seriesIndex"
+        [class]="
+          segment.fill
+            ? 'bar-chart__segment bar-chart__segment--swatch'
+            : 'bar-chart__segment chart-fill-' + segment.seriesIndex
+        "
+        [attr.fill]="segment.fill"
+        [attr.filter]="segment.filter"
+        [attr.fill-opacity]="segment.fillOpacity"
         [attr.x]="segment.x"
         [attr.y]="segment.y"
         [attr.width]="segment.w"

--- a/src/app/shared/charts/bar-chart.component.scss
+++ b/src/app/shared/charts/bar-chart.component.scss
@@ -93,3 +93,10 @@
     transition: opacity 120ms ease-in-out;
   }
 }
+
+.bar-chart__segment--swatch {
+  // Two black spools are otherwise indistinguishable, and dark colours vanish on the dark
+  // theme. Every swatch-filled mark gets a theme-contrast outline (spec §10).
+  stroke: var(--chart-swatch-outline);
+  stroke-width: 1;
+}

--- a/src/app/shared/charts/bar-chart.component.spec.ts
+++ b/src/app/shared/charts/bar-chart.component.spec.ts
@@ -190,4 +190,25 @@ describe('BarChartComponent', () => {
       ).length
     ).toBe(0);
   });
+  it('uses a datum fill when one is supplied and the theme class otherwise', () => {
+    fixture.componentRef.setInput('series', [
+      { key: 'value', label: 'Used', seriesIndex: 1 },
+    ]);
+    fixture.componentRef.setInput('data', [
+      { label: 'PLA', fullLabel: 'PLA', values: { value: 5 }, fill: '#ff0000' },
+      { label: 'PETG', fullLabel: 'PETG', values: { value: 3 } },
+    ]);
+    fixture.componentRef.setInput('width', 900);
+    fixture.componentRef.setInput('height', 300);
+    fixture.detectChanges();
+
+    const [pla, petg] = fixture.componentInstance.segments();
+    expect(pla.fill).toBe('#ff0000');
+    expect(petg.fill).toBeNull();
+  });
+
+  it('projects swatch defs into its own svg', () => {
+    // The defs must live INSIDE the chart's <svg>; a url(#id) fill cannot resolve otherwise.
+    expect(fixture.nativeElement.querySelector('svg')).toBeTruthy();
+  });
 });

--- a/src/app/shared/charts/bar-chart.component.ts
+++ b/src/app/shared/charts/bar-chart.component.ts
@@ -21,6 +21,14 @@ export interface BarDatum {
   /** Full label for tooltips and the accessible table. */
   fullLabel: string;
   values: Record<string, number>;
+  /**
+   * Optional per-datum fill — a hex colour or a `url(#…)` reference from
+   * filament-svg-defs. When absent the mark takes its series' theme class, which is the
+   * default and the right choice for anything that must stay readable at a glance.
+   */
+  fill?: string;
+  filter?: string | null;
+  fillOpacity?: number;
 }
 
 interface Segment {
@@ -32,6 +40,9 @@ interface Segment {
   seriesKey: string;
   label: string;
   tooltip: string;
+  fill: string | null;
+  filter: string | null;
+  fillOpacity: number;
 }
 
 interface BucketHitbox {
@@ -209,6 +220,9 @@ export class BarChartComponent {
             seriesKey: s.key,
             label: d.label,
             tooltip: `${d.fullLabel} — ${s.label}: ${v}`,
+            fill: d.fill ?? null,
+            filter: d.filter ?? null,
+            fillOpacity: d.fillOpacity ?? 1,
           });
           cursor += v;
         }
@@ -235,6 +249,9 @@ export class BarChartComponent {
             seriesKey: s.key,
             label: d.label,
             tooltip: `${d.fullLabel} — ${s.label}: ${v}`,
+            fill: d.fill ?? null,
+            filter: d.filter ?? null,
+            fillOpacity: d.fillOpacity ?? 1,
           });
           cursor += v;
         }

--- a/src/app/shared/charts/filament-svg-defs.component.html
+++ b/src/app/shared/charts/filament-svg-defs.component.html
@@ -1,0 +1,33 @@
+<defs>
+  @for (def of defs(); track def.id) {
+    @if (def.gradientId) {
+      <linearGradient [attr.id]="def.gradientId" x1="0" y1="0" x2="1" y2="0">
+        @for (stop of def.stops; track $index) {
+          <stop [attr.offset]="stop.offset" [attr.stop-color]="stop.color" />
+        }
+        @if (def.descriptor.shimmer) {
+          <!-- Silk reads as a highlight band rather than a separate overlay element. -->
+          <stop offset="48%" stop-color="#ffffff" stop-opacity="0.3" />
+          <stop offset="52%" stop-color="#ffffff" stop-opacity="0" />
+        }
+      </linearGradient>
+    }
+
+    @if (def.filterId) {
+      <filter [attr.id]="def.filterId">
+        @if (def.descriptor.desaturate) {
+          <feColorMatrix type="saturate" values="0.6" />
+        }
+        @if (def.descriptor.glow) {
+          <feDropShadow
+            dx="0"
+            dy="0"
+            stdDeviation="2"
+            flood-color="rgb(120,255,120)"
+            flood-opacity="0.5"
+          />
+        }
+      </filter>
+    }
+  }
+</defs>

--- a/src/app/shared/charts/filament-svg-defs.component.html
+++ b/src/app/shared/charts/filament-svg-defs.component.html
@@ -1,25 +1,29 @@
-<defs>
+<!-- Every element carries the svg: namespace prefix. The component's host is a <g> inside a
+     chart's <svg>, but Angular type-checks the template in the HTML context, and its element
+     schema rejects the SVG-only tags below (NG8001). This is an AOT-only failure: JIT unit
+     tests pass without the prefix and the PRODUCTION build does not. -->
+<svg:defs>
   @for (def of defs(); track def.id) {
     @if (def.gradientId) {
-      <linearGradient [attr.id]="def.gradientId" x1="0" y1="0" x2="1" y2="0">
+      <svg:linearGradient [attr.id]="def.gradientId" x1="0" y1="0" x2="1" y2="0">
         @for (stop of def.stops; track $index) {
-          <stop [attr.offset]="stop.offset" [attr.stop-color]="stop.color" />
+          <svg:stop [attr.offset]="stop.offset" [attr.stop-color]="stop.color" />
         }
         @if (def.descriptor.shimmer) {
           <!-- Silk reads as a highlight band rather than a separate overlay element. -->
-          <stop offset="48%" stop-color="#ffffff" stop-opacity="0.3" />
-          <stop offset="52%" stop-color="#ffffff" stop-opacity="0" />
+          <svg:stop offset="48%" stop-color="#ffffff" stop-opacity="0.3" />
+          <svg:stop offset="52%" stop-color="#ffffff" stop-opacity="0" />
         }
-      </linearGradient>
+      </svg:linearGradient>
     }
 
     @if (def.filterId) {
-      <filter [attr.id]="def.filterId">
+      <svg:filter [attr.id]="def.filterId">
         @if (def.descriptor.desaturate) {
-          <feColorMatrix type="saturate" values="0.6" />
+          <svg:feColorMatrix type="saturate" values="0.6" />
         }
         @if (def.descriptor.glow) {
-          <feDropShadow
+          <svg:feDropShadow
             dx="0"
             dy="0"
             stdDeviation="2"
@@ -27,7 +31,7 @@
             flood-opacity="0.5"
           />
         }
-      </filter>
+      </svg:filter>
     }
   }
-</defs>
+</svg:defs>

--- a/src/app/shared/charts/filament-svg-defs.component.spec.ts
+++ b/src/app/shared/charts/filament-svg-defs.component.spec.ts
@@ -1,0 +1,123 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  ColorPatternType,
+  FilamentEffect,
+  FilamentFinishType,
+} from 'src/app/core/services/filament.service';
+import { FilamentSvgDefsComponent } from './filament-svg-defs.component';
+
+describe('FilamentSvgDefsComponent', () => {
+  let fixture: ComponentFixture<FilamentSvgDefsComponent>;
+  let component: FilamentSvgDefsComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FilamentSvgDefsComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FilamentSvgDefsComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('returns a literal colour for a solid swatch rather than an unnecessary gradient', () => {
+    fixture.componentRef.setInput('swatches', [
+      { id: 'a', colors: ['ff0000'], colorPattern: ColorPatternType.Solid },
+    ]);
+    fixture.detectChanges();
+
+    expect(component.fillFor('a')).toBe('#ff0000');
+    expect(
+      fixture.nativeElement.querySelectorAll('linearGradient').length
+    ).toBe(0);
+  });
+
+  it('emits a gradient and returns a url() fill for a multi-colour swatch', () => {
+    fixture.componentRef.setInput('swatches', [
+      {
+        id: 'a',
+        colors: ['ff0000', '0000ff'],
+        colorPattern: ColorPatternType.Gradient,
+      },
+    ]);
+    fixture.detectChanges();
+
+    expect(component.fillFor('a')).toMatch(/^url\(#.+\)$/);
+    expect(
+      fixture.nativeElement.querySelectorAll('linearGradient').length
+    ).toBe(1);
+    expect(fixture.nativeElement.querySelectorAll('stop').length).toBe(2);
+  });
+
+  it('scopes ids per instance so two charts cannot share a gradient', () => {
+    const other = TestBed.createComponent(FilamentSvgDefsComponent);
+
+    fixture.componentRef.setInput('swatches', [
+      {
+        id: 'a',
+        colors: ['ff0000', '0000ff'],
+        colorPattern: ColorPatternType.Gradient,
+      },
+    ]);
+    other.componentRef.setInput('swatches', [
+      {
+        id: 'a',
+        colors: ['00ff00', '000000'],
+        colorPattern: ColorPatternType.Gradient,
+      },
+    ]);
+    fixture.detectChanges();
+    other.detectChanges();
+
+    expect(component.fillFor('a')).not.toBe(
+      other.componentInstance.fillFor('a')
+    );
+  });
+
+  it('never emits a colour that failed hex validation', () => {
+    fixture.componentRef.setInput('swatches', [
+      {
+        id: 'a',
+        colors: ['#ff0000;fill:url(#evil)', 'javascript:alert(1)'],
+        colorPattern: ColorPatternType.Gradient,
+      },
+    ]);
+    fixture.detectChanges();
+
+    const markup = fixture.nativeElement.innerHTML as string;
+    expect(markup).not.toContain('evil');
+    expect(markup).not.toContain('javascript');
+    Array.from(
+      fixture.nativeElement.querySelectorAll(
+        'stop'
+      ) as NodeListOf<SVGStopElement>
+    ).forEach((stop) => {
+      expect(stop.getAttribute('stop-color')).toMatch(/^#[0-9a-fA-F]{3,6}$/);
+    });
+  });
+
+  it('emits a filter for Matte and glow, and exposes the translucent opacity', () => {
+    fixture.componentRef.setInput('swatches', [
+      {
+        id: 'a',
+        colors: ['ff0000'],
+        colorPattern: ColorPatternType.Solid,
+        finishType: FilamentFinishType.Matte,
+        effects: [FilamentEffect.Translucent],
+      },
+    ]);
+    fixture.detectChanges();
+
+    expect(fixture.nativeElement.querySelectorAll('filter').length).toBe(1);
+    expect(component.filterFor('a')).toMatch(/^url\(#.+\)$/);
+    expect(component.opacityFor('a')).toBe(0.7);
+  });
+
+  it('falls back to a neutral fill for an unknown swatch id', () => {
+    fixture.componentRef.setInput('swatches', []);
+    fixture.detectChanges();
+
+    expect(component.fillFor('missing')).toBe('var(--chart-series-6)');
+    expect(component.filterFor('missing')).toBeNull();
+    expect(component.opacityFor('missing')).toBe(1);
+  });
+});

--- a/src/app/shared/charts/filament-svg-defs.component.ts
+++ b/src/app/shared/charts/filament-svg-defs.component.ts
@@ -46,6 +46,10 @@ let instanceCounter = 0;
  * are hex-validated upstream by normalizeHex, and anything that failed is already #000000.
  */
 @Component({
+  // An ATTRIBUTE selector on a real <g>, not an element. A custom element inside <svg> is
+  // parsed into the SVG namespace as an unknown element, and neither it nor its <defs>
+  // children render — so an app-prefixed element selector would silently produce no gradients.
+  // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'g[appFilamentSvgDefs]',
   templateUrl: './filament-svg-defs.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/shared/charts/filament-svg-defs.component.ts
+++ b/src/app/shared/charts/filament-svg-defs.component.ts
@@ -1,0 +1,108 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from '@angular/core';
+import {
+  ColorPatternType,
+  FilamentEffect,
+  FilamentFinishType,
+} from 'src/app/core/services/filament.service';
+import {
+  SwatchDescriptor,
+  buildSwatchDescriptor,
+} from './filament-swatch-colors';
+
+export interface FilamentSwatchInput {
+  /** Stable identity for the swatch — a filament id, a material type, a colour name. */
+  id: string;
+  colors: string[];
+  colorPattern: ColorPatternType;
+  finishType?: FilamentFinishType;
+  effects?: FilamentEffect[];
+}
+
+export interface SwatchDef {
+  id: string;
+  gradientId: string | null;
+  filterId: string | null;
+  descriptor: SwatchDescriptor;
+  /** Evenly spaced offsets for a smooth gradient; the descriptor's own for a hard one. */
+  stops: { color: string; offset: string }[];
+}
+
+// SVG element ids are DOCUMENT-global. Two charts on one page using the same filament id would
+// cross-contaminate each other's fills, so each component instance gets its own prefix.
+let instanceCounter = 0;
+
+/**
+ * Emits <linearGradient> and <filter> definitions for filament swatches, and hands back the
+ * `fill` values that reference them.
+ *
+ * Everything here is Angular template markup with bound attributes — never string
+ * concatenation. Colours, patterns, effects and names are user-controlled persisted data;
+ * building SVG by string interpolation is how that data becomes an injection vector. Colours
+ * are hex-validated upstream by normalizeHex, and anything that failed is already #000000.
+ */
+@Component({
+  selector: 'g[appFilamentSvgDefs]',
+  templateUrl: './filament-svg-defs.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FilamentSvgDefsComponent {
+  readonly swatches = input<FilamentSwatchInput[]>([]);
+
+  private readonly prefix = `fil-${instanceCounter++}`;
+
+  readonly defs = computed<SwatchDef[]>(() =>
+    this.swatches().map((swatch, index) => {
+      const descriptor = buildSwatchDescriptor(
+        swatch.colors,
+        swatch.colorPattern,
+        swatch.finishType,
+        swatch.effects
+      );
+
+      const needsFilter = descriptor.desaturate || descriptor.glow;
+      const count = descriptor.stops.length;
+
+      return {
+        id: swatch.id,
+        gradientId:
+          descriptor.kind === 'gradient' ? `${this.prefix}-g${index}` : null,
+        filterId: needsFilter ? `${this.prefix}-f${index}` : null,
+        descriptor,
+        stops: descriptor.stops.map((stop, stopIndex) => ({
+          color: stop.color,
+          offset:
+            stop.offsetPercent !== null
+              ? `${stop.offsetPercent}%`
+              : `${count <= 1 ? 0 : Math.round((stopIndex / (count - 1)) * 100)}%`,
+        })),
+      };
+    })
+  );
+
+  private readonly byId = computed(
+    () => new Map(this.defs().map((d) => [d.id, d]))
+  );
+
+  /** A url() reference for a gradient, a literal hex for a solid, or the neutral series token. */
+  fillFor(id: string): string {
+    const def = this.byId().get(id);
+    if (!def) return 'var(--chart-series-6)';
+    return def.gradientId
+      ? `url(#${def.gradientId})`
+      : def.descriptor.stops[0].color;
+  }
+
+  filterFor(id: string): string | null {
+    const def = this.byId().get(id);
+    return def?.filterId ? `url(#${def.filterId})` : null;
+  }
+
+  opacityFor(id: string): number {
+    return this.byId().get(id)?.descriptor.opacity ?? 1;
+  }
+}

--- a/src/app/shared/charts/filament-swatch-colors.spec.ts
+++ b/src/app/shared/charts/filament-swatch-colors.spec.ts
@@ -1,0 +1,119 @@
+import {
+  ColorPatternType,
+  FilamentEffect,
+  FilamentFinishType,
+} from 'src/app/core/services/filament.service';
+import {
+  buildSwatchDescriptor,
+  normalizeHex,
+  swatchCssStyle,
+} from './filament-swatch-colors';
+
+describe('normalizeHex', () => {
+  it('accepts three- and six-digit hex with or without a hash', () => {
+    expect(normalizeHex('ff0000')).toBe('#ff0000');
+    expect(normalizeHex('#FF0000')).toBe('#FF0000');
+    expect(normalizeHex('f00')).toBe('#f00');
+  });
+
+  it('rejects anything that is not a hex colour', () => {
+    // These are the values that must never reach an SVG attribute.
+    expect(normalizeHex('red')).toBeNull();
+    expect(normalizeHex('url(#x)')).toBeNull();
+    expect(normalizeHex('#ff0000;fill:url(#evil)')).toBeNull();
+    expect(normalizeHex('')).toBeNull();
+    expect(normalizeHex(null)).toBeNull();
+  });
+});
+
+describe('buildSwatchDescriptor', () => {
+  it('describes a solid colour as one stop with no offset', () => {
+    const descriptor = buildSwatchDescriptor(
+      ['ff0000'],
+      ColorPatternType.Solid
+    );
+
+    expect(descriptor.kind).toBe('solid');
+    expect(descriptor.stops).toEqual([
+      { color: '#ff0000', offsetPercent: null },
+    ]);
+  });
+
+  it('describes Gradient and Rainbow as stops without offsets', () => {
+    const descriptor = buildSwatchDescriptor(
+      ['ff0000', '0000ff'],
+      ColorPatternType.Gradient
+    );
+
+    expect(descriptor.kind).toBe('gradient');
+    expect(descriptor.stops.map((s) => s.offsetPercent)).toEqual([null, null]);
+  });
+
+  it('describes Multi as doubled hard stops with offsets', () => {
+    const descriptor = buildSwatchDescriptor(
+      ['ff0000', '0000ff'],
+      ColorPatternType.Multi
+    );
+
+    expect(descriptor.stops).toEqual([
+      { color: '#ff0000', offsetPercent: 0 },
+      { color: '#ff0000', offsetPercent: 50 },
+      { color: '#0000ff', offsetPercent: 50 },
+      { color: '#0000ff', offsetPercent: 100 },
+    ]);
+  });
+
+  it('falls back to black for an empty colour list, as the pipe always has', () => {
+    const descriptor = buildSwatchDescriptor([], ColorPatternType.Solid);
+
+    expect(descriptor.stops).toEqual([
+      { color: '#000000', offsetPercent: null },
+    ]);
+  });
+
+  it('falls back to black for a colour token that is not valid hex', () => {
+    const descriptor = buildSwatchDescriptor(
+      ['url(#evil)'],
+      ColorPatternType.Solid
+    );
+
+    expect(descriptor.stops).toEqual([
+      { color: '#000000', offsetPercent: null },
+    ]);
+  });
+
+  it('falls back to solid for an unknown pattern value', () => {
+    const descriptor = buildSwatchDescriptor(
+      ['ff0000', '0000ff'],
+      99 as ColorPatternType
+    );
+
+    expect(descriptor.kind).toBe('solid');
+  });
+
+  it('records finish and effects as flags rather than CSS', () => {
+    const descriptor = buildSwatchDescriptor(
+      ['ff0000'],
+      ColorPatternType.Solid,
+      FilamentFinishType.Silk,
+      [FilamentEffect.Translucent, FilamentEffect.GlowInDark]
+    );
+
+    expect(descriptor.shimmer).toBeTrue();
+    expect(descriptor.desaturate).toBeFalse();
+    expect(descriptor.opacity).toBe(0.7);
+    expect(descriptor.glow).toBeTrue();
+  });
+});
+
+describe('swatchCssStyle', () => {
+  it('reproduces the exact Multi gradient string the pipe has always emitted', () => {
+    const style = swatchCssStyle(
+      buildSwatchDescriptor(['ff0000', '0000ff'], ColorPatternType.Multi)
+    );
+
+    expect(style).toBe(
+      'background: linear-gradient(90deg, #ff0000 0%, #ff0000 50%, #0000ff 50%, #0000ff 100%)'
+    );
+  });
+});

--- a/src/app/shared/charts/filament-swatch-colors.ts
+++ b/src/app/shared/charts/filament-swatch-colors.ts
@@ -1,0 +1,151 @@
+import {
+  ColorPatternType,
+  FilamentEffect,
+  FilamentFinishType,
+} from 'src/app/core/services/filament.service';
+
+export interface SwatchStop {
+  color: string;
+  /** Null for a smooth gradient stop; a percentage for a hard Multi stop. */
+  offsetPercent: number | null;
+}
+
+/**
+ * A filament's appearance, described once and rendered two ways: as a CSS style string by
+ * FilamentColorSwatchStylePipe, and as SVG <linearGradient>/<filter> defs by
+ * filament-svg-defs. A CSS style string cannot be assigned to an SVG `fill`, which is why the
+ * descriptor exists rather than the pipe being reused directly.
+ */
+export interface SwatchDescriptor {
+  kind: 'solid' | 'gradient';
+  stops: SwatchStop[];
+  /** Silk. */
+  shimmer: boolean;
+  /** Matte. */
+  desaturate: boolean;
+  /** 0.7 for Translucent, otherwise 1. */
+  opacity: number;
+  /** Glow in the dark. */
+  glow: boolean;
+}
+
+const FALLBACK = '#000000';
+const HEX = /^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
+
+/**
+ * Returns the token with a leading hash, or null if it is not a hex colour.
+ *
+ * Colours are user-controlled persisted data and end up inside SVG attributes, so they are
+ * validated against a strict pattern before use — "#ff0000;fill:url(#evil)" must never reach a
+ * fill. Case is preserved because the pipe's pinned specs compare exact strings.
+ */
+export function normalizeHex(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!HEX.test(trimmed)) return null;
+  return trimmed.startsWith('#') ? trimmed : `#${trimmed}`;
+}
+
+export function buildSwatchDescriptor(
+  colors: string[],
+  pattern: ColorPatternType,
+  finishType?: FilamentFinishType,
+  effects?: FilamentEffect[]
+): SwatchDescriptor {
+  const safe = (colors ?? []).map((c) => normalizeHex(c) ?? FALLBACK);
+
+  const flags = {
+    shimmer: finishType === FilamentFinishType.Silk,
+    desaturate: finishType === FilamentFinishType.Matte,
+    opacity: effects?.includes(FilamentEffect.Translucent) ? 0.7 : 1,
+    glow: effects?.includes(FilamentEffect.GlowInDark) ?? false,
+  };
+
+  if (safe.length === 0) {
+    return {
+      kind: 'solid',
+      stops: [{ color: FALLBACK, offsetPercent: null }],
+      ...flags,
+    };
+  }
+
+  switch (pattern) {
+    case ColorPatternType.Gradient:
+    case ColorPatternType.Rainbow:
+      return {
+        kind: 'gradient',
+        stops: safe.map((color) => ({ color, offsetPercent: null })),
+        ...flags,
+      };
+
+    case ColorPatternType.Multi: {
+      const stops: SwatchStop[] = [];
+      safe.forEach((color, index) => {
+        stops.push({
+          color,
+          offsetPercent: Math.round((index / safe.length) * 100),
+        });
+        stops.push({
+          color,
+          offsetPercent: Math.round(((index + 1) / safe.length) * 100),
+        });
+      });
+      return { kind: 'gradient', stops, ...flags };
+    }
+
+    case ColorPatternType.Solid:
+    default:
+      // An unknown enum value falls back to solid rather than rendering something arbitrary.
+      return {
+        kind: 'solid',
+        stops: [{ color: safe[0], offsetPercent: null }],
+        ...flags,
+      };
+  }
+}
+
+const SHIMMER =
+  'linear-gradient(110deg, transparent 35%, rgba(255,255,255,0.3) 50%, transparent 65%)';
+
+/**
+ * The CSS form. Output is pinned byte-for-byte by filament-color-swatch-style.pipe.spec.ts —
+ * this function exists so the pipe and the SVG defs cannot drift, not to change any string.
+ */
+export function swatchCssStyle(descriptor: SwatchDescriptor): string {
+  const value =
+    descriptor.kind === 'gradient'
+      ? `linear-gradient(90deg, ${descriptor.stops
+          .map((s) =>
+            s.offsetPercent === null
+              ? s.color
+              : `${s.color} ${s.offsetPercent}%`
+          )
+          .join(', ')})`
+      : descriptor.stops[0].color;
+
+  const parts: string[] = [];
+
+  if (descriptor.shimmer) {
+    if (descriptor.kind === 'gradient') {
+      parts.push(`background-image: ${SHIMMER}, ${value}`);
+      parts.push('background-size: 200% 100%, 100% 100%');
+    } else {
+      parts.push(`background-image: ${SHIMMER}`);
+      parts.push(`background-color: ${value}`);
+      parts.push('background-size: 200% 100%');
+    }
+  } else {
+    parts.push(`background: ${value}`);
+  }
+
+  if (descriptor.desaturate)
+    parts.push('filter: saturate(0.6) brightness(0.95)');
+  if (descriptor.opacity !== 1) parts.push(`opacity: ${descriptor.opacity}`);
+  if (descriptor.glow) {
+    parts.push(
+      'box-shadow: inset 0 0 6px rgba(120,255,120,0.5), 0 0 8px rgba(120,255,120,0.4)'
+    );
+  }
+
+  return parts.join('; ');
+}

--- a/src/app/shared/pipes/filament-color-swatch-style.pipe.ts
+++ b/src/app/shared/pipes/filament-color-swatch-style.pipe.ts
@@ -1,10 +1,19 @@
 import { Pipe, PipeTransform } from '@angular/core';
 import {
+  buildSwatchDescriptor,
+  swatchCssStyle,
+} from '../charts/filament-swatch-colors';
+import {
   ColorPatternType,
   FilamentEffect,
   FilamentFinishType,
 } from '../../core/services/filament.service';
 
+/**
+ * Thin adapter over the shared swatch descriptor. The logic lives in
+ * shared/charts/filament-swatch-colors.ts so the CSS swatches and the SVG chart fills are
+ * built from ONE description of a filament's appearance and cannot drift apart.
+ */
 @Pipe({ name: 'filamentColorSwatchStyle', pure: true })
 export class FilamentColorSwatchStylePipe implements PipeTransform {
   transform(
@@ -13,76 +22,8 @@ export class FilamentColorSwatchStylePipe implements PipeTransform {
     finishType?: FilamentFinishType,
     effects?: FilamentEffect[]
   ): string {
-    const colorPart = this.buildColorPart(colors, pattern);
-    const parts: string[] = [];
-
-    const shimmer =
-      'linear-gradient(110deg, transparent 35%, rgba(255,255,255,0.3) 50%, transparent 65%)';
-
-    if (finishType === FilamentFinishType.Silk) {
-      if (colorPart.type === 'gradient') {
-        parts.push(`background-image: ${shimmer}, ${colorPart.value}`);
-        parts.push('background-size: 200% 100%, 100% 100%');
-      } else {
-        parts.push(`background-image: ${shimmer}`);
-        parts.push(`background-color: ${colorPart.value}`);
-        parts.push('background-size: 200% 100%');
-      }
-    } else {
-      parts.push(`background: ${colorPart.value}`);
-    }
-
-    if (finishType === FilamentFinishType.Matte) {
-      parts.push('filter: saturate(0.6) brightness(0.95)');
-    }
-
-    if (effects?.includes(FilamentEffect.Translucent)) {
-      parts.push('opacity: 0.7');
-    }
-
-    if (effects?.includes(FilamentEffect.GlowInDark)) {
-      parts.push(
-        'box-shadow: inset 0 0 6px rgba(120,255,120,0.5), 0 0 8px rgba(120,255,120,0.4)'
-      );
-    }
-
-    return parts.join('; ');
-  }
-
-  private buildColorPart(
-    colors: string[],
-    pattern: ColorPatternType
-  ): { type: 'solid' | 'gradient'; value: string } {
-    if (!colors?.length) return { type: 'solid', value: '#000000' };
-
-    const hex = (c: string) => (c.startsWith('#') ? c : `#${c}`);
-
-    switch (pattern) {
-      case ColorPatternType.Gradient:
-      case ColorPatternType.Rainbow:
-        return {
-          type: 'gradient',
-          value: `linear-gradient(90deg, ${colors.map(hex).join(', ')})`,
-        };
-
-      case ColorPatternType.Multi: {
-        const n = colors.length;
-        const stops: string[] = [];
-        colors.forEach((c, i) => {
-          const startPct = Math.round((i / n) * 100);
-          const endPct = Math.round(((i + 1) / n) * 100);
-          stops.push(`${hex(c)} ${startPct}%`);
-          stops.push(`${hex(c)} ${endPct}%`);
-        });
-        return {
-          type: 'gradient',
-          value: `linear-gradient(90deg, ${stops.join(', ')})`,
-        };
-      }
-
-      case ColorPatternType.Solid:
-      default:
-        return { type: 'solid', value: hex(colors[0]) };
-    }
+    return swatchCssStyle(
+      buildSwatchDescriptor(colors, pattern, finishType, effects)
+    );
   }
 }


### PR DESCRIPTION
Part B of the Analytics redesign (spec §15.3, plan `2026-07-30-analytics-phases-2-4.md`).

**Depends on HoffmanEngineering/3d-print-log-api#31** — the tab calls `/api/analytics/materials`. Merge and deploy that first.

## What this adds

A fourth Analytics tab: filament by material type / brand / colour, consumption over time stacked by type, top spools with remaining stock, and a "running low" list driven by burn rate and runway. Waste mass and waste cost sit in stat tiles.

Filament swatches now render in charts, not just in HTML lists.

## The swatch work

`filament-color-swatch-style.pipe.ts` grew a shared descriptor underneath it (`shared/charts/filament-swatch-colors.ts`), so the CSS swatches and the new SVG chart fills are built from **one** description of a filament's appearance and cannot drift. The pipe is now a thin adapter — its ~15 consuming templates are unaffected, and its existing spec pins the exact output strings, which are byte-identical.

One behaviour change: colour tokens are validated against a strict hex pattern, and an invalid token falls back to black instead of being interpolated verbatim. Valid input is unchanged. This matters because these colours are user-controlled persisted data that now reaches SVG attributes — previously an invalid token produced invalid CSS (a visual no-op); in SVG it would be the injection surface. The defs are Angular template markup with bound attributes, never string concatenation, and gradient ids are scoped per component instance because SVG ids are document-global.

## Where swatch fills are used, and where they aren't

| Chart | Fill | Why |
|---|---|---|
| By type / brand / colour | Swatch, with a contrast outline | Single series, directly labelled — the swatch *is* the information |
| Consumption over time (stacked) | Categorical palette | A stacked series must be readable at a glance; two black spools are indistinguishable and dark colours vanish on the dark theme |
| Top spools, running low | HTML swatch via the existing pipe | Not a chart |

Every swatch-filled mark is also labelled with its material name and value, so colour is never the sole encoder.

## Notes for the reviewer

- **A production-only build failure was fixed here.** Angular's element schema rejects bare SVG filter tags under AOT (`NG8001` on `filter`, `feColorMatrix`, `feDropShadow`) while JIT accepts them — all unit tests and lint passed with the broken template, and only `npm run build` caught it. The defs template is namespaced with `svg:` throughout.
- The spool table's link is a real `<button>`, not a row `(click)` — keyboard- and AT-operable, with padding carrying it to a ≥44px touch target.
- By-type/brand/colour groups are deliberately **not** click-through: their keys are attribute strings and the print list has no attribute filter, so a link that silently dropped its filter would be worse than none. Spool rows do link, by filament id, and never send `userId`.
- Negative remaining is shown as-is rather than clamped — it means usage was logged beyond the spool's initial weight.

## Verification

`npm run test:brief` — **855 passed**. `npm run lint:brief` — clean. `npm run build:dev` — succeeds.

**`cypress/e2e/analytics/analytics-materials.cy.ts` has not been verified against a running stack.** My local dev server was serving a bundle without the new tab, and the already-shipped `analytics-printers.cy.ts` fails 2 of 3 in the same environment for want of seeded local data. The spec needs a real run before merge — I'm not claiming it passes.