### PR TITLE
release: 1.45.0 - The New Analytics Page

### DIFF
--- a/cypress/e2e/analytics/analytics-materials.cy.ts
+++ b/cypress/e2e/analytics/analytics-materials.cy.ts
@@ -24,7 +24,7 @@ describe('Analytics — Materials tab', () => {
     });
   });
 
-  it('never emits a swatch gradient whose stop-color is not a hex colour', () => {
+  it('never emits a swatch gradient whose stop-color is not a hex color', () => {
     cy.viewport(1440, 900);
     cy.visit('/analytics');
     cy.contains('.mat-mdc-tab', 'Materials').click();
@@ -42,7 +42,7 @@ describe('Analytics — Materials tab', () => {
     });
   });
 
-  it('labels every swatch-filled bar with its material name, not colour alone', () => {
+  it('labels every swatch-filled bar with its material name, not color alone', () => {
     cy.viewport(1440, 900);
     cy.visit('/analytics');
     cy.contains('.mat-mdc-tab', 'Materials').click();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "print-log-ui",
-  "version": "1.44.0",
+  "version": "1.45.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --ssl --host 0.0.0.0 ",

--- a/src/app/analytics/tabs/costs/costs-tab.component.spec.ts
+++ b/src/app/analytics/tabs/costs/costs-tab.component.spec.ts
@@ -115,7 +115,7 @@ describe('CostsTabComponent', () => {
     );
   }));
 
-  it('keeps the three cost components on fixed colours across the tab', fakeAsync(() => {
+  it('keeps the three cost components on fixed colors across the tab', fakeAsync(() => {
     setup();
 
     expect(component.componentSeries.map((s) => s.key)).toEqual([

--- a/src/app/analytics/tabs/costs/costs-tab.component.ts
+++ b/src/app/analytics/tabs/costs/costs-tab.component.ts
@@ -95,7 +95,7 @@ export class CostsTabComponent {
   readonly data = this.tab.data;
   readonly state = this.tab.state;
 
-  /** Fixed indices so a component keeps its colour in every chart on the tab. */
+  /** Fixed indices so a component keeps its color in every chart on the tab. */
   readonly componentSeries: readonly BarSeries[] = [
     { key: 'filament', label: 'Filament', seriesIndex: 1 },
     { key: 'electricity', label: 'Electricity', seriesIndex: 2 },

--- a/src/app/analytics/tabs/materials/materials-tab.component.html
+++ b/src/app/analytics/tabs/materials/materials-tab.component.html
@@ -100,11 +100,11 @@
     <app-chart-frame
       class="materials-tab__chart"
       #colorFrame
-      title="Filament by colour"
+      title="Filament by color"
       [csv]="byColorCsv()"
       [state]="state()"
       [coverage]="data()?.coverage ?? null"
-      ariaSummary="Grams of filament used per colour"
+      ariaSummary="Grams of filament used per color"
       emptyMessage="No spool-tracked filament in this range yet."
       (retry)="onRetry()"
     >
@@ -120,7 +120,7 @@
 
       <table chartDataTable>
         <caption>
-          Filament by colour
+          Filament by color
         </caption>
         <tbody>
           @for (group of data()?.byColor ?? []; track group.key) {

--- a/src/app/analytics/tabs/materials/materials-tab.component.scss
+++ b/src/app/analytics/tabs/materials/materials-tab.component.scss
@@ -33,7 +33,7 @@
   block-size: 0.75rem;
   margin-inline-end: 0.35rem;
   border-radius: 2px;
-  // Same reason as the SVG outline: dark colours vanish against the dark theme.
+  // Same reason as the SVG outline: dark colors vanish against the dark theme.
   outline: 1px solid var(--chart-swatch-outline);
   vertical-align: middle;
 }

--- a/src/app/analytics/tabs/materials/materials-tab.component.ts
+++ b/src/app/analytics/tabs/materials/materials-tab.component.ts
@@ -152,7 +152,7 @@ export class MaterialsTabComponent {
   );
 
   readonly byColorCsv = computed<CsvExport>(() =>
-    this.groupCsv('colour', this.data()?.byColor ?? [])
+    this.groupCsv('color', this.data()?.byColor ?? [])
   );
 
   readonly consumptionCsv = computed<CsvExport>(() => ({
@@ -196,7 +196,7 @@ export class MaterialsTabComponent {
   readonly tabCsv = computed<CsvSection[]>(() => [
     sectionOf('By type', this.byTypeCsv()),
     sectionOf('By brand', this.byBrandCsv()),
-    sectionOf('By colour', this.byColorCsv()),
+    sectionOf('By color', this.byColorCsv()),
     sectionOf('Consumption per period', this.consumptionCsv()),
     sectionOf('Top spools', this.topSpoolsCsv()),
     {
@@ -232,7 +232,7 @@ export class MaterialsTabComponent {
    * Click-through is a cross-cutting promise (spec §9), so it applies here too. The print list
    * filters by filament id, which is what a spool row and a running-low row both carry.
    *
-   * The by-type / by-brand / by-colour groups are NOT clickable: their keys are attribute
+   * The by-type / by-brand / by-color groups are NOT clickable: their keys are attribute
    * strings, and the print list has no attribute filter — a link that silently dropped its
    * filter would be worse than no link. Never sends userId (that means "public prints only").
    */

--- a/src/app/analytics/tabs/overview/overview-tab.component.ts
+++ b/src/app/analytics/tabs/overview/overview-tab.component.ts
@@ -35,8 +35,8 @@ import { CsvSection, buildTabCsv, sectionOf } from '../tab-csv';
 import { createTabData } from '../tab-data';
 
 /**
- * Status ordering and colour assignment are fixed here so the donut, the stacked bars, and
- * the legend always agree — a status must not change colour between two charts on one screen.
+ * Status ordering and color assignment are fixed here so the donut, the stacked bars, and
+ * the legend always agree — a status must not change color between two charts on one screen.
  */
 const STATUS_SERIES: readonly {
   key: string;

--- a/src/app/analytics/tabs/printers/printer-comparison.component.scss
+++ b/src/app/analytics/tabs/printers/printer-comparison.component.scss
@@ -29,7 +29,7 @@
   // where the cell padding puts it.
   //
   // justify-content, not just text-align: the button lays its label out with flex and
-  // centres it, so text-align alone left every header floating mid-column above
+  // centers it, so text-align alone left every header floating mid-column above
   // right-aligned figures — which is the misalignment that shows up on screen.
   thead button {
     padding: 0;

--- a/src/app/analytics/tabs/printers/printers-tab.component.ts
+++ b/src/app/analytics/tabs/printers/printers-tab.component.ts
@@ -81,7 +81,7 @@ export class PrintersTabComponent implements OnDestroy {
   }
 
   /**
-   * One series per printer, colours cycling through the six theme tokens. The key is the
+   * One series per printer, colors cycling through the six theme tokens. The key is the
    * printer id as a string, matching PrinterSeriesBucket.printSecondsByPrinterId, so the
    * stacked chart and the table are looking at the same identity.
    */

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -28,6 +28,34 @@ export class VersionReleaseNoteDialogService {
   private readonly LOCAL_STORAGE_KEY = 'LastLoggedInVersion';
 
   private releaseNotes: ReleaseNoteHistory = {
+    '1.45.0': {
+      title: '1.45.0 - The New Analytics Page',
+      body: `<p>
+<strong>The new Analytics page</strong> is here! Six tabs (Overview, Activity, Printers, Materials, Costs and Accuracy) share one filter bar, so you can pick a date range and narrow to particular printers, materials, projects or statuses, and every chart follows along. Compare any period to the one before it, and bookmark or share a view straight from the address bar.
+</p>
+<p>
+See a calendar of your printing days and streaks, compare your machines side by side, watch filament use by type, brand and color (in the real spool colors), break your spending into filament, electricity and maintenance, and find out whether your slicer estimates run long or short. Every chart exports as a CSV or a PNG. Take a look at <a href="/analytics">Analytics</a>, or read <a href="/docs/analytics">the Analytics documentation</a>.
+</p>
+<p>
+  <strong>Support development of 3D Print Log:</strong><br />
+  <a href="/subscription">Subscribe to Pro</a> for an ad-free experience and extra cloud storage,
+  buy me a coffee by <a
+    href="https://paypal.me/hoffmanengineering"
+    rel="noreferrer noopener"
+    target="_blank"
+    >donating via PayPal</a
+  >, or by becoming a
+  <a
+    href="https://www.patreon.com/HoffmanEngineering"
+    rel="noreferrer noopener"
+    target="_blank"
+  >
+    Patron of Hoffman Engineering</a
+  >
+  on Patreon.com
+  </p><p>Share <strong>3D Print Log</strong> with a friend, and Happy Printing!
+</p>`,
+    },
     '1.44.0': {
       title: '1.44.0 - Connect an AI Assistant (MCP)',
       body: `<p>

--- a/src/app/documentation/docs/docs-analytics/docs-analytics.component.html
+++ b/src/app/documentation/docs/docs-analytics/docs-analytics.component.html
@@ -4,7 +4,7 @@
   <p>
     Open <a [routerLink]="['/analytics']">Analytics</a> to see what you have
     printed, how long it took, what it used, and roughly what it cost. The page
-    is organised into six tabs that all share one filter bar at the top.
+    is organized into six tabs that all share one filter bar at the top.
   </p>
 
   <hr />
@@ -26,7 +26,7 @@
   </p>
   <p>
     <strong>Materials</strong> breaks your filament use down by type, brand and
-    colour, shows which spools you are getting through fastest, and estimates
+    color, shows which spools you are getting through fastest, and estimates
     how long each one will last.
   </p>
   <p>

--- a/src/app/documentation/docs/docs-mcp/docs-mcp.component.html
+++ b/src/app/documentation/docs/docs-mcp/docs-mcp.component.html
@@ -63,7 +63,7 @@
       <strong>Your prints.</strong> &ldquo;How many prints did I finish last
       year, and how many failed?&rdquo; You can search by name or project
       (&ldquo;what was that soap dish I printed?&rdquo;), and ask what a print
-      used, including each colour of a multi-colour print.
+      used, including each color of a multi-color print.
     </li>
     <li>
       <strong>Your materials.</strong> &ldquo;What blue PLA do I have, and where
@@ -99,9 +99,9 @@
   <ul>
     <li>
       <strong>Log a finished print.</strong> &ldquo;Log that Benchy I just
-      finished on the Bambu. It used about 12&nbsp;g of the grey PLA.&rdquo; It
+      finished on the Bambu. It used about 12&nbsp;g of the gray PLA.&rdquo; It
       records the status, print time, notes, and material used, and can file the
-      print under a project. A multi-colour print can list what each material
+      print under a project. A multi-color print can list what each material
       contributed, and you can give either the amount you measured or the
       slicer&rsquo;s estimate.
     </li>
@@ -132,17 +132,17 @@
       <strong>Add material.</strong> &ldquo;Add a new 1&nbsp;kg spool of
       Prusament Galaxy Black PLA.&rdquo; New material goes straight into your
       inventory. This isn&rsquo;t just filament: resin and powder work too,
-      along with details like brand, colour, finish, price, and where you store
+      along with details like brand, color, finish, price, and where you store
       it.
     </li>
     <li>
       <strong>Update material details.</strong> &ldquo;Move the blue PLA to Dry
-      Box B&rdquo; or &ldquo;mark the Galaxy Black as a favourite.&rdquo;
-      Storage location, colour, temperatures, and purchase details can all be
+      Box B&rdquo; or &ldquo;mark the Galaxy Black as a favorite.&rdquo;
+      Storage location, color, temperatures, and purchase details can all be
       corrected after the fact.
     </li>
     <li>
-      <strong>Correct what&rsquo;s left.</strong> &ldquo;I weighed the grey PLA.
+      <strong>Correct what&rsquo;s left.</strong> &ldquo;I weighed the gray PLA.
       It&rsquo;s actually 640&nbsp;g now.&rdquo; Adjust a spool&rsquo;s
       remaining amount up or down. It can&rsquo;t go below empty or above what
       the spool started with, so if a correction is refused, check the starting

--- a/src/app/documentation/docs/docs-projects/docs-projects.component.html
+++ b/src/app/documentation/docs/docs-projects/docs-projects.component.html
@@ -26,7 +26,7 @@
   </p>
 
   <h3>Viewing Project Totals</h3>
-  <p>Projects appear on your print list as coloured chips. You can:</p>
+  <p>Projects appear on your print list as colored chips. You can:</p>
   <ul>
     <li>Click a project chip to filter the list to that project's prints.</li>
     <li>
@@ -52,7 +52,7 @@
   <p>
     Each project has a status: <strong>In Progress</strong>,
     <strong>Complete</strong>, <strong>On Hold</strong>, or
-    <strong>Cancelled</strong>. The status is shown as a colour-coded dot on the
+    <strong>Cancelled</strong>. The status is shown as a color-coded dot on the
     project chip and can be changed from the project detail page.
   </p>
 

--- a/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
+++ b/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
@@ -2,6 +2,224 @@
   <h2>Release Notes</h2>
   <hr />
 
+  <h3 id="v1.45.0">1.45.0 - The New Analytics Page</h3>
+  <p>
+    Analytics has been rebuilt from the ground up. Instead of a single page of totals, there are now
+    six tabs (Overview, Activity, Printers, Materials, Costs and Accuracy) that all share one filter
+    bar, so you can pick a date range, narrow to particular printers, materials, projects or
+    statuses, and every chart on every tab follows along. Turn on compare to previous period to see
+    how each figure moved against the period immediately before it, and because your filters and tab
+    live in the page address, you can bookmark a view or send someone the link.
+  </p>
+  <p>
+    The new tabs answer questions the old page could not. Activity shows a calendar of your printing
+    days, your current and longest streaks, and which days and hours you actually start prints.
+    Printers compares your machines side by side on prints, success rate, hours, filament and
+    maintenance spend. Materials breaks filament use down by type, brand and color (with the real
+    spool colors in the charts), shows which spools you are burning through, and estimates how long
+    each one will last. Costs splits your spending into filament, electricity and maintenance and
+    shows what a typical print costs and how much went on prints that did not work out. Accuracy
+    compares your slicer's estimates against what really happened, so you can see whether a printer
+    or a material consistently runs long or short.
+  </p>
+  <p>
+    Every chart can be exported as a CSV or a PNG image, and each tab can export all of its data at
+    once. Numbers are honest about where they came from: a recorded value is always preferred over a
+    slicer estimate, the charts tell you when estimates were involved, and a missing duration or
+    amount is treated as not recorded rather than as a zero. See
+    <a routerLink="/docs/analytics">the Analytics documentation</a> for how success rate, waste and
+    costs are worked out.
+  </p>
+  <h4>Full List of Changes:</h4>
+  <ul>
+    <li>
+      <strong>Redesigned Analytics page</strong> - Six tabs (Overview, Activity, Printers, Materials,
+      Costs and Accuracy) replace the old single-page layout, with all figures aggregated on the
+      server so large print histories stay fast.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/76"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #76</a
+      >,
+      <a
+        href="https://github.com/HoffmanEngineering/3d-print-log-api/pull/29"
+        rel="noreferrer noopener"
+        target="_blank"
+        >API PR #29</a
+      >)
+    </li>
+    <li>
+      <strong>Shared filter bar</strong> - Date presets or a custom range, plus printer, material,
+      project and status filters, a compare to previous period toggle, and a bottom sheet version on
+      phones. Your selection and current tab are stored in the page address so views can be
+      bookmarked and shared.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/76"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #76</a
+      >)
+    </li>
+    <li>
+      <strong>Activity tab</strong> - A calendar heatmap of active days, current and longest streaks,
+      a print duration histogram, and a weekday-by-hour matrix of when you start prints, with a
+      metric toggle to switch what the calendar is measuring.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/77"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #77</a
+      >,
+      <a
+        href="https://github.com/HoffmanEngineering/3d-print-log-api/pull/30"
+        rel="noreferrer noopener"
+        target="_blank"
+        >API PR #30</a
+      >)
+    </li>
+    <li>
+      <strong>Printers tab</strong> - A sortable comparison table (cards on small screens) covering
+      prints, success rate, hours run, filament used, utilization and maintenance spend per machine.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/77"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #77</a
+      >,
+      <a
+        href="https://github.com/HoffmanEngineering/3d-print-log-api/pull/30"
+        rel="noreferrer noopener"
+        target="_blank"
+        >API PR #30</a
+      >)
+    </li>
+    <li>
+      <strong>Click through to your prints</strong> - Selecting a point on a time chart or calendar
+      opens the print list filtered to exactly that date range.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/77"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #77</a
+      >)
+    </li>
+    <li>
+      <strong>Materials tab</strong> - Filament use by type, brand and color, your top spools by
+      consumption, and a runway estimate for how long each spool will last. Bars are filled with the
+      spool's actual color, including gradients for multi-color filaments.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/78"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #78</a
+      >,
+      <a
+        href="https://github.com/HoffmanEngineering/3d-print-log-api/pull/31"
+        rel="noreferrer noopener"
+        target="_blank"
+        >API PR #31</a
+      >)
+    </li>
+    <li>
+      <strong>Costs tab</strong> - Spending split into filament, electricity and maintenance, the
+      distribution of what a print costs, how much went to waste, and prompts telling you what to
+      fill in (spool prices, electricity rate, printer wattage) if a figure is missing.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/79"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #79</a
+      >,
+      <a
+        href="https://github.com/HoffmanEngineering/3d-print-log-api/pull/32"
+        rel="noreferrer noopener"
+        target="_blank"
+        >API PR #32</a
+      >)
+    </li>
+    <li>
+      <strong>Accuracy tab</strong> - Estimated versus actual print time and filament on a scatter
+      chart with a reference line, median differences per printer and material, and plain-language
+      callouts describing where your estimates run long or short.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/79"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #79</a
+      >,
+      <a
+        href="https://github.com/HoffmanEngineering/3d-print-log-api/pull/32"
+        rel="noreferrer noopener"
+        target="_blank"
+        >API PR #32</a
+      >)
+    </li>
+    <li>
+      <strong>Chart and tab export</strong> - Export any chart as a CSV or a theme-matched PNG image,
+      or export everything on the current tab as a CSV in one go.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/79"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #79</a
+      >)
+    </li>
+    <li>
+      <strong>Clearer notes on where numbers come from</strong> - Charts now say in plain language
+      when estimates were used, when prints were left out for a missing duration, and when a range
+      was shortened to fit your data.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/77"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #77</a
+      >)
+    </li>
+    <li>
+      <strong>Unpriced costs are no longer shown as zero</strong> - A cost component that could not
+      be priced (a spool with no purchase price, for example) is now distinguishable from a genuine
+      zero, and amounts in another currency are called out instead of being silently added up.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/79"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #79</a
+      >)
+    </li>
+    <li>
+      <strong>Volume-based filament costing fixed</strong> - Prints that record filament by volume
+      are now costed from that volume instead of a converted weight.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/76"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #76</a
+      >)
+    </li>
+    <li>
+      <strong>Updated Analytics documentation</strong> - The
+      <a routerLink="/docs/analytics">Analytics page</a> now explains each tab, how success rate and
+      waste are decided, how costs are valued, and what to fill in so the Costs tab works.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/79"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #79</a
+      >)
+    </li>
+    <li>
+      <strong>Release notes popup renders correctly again</strong> - The popup you are reading this
+      in appeared unstyled (plain text and a bare button) when it opened straight after signing in.
+    </li>
+    <li>
+      <strong>More readable popup text</strong> - Text in confirmation and release note popups is
+      now full-strength instead of the faded grey it used before.
+    </li>
+  </ul>
+
+  <hr />
+
   <h3 id="v1.44.0">1.44.0 - Connect an AI Assistant (MCP)</h3>
   <p>
     3D Print Log now connects to AI assistants like Claude and ChatGPT. Once connected, you can ask

--- a/src/app/print/view-print-detail/view-print-detail.component.spec.ts
+++ b/src/app/print/view-print-detail/view-print-detail.component.spec.ts
@@ -156,7 +156,7 @@ describe('ViewPrintDetailComponent', () => {
       fixture.detectChanges();
     });
 
-    it('should initialise selectedImageIndex to the default image index', () => {
+    it('should initialize selectedImageIndex to the default image index', () => {
       expect(component.selectedImageIndex).toBe(0);
     });
 

--- a/src/app/shared/charts/bar-chart.component.scss
+++ b/src/app/shared/charts/bar-chart.component.scss
@@ -95,7 +95,7 @@
 }
 
 .bar-chart__segment--swatch {
-  // Two black spools are otherwise indistinguishable, and dark colours vanish on the dark
+  // Two black spools are otherwise indistinguishable, and dark colors vanish on the dark
   // theme. Every swatch-filled mark gets a theme-contrast outline (spec §10).
   stroke: var(--chart-swatch-outline);
   stroke-width: 1;

--- a/src/app/shared/charts/bar-chart.component.spec.ts
+++ b/src/app/shared/charts/bar-chart.component.spec.ts
@@ -75,7 +75,7 @@ describe('BarChartComponent', () => {
     expect(new Set(xPositions).size).toBe(2);
   });
 
-  it('colours segments with theme classes, never literal fills', () => {
+  it('colors segments with theme classes, never literal fills', () => {
     const el = render(900);
     const segment = el.querySelector('rect.bar-chart__segment')!;
 

--- a/src/app/shared/charts/bar-chart.component.ts
+++ b/src/app/shared/charts/bar-chart.component.ts
@@ -22,7 +22,7 @@ export interface BarDatum {
   fullLabel: string;
   values: Record<string, number>;
   /**
-   * Optional per-datum fill — a hex colour or a `url(#…)` reference from
+   * Optional per-datum fill — a hex color or a `url(#…)` reference from
    * filament-svg-defs. When absent the mark takes its series' theme class, which is the
    * default and the right choice for anything that must stay readable at a glance.
    */

--- a/src/app/shared/charts/calendar-heatmap.component.scss
+++ b/src/app/shared/charts/calendar-heatmap.component.scss
@@ -7,7 +7,7 @@
   min-inline-size: 0;
   scroll-snap-type: x proximity;
 
-  // Centred when the grid is narrower than the panel — a short date range is only a few
+  // Centered when the grid is narrower than the panel — a short date range is only a few
   // week-columns wide, and left-aligning it in a wide card reads as a rendering fault
   // rather than as "you filtered to a short range". `safe` keeps the start edge reachable
   // when it DOES overflow, which plain centring would clip.

--- a/src/app/shared/charts/chart-axis.spec.ts
+++ b/src/app/shared/charts/chart-axis.spec.ts
@@ -15,7 +15,7 @@ describe('parseLocalDate', () => {
     expect(parsed.getDate()).toBe(1);
   });
 
-  it('renders a date-only bucket start with the same day the server labelled it', () => {
+  it('renders a date-only bucket start with the same day the server labeled it', () => {
     expect(formatTickDate(parseLocalDate('2026-07-01'), 'Day', true)).toBe(
       '7/1'
     );

--- a/src/app/shared/charts/chart-axis.ts
+++ b/src/app/shared/charts/chart-axis.ts
@@ -5,7 +5,7 @@ export type TickGranularity = 'Day' | 'Week' | 'Month';
  *
  * The API sends DateOnly, which serializes as "2026-07-01". `new Date("2026-07-01")` is
  * specified to parse a date-only form as UTC midnight, so every getMonth()/getDate() west of
- * UTC reads the PREVIOUS day — a bucket the server labelled 1 July renders as 6/30 in Chicago.
+ * UTC reads the PREVIOUS day — a bucket the server labeled 1 July renders as 6/30 in Chicago.
  * Splitting the parts and building a local date keeps the civil date the server computed.
  *
  * Values carrying a time component are left to the normal parser, which is already correct

--- a/src/app/shared/charts/chart-export.ts
+++ b/src/app/shared/charts/chart-export.ts
@@ -63,7 +63,7 @@ export async function svgToPngBlob(
   background?: string
 ): Promise<Blob> {
   // Resolved from the live page, not hardcoded white: on the dark theme the marks rasterise
-  // in their dark-theme colours, and a white canvas behind them would be unreadable. Opaque
+  // in their dark-theme colors, and a white canvas behind them would be unreadable. Opaque
   // either way — a transparent PNG pasted into a document is unreadable too.
   const surface = background ?? resolveSurfaceColor(svg);
   const rect = svg.getBoundingClientRect();

--- a/src/app/shared/charts/chart-frame.component.html
+++ b/src/app/shared/charts/chart-frame.component.html
@@ -60,7 +60,7 @@
         <!--
           role="group", not role="img": an img's subtree is presentational, which would hide
           the focusable chart marks inside it from assistive tech while they remained in the
-          tab order. A labelled group keeps the summary announced AND exposes the controls.
+          tab order. A labeled group keeps the summary announced AND exposes the controls.
         -->
         <div
           class="chart-frame__content"

--- a/src/app/shared/charts/chart-frame.component.ts
+++ b/src/app/shared/charts/chart-frame.component.ts
@@ -30,7 +30,7 @@ export type ChartState = 'loading' | 'ready' | 'empty' | 'error';
 
 /**
  * Every chart's outer shell: heading, loading/empty/error states, coverage badge, and the
- * measured size children render into. Cross-cutting behaviour lives here once so the
+ * measured size children render into. Cross-cutting behavior lives here once so the
  * individual chart types stay small.
  */
 @Component({

--- a/src/app/shared/charts/filament-svg-defs.component.spec.ts
+++ b/src/app/shared/charts/filament-svg-defs.component.spec.ts
@@ -19,7 +19,7 @@ describe('FilamentSvgDefsComponent', () => {
     component = fixture.componentInstance;
   });
 
-  it('returns a literal colour for a solid swatch rather than an unnecessary gradient', () => {
+  it('returns a literal color for a solid swatch rather than an unnecessary gradient', () => {
     fixture.componentRef.setInput('swatches', [
       { id: 'a', colors: ['ff0000'], colorPattern: ColorPatternType.Solid },
     ]);
@@ -31,7 +31,7 @@ describe('FilamentSvgDefsComponent', () => {
     ).toBe(0);
   });
 
-  it('emits a gradient and returns a url() fill for a multi-colour swatch', () => {
+  it('emits a gradient and returns a url() fill for a multi-color swatch', () => {
     fixture.componentRef.setInput('swatches', [
       {
         id: 'a',
@@ -73,7 +73,7 @@ describe('FilamentSvgDefsComponent', () => {
     );
   });
 
-  it('never emits a colour that failed hex validation', () => {
+  it('never emits a color that failed hex validation', () => {
     fixture.componentRef.setInput('swatches', [
       {
         id: 'a',

--- a/src/app/shared/charts/filament-svg-defs.component.ts
+++ b/src/app/shared/charts/filament-svg-defs.component.ts
@@ -15,7 +15,7 @@ import {
 } from './filament-swatch-colors';
 
 export interface FilamentSwatchInput {
-  /** Stable identity for the swatch — a filament id, a material type, a colour name. */
+  /** Stable identity for the swatch — a filament id, a material type, a color name. */
   id: string;
   colors: string[];
   colorPattern: ColorPatternType;
@@ -41,8 +41,8 @@ let instanceCounter = 0;
  * `fill` values that reference them.
  *
  * Everything here is Angular template markup with bound attributes — never string
- * concatenation. Colours, patterns, effects and names are user-controlled persisted data;
- * building SVG by string interpolation is how that data becomes an injection vector. Colours
+ * concatenation. Colors, patterns, effects and names are user-controlled persisted data;
+ * building SVG by string interpolation is how that data becomes an injection vector. Colors
  * are hex-validated upstream by normalizeHex, and anything that failed is already #000000.
  */
 @Component({

--- a/src/app/shared/charts/filament-swatch-colors.spec.ts
+++ b/src/app/shared/charts/filament-swatch-colors.spec.ts
@@ -16,7 +16,7 @@ describe('normalizeHex', () => {
     expect(normalizeHex('f00')).toBe('#f00');
   });
 
-  it('rejects anything that is not a hex colour', () => {
+  it('rejects anything that is not a hex color', () => {
     // These are the values that must never reach an SVG attribute.
     expect(normalizeHex('red')).toBeNull();
     expect(normalizeHex('url(#x)')).toBeNull();
@@ -27,7 +27,7 @@ describe('normalizeHex', () => {
 });
 
 describe('buildSwatchDescriptor', () => {
-  it('describes a solid colour as one stop with no offset', () => {
+  it('describes a solid color as one stop with no offset', () => {
     const descriptor = buildSwatchDescriptor(
       ['ff0000'],
       ColorPatternType.Solid
@@ -63,7 +63,7 @@ describe('buildSwatchDescriptor', () => {
     ]);
   });
 
-  it('falls back to black for an empty colour list, as the pipe always has', () => {
+  it('falls back to black for an empty color list, as the pipe always has', () => {
     const descriptor = buildSwatchDescriptor([], ColorPatternType.Solid);
 
     expect(descriptor.stops).toEqual([
@@ -71,7 +71,7 @@ describe('buildSwatchDescriptor', () => {
     ]);
   });
 
-  it('falls back to black for a colour token that is not valid hex', () => {
+  it('falls back to black for a color token that is not valid hex', () => {
     const descriptor = buildSwatchDescriptor(
       ['url(#evil)'],
       ColorPatternType.Solid

--- a/src/app/shared/charts/filament-swatch-colors.ts
+++ b/src/app/shared/charts/filament-swatch-colors.ts
@@ -33,9 +33,9 @@ const FALLBACK = '#000000';
 const HEX = /^#?([0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
 
 /**
- * Returns the token with a leading hash, or null if it is not a hex colour.
+ * Returns the token with a leading hash, or null if it is not a hex color.
  *
- * Colours are user-controlled persisted data and end up inside SVG attributes, so they are
+ * Colors are user-controlled persisted data and end up inside SVG attributes, so they are
  * validated against a strict pattern before use — "#ff0000;fill:url(#evil)" must never reach a
  * fill. Case is preserved because the pipe's pinned specs compare exact strings.
  */

--- a/src/app/shared/charts/matrix-heatmap.component.ts
+++ b/src/app/shared/charts/matrix-heatmap.component.ts
@@ -24,7 +24,7 @@ const COLUMN_LABEL_HEIGHT = 14;
 
 /**
  * A fixed row × column matrix that fills its container. Unlike the calendar heatmap this never
- * scrolls and both axes are labelled, so the two are separate components rather than one with a
+ * scrolls and both axes are labeled, so the two are separate components rather than one with a
  * mode flag controlling layout, labels, sizing and overflow.
  *
  * Levels are scaled against the busiest cell, which is the honest scale here: the question the

--- a/src/app/shared/filament-list/filament-list.component.scss
+++ b/src/app/shared/filament-list/filament-list.component.scss
@@ -58,7 +58,7 @@ table {
   flex-shrink: 0;
   white-space: nowrap;
 
-  // Ensure the matBadge number is vertically centred within the bubble.
+  // Ensure the matBadge number is vertically centered within the bubble.
   ::ng-deep .mat-badge-content {
     display: flex;
     align-items: center;
@@ -66,7 +66,7 @@ table {
   }
 
   // Material uses visibility:hidden for mat-badge-hidden, which hides the number
-  // but leaves the coloured circle painted. Use display:none instead.
+  // but leaves the colored circle painted. Use display:none instead.
   &.mat-badge-hidden ::ng-deep .mat-badge-content {
     display: none;
   }

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -43,7 +43,6 @@ import { MaterialNamePipe } from './pipes/material-name.pipe';
 import { PrintImageComponent } from './print-image/print-image.component';
 import { PrintSummaryCardComponent } from './print-summary-card/print-summary-card.component';
 import { SidebarComponent } from './sidebar/sidebar.component';
-import { SimpleDialogComponent } from './simple-dialog/simple-dialog.component';
 import { GcodeViewerModalComponent } from './gcode-viewer-modal/gcode-viewer-modal.component';
 import { NotificationBellComponent } from './notification-bell/notification-bell.component';
 import { AdComponent } from './ad/ad.component';
@@ -70,7 +69,6 @@ import { FilamentColorSwatchStylePipe } from './pipes/filament-color-swatch-styl
     StatPanelComponent,
     CommentComponent,
     HumanizePipe,
-    SimpleDialogComponent,
     ParserUnavailableDialogComponent,
     MaterialNamePipe,
     FilamentListComponent,

--- a/src/app/shared/simple-dialog/simple-dialog.component.scss
+++ b/src/app/shared/simple-dialog/simple-dialog.component.scss
@@ -1,0 +1,7 @@
+:host {
+  // Material's supporting-text token is rgba(0, 0, 0, 0.54), which is meant for text that
+  // merely supports a headline. Here the body IS the message (release notes, confirmations),
+  // so it takes the app's primary text emphasis instead. --app-text-primary already follows
+  // the active theme, so this stays correct in dark mode.
+  --mat-dialog-supporting-text-color: var(--app-text-primary);
+}

--- a/src/app/shared/simple-dialog/simple-dialog.component.spec.ts
+++ b/src/app/shared/simple-dialog/simple-dialog.component.spec.ts
@@ -1,9 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import {
-  MatDialogModule,
-  MatDialogRef,
-  MAT_DIALOG_DATA,
-} from '@angular/material/dialog';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 
 import { SimpleDialogComponent } from './simple-dialog.component';
 
@@ -12,9 +8,11 @@ describe('SimpleDialogComponent', () => {
   let fixture: ComponentFixture<SimpleDialogComponent>;
 
   beforeEach(async () => {
+    // Deliberately no Material modules here. This dialog is opened programmatically by
+    // root-provided services (the release note popup fires at startup), so it must carry its
+    // own directive scope — see the styling assertions below.
     await TestBed.configureTestingModule({
-      declarations: [SimpleDialogComponent],
-      imports: [MatDialogModule],
+      imports: [SimpleDialogComponent],
       providers: [
         { provide: MatDialogRef, useValue: {} },
         { provide: MAT_DIALOG_DATA, useValue: [] },
@@ -25,10 +23,41 @@ describe('SimpleDialogComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(SimpleDialogComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
   });
 
   it('should create', () => {
+    fixture.detectChanges();
+
     expect(component).toBeTruthy();
+  });
+
+  // Regression: when the component relied on SharedModule for its directive scope, opening it
+  // before any lazy feature module had loaded SharedModule rendered a completely unstyled
+  // dialog (bare <button>, no padding, default font). Unmatched attribute selectors are not an
+  // Angular error, so only the emitted classes prove the directives actually applied.
+  it('applies the Material dialog directives without an owning NgModule', () => {
+    component.title = 'A title';
+    component.body = '<p>Body</p>';
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+
+    expect(el.querySelector('h1')?.classList).toContain('mat-mdc-dialog-title');
+    expect(el.querySelector('div[mat-dialog-content]')?.classList).toContain(
+      'mat-mdc-dialog-content'
+    );
+    expect(el.querySelector('mat-dialog-actions')?.classList).toContain(
+      'mat-mdc-dialog-actions'
+    );
+  });
+
+  it('applies the Material button directives without an owning NgModule', () => {
+    fixture.detectChanges();
+
+    const confirm = (fixture.nativeElement as HTMLElement).querySelector(
+      'button[mat-flat-button]'
+    );
+
+    expect(confirm?.classList).toContain('mat-mdc-button-base');
   });
 });

--- a/src/app/shared/simple-dialog/simple-dialog.component.ts
+++ b/src/app/shared/simple-dialog/simple-dialog.component.ts
@@ -1,12 +1,24 @@
 import { Component, Inject, Input } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MatDialogModule,
+  MatDialogRef,
+  MAT_DIALOG_DATA,
+} from '@angular/material/dialog';
 import { DialogData } from 'src/app/print/print-share-dialog/print-share-dialog.component';
 
+/**
+ * Standalone on purpose. Root-provided services open this dialog directly (the release note
+ * popup fires on login, before any lazy feature module has run), so it cannot depend on
+ * SharedModule for its directive scope: an NgModule that has never been evaluated registers no
+ * scope, Angular silently drops the unmatched `mat-*` attribute directives, and the dialog
+ * renders as bare HTML.
+ */
 @Component({
   selector: 'app-simple-dialog',
   templateUrl: './simple-dialog.component.html',
   styleUrls: ['./simple-dialog.component.scss'],
-  standalone: false,
+  imports: [MatButtonModule, MatDialogModule],
 })
 export class SimpleDialogComponent {
   @Input() public title: string;

--- a/src/app/shared/utils/filament-display.utils.ts
+++ b/src/app/shared/utils/filament-display.utils.ts
@@ -86,7 +86,7 @@ export function convertFilamentValue(
   const radiusCm = diameterMm ? diameterMm / 2 / 10 : 0;
   const crossSectionCm2 = diameterMm ? Math.PI * radiusCm * radiusCm : 0;
 
-  // Normalise to volume in cm³ (= ml)
+  // Normalize to volume in cm³ (= ml)
   let volumeCm3: number;
   if (fromUnit === PrintFilamentSourceMeasurement.Weight) {
     volumeCm3 = value / 1000 / density!; // mg → g → cm³


### PR DESCRIPTION
Cuts the 1.45.0 minor release, covering the analytics work delivered by #76, #77, #78 and #79 (with API PRs #29-#32).

## Release

- `package.json` bumped to 1.45.0
- New section at the top of the release notes page, every bullet linked to its PR (UI PRs by default, API PRs labeled separately where the feature is API-led)
- New `1.45.0` entry in `version-release-note-dialog.service.ts` for the post-login popup

## Also in this branch

Three things surfaced while preparing the release and are fixed here rather than deferred.

### The release notes popup was rendering unstyled

Reproduced on the home page: `<button mat-flat-button>` rendered with `class=""`. No padding, default font, a native button.

`SimpleDialogComponent` was non-standalone and declared in `SharedModule`, but root-provided services open it directly, and the release note popup fires on `userProfile$` at startup. Eager bundle splitting had taken `SharedModule` out of the startup bundle, so at that moment nothing had evaluated the module. An NgModule that never runs registers no directive scope, and Angular silently dropped every `mat-*` attribute directive — unmatched attribute selectors are not an error, so nothing reported it.

The existing spec passed throughout, because it declared the component through a TestBed module that *did* supply the scope. The new specs configure TestBed with no Material modules at all, so they fail if the component ever stops carrying its own imports.

The component has no template usages anywhere (only `dialog.open`), so moving it out of `SharedModule` is self-contained.

Verified in the browser: previously unstyled on `/` and correctly styled on `/docs/analytics` (where `SharedModule` had loaded); now correct on both.

**Same latent pattern, not touched here:** `GcodeViewerModalComponent` and `ParserUnavailableDialogComponent` are also module-declared and opened from a root service. They are safe today only because they are reachable solely from flows where `SharedModule` is already loaded.

### Dialog body text contrast

The Material supporting-text token is `rgba(0, 0, 0, 0.54)` (~4.6:1 on white) — passing but washed out for text that *is* the message. Now bound to `--app-text-primary`, which already tracks the theme: 0.87 black in light, 0.87 white on `#424242` in dark.

### American English spellings

British variants replaced across prose, comments, test names and CSV headers. `Cancelled` is left alone (enum value shared with the API), as is `aria-labelledby`.

⚠️ This renames two user-visible Materials tab CSV headers: `colour` → `color` and `By colour` → `By color`.

## Verification

- 899 unit tests pass (up from 897)
- `npm run lint:brief` clean
- Release notes diff is additions-only (218 insertions, 0 deletions), so the file's pre-existing formatting drift is untouched

## After merge

```bash
git tag v1.45.0
git push origin v1.45.0
```
