### PR TITLE
feat(prints): differentiated, actionable empty states

### DIFF
--- a/cypress/e2e/prints/print-empty-states.cy.ts
+++ b/cypress/e2e/prints/print-empty-states.cy.ts
@@ -1,0 +1,65 @@
+describe('Print List Empty States', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('shows the filtered empty state for a search that matches nothing', () => {
+    const noMatch = 'zzz-no-such-print-' + new Date().getTime();
+
+    cy.visit('/prints');
+    cy.get('[cy-print-row]').should('have.length.greaterThan', 0);
+
+    cy.findByRole('textbox', { name: /search/i }).type(noMatch);
+
+    cy.get('app-print-empty-state').should('be.visible');
+    cy.contains('No prints match your filters').should('be.visible');
+    cy.contains(`a search for "${noMatch}"`).should('be.visible');
+
+    // The first-run copy must not appear when the user is only filtered out.
+    cy.contains('Log your first print').should('not.exist');
+  });
+
+  it('mentions the number of active filters alongside the search term', () => {
+    const noMatch = 'zzz-no-such-print-' + new Date().getTime();
+
+    cy.visit('/prints');
+
+    cy.get('#filter-panel').then(($panel) => {
+      if (!$panel.hasClass('filter-panel--open')) {
+        cy.get('[aria-controls="filter-panel"]').click();
+      }
+    });
+
+    cy.findByRole('combobox', { name: /status/i }).click();
+    cy.findByRole('option', { name: 'Success' }).click();
+
+    cy.findByRole('textbox', { name: /search/i }).type(noMatch);
+
+    cy.contains('1 active filter').should('be.visible');
+    cy.contains(`a search for "${noMatch}"`).should('be.visible');
+  });
+
+  it('clear filters from the empty state restores the full list', () => {
+    const noMatch = 'zzz-no-such-print-' + new Date().getTime();
+
+    cy.visit('/prints');
+    cy.findByRole('textbox', { name: /search/i }).type(noMatch);
+
+    cy.get('[data-cy="empty-state-clear-filters"]')
+      .should('be.visible')
+      .click();
+
+    cy.get('app-print-empty-state').should('not.exist');
+    cy.get('[cy-print-row]').should('have.length.greaterThan', 0);
+    cy.findByRole('textbox', { name: /search/i }).should('have.value', '');
+  });
+
+  it('announces the empty state politely', () => {
+    const noMatch = 'zzz-no-such-print-' + new Date().getTime();
+
+    cy.visit('/prints');
+    cy.findByRole('textbox', { name: /search/i }).type(noMatch);
+
+    cy.get('app-empty-state').should('have.attr', 'role', 'status');
+  });
+});

--- a/src/app/filament/filament-list-container/filament-list-container.component.html
+++ b/src/app/filament/filament-list-container/filament-list-container.component.html
@@ -643,10 +643,40 @@
       </div>
     }
   </div>
-  @if (totalCount === 0) {
-    <div class="no-filament">
-      No Materials found. Add a new Material or try a different search.
-    </div>
+  @if (!isLoading && totalCount === 0) {
+    @if (activeFilterCount > 0 || searchText.trim().length > 0) {
+      <app-empty-state
+        icon="filter_alt_off"
+        heading="No materials match your filters"
+        [message]="emptyStateFilteredMessage"
+      >
+        <button
+          mat-raised-button
+          color="accent"
+          type="button"
+          data-cy="empty-state-clear-filters"
+          (click)="resetFilters()"
+        >
+          <mat-icon>filter_alt_off</mat-icon>Clear filters
+        </button>
+      </app-empty-state>
+    } @else {
+      <app-empty-state
+        icon="category"
+        heading="Add your first material"
+        message="Track the spools and resins you print with so every print records what it used and what it cost. Search the shared catalog to fill in the specs automatically."
+      >
+        <button
+          mat-raised-button
+          color="accent"
+          type="button"
+          routerLink="new"
+          data-cy="empty-state-add-material"
+        >
+          <mat-icon>add</mat-icon>Add material
+        </button>
+      </app-empty-state>
+    }
   }
   <mat-paginator
     [length]="totalCount"

--- a/src/app/filament/filament-list-container/filament-list-container.component.scss
+++ b/src/app/filament/filament-list-container/filament-list-container.component.scss
@@ -174,12 +174,6 @@ table {
     0 1px 4px rgba(0, 0, 0, 0.18);
 }
 
-.no-filament {
-  font-size: 16px;
-  line-height: 28px;
-  margin-left: 20px;
-}
-
 .mat-column-more {
   flex: 0 0 1% !important;
   width: 1% !important;

--- a/src/app/filament/filament-list-container/filament-list-container.component.ts
+++ b/src/app/filament/filament-list-container/filament-list-container.component.ts
@@ -95,11 +95,17 @@ export class FilamentListContainerComponent implements OnInit, OnDestroy {
     private readonly dialog: MatDialog,
     private readonly toastrService: ToastrService
   ) {
-    this.debouncedUpdateFilter = debounce(() => {
-      this.isLoading = true;
+    // Mark the list as loading on the keystroke itself, not when the debounce
+    // finally fires, so the empty state cannot flash stale copy for 400ms.
+    const debouncedFilterUpdate = debounce(() => {
       this.currentPage = 1;
       this.updateFilter();
     }, 400);
+
+    this.debouncedUpdateFilter = () => {
+      this.isLoading = true;
+      debouncedFilterUpdate();
+    };
 
     this.subscriptions.add(
       router.events
@@ -498,6 +504,22 @@ export class FilamentListContainerComponent implements OnInit, OnDestroy {
     else this.filterByEffects.push(effect);
     this.currentPage = 1;
     this.updateFilter();
+  }
+
+  /** Explains which filters and search term are hiding every material. */
+  public get emptyStateFilteredMessage(): string {
+    const parts: string[] = [];
+    const count = this.activeFilterCount;
+
+    if (count > 0) {
+      parts.push(`${count} active filter${count === 1 ? '' : 's'}`);
+    }
+
+    if (this.searchText.trim().length > 0) {
+      parts.push(`a search for "${this.searchText.trim()}"`);
+    }
+
+    return `Nothing matched ${parts.join(' and ')}. Clear them to see your whole material list.`;
   }
 
   public resetFilters(): void {

--- a/src/app/filament/filament.module.ts
+++ b/src/app/filament/filament.module.ts
@@ -10,10 +10,16 @@ import { CopyFilamentDetailResolverService } from './resolvers/copy-filament-det
 import { FilamentDetailResolverService } from './resolvers/filament-detail-resolver.service';
 import { FilamentListResolverService } from './resolvers/filament-list-resolver.service';
 import { MaterialResolverService } from './resolvers/material-resolver.service';
+import { EmptyStateComponent } from '../shared/empty-state/empty-state.component';
 
 @NgModule({
   declarations: [FilamentDetailComponent, FilamentListContainerComponent],
-  imports: [SharedModule, FilamentRoutingModule, AdsenseModule],
+  imports: [
+    SharedModule,
+    FilamentRoutingModule,
+    AdsenseModule,
+    EmptyStateComponent,
+  ],
   providers: [
     FilamentListResolverService,
     FilamentDetailResolverService,

--- a/src/app/print/print-list/print-empty-state/print-empty-state.component.html
+++ b/src/app/print/print-list/print-empty-state/print-empty-state.component.html
@@ -1,0 +1,44 @@
+@if (isFiltered()) {
+  <app-empty-state
+    icon="filter_alt_off"
+    heading="No prints match your filters"
+    [message]="filteredMessage()"
+    [announce]="announce()"
+  >
+    <button
+      mat-raised-button
+      color="accent"
+      type="button"
+      data-cy="empty-state-clear-filters"
+      (click)="onClearFilters()"
+    >
+      <mat-icon>filter_alt_off</mat-icon>Clear filters
+    </button>
+  </app-empty-state>
+} @else {
+  <app-empty-state
+    icon="print_disabled"
+    heading="Log your first print"
+    message="Keep a record of every print you run: printer, material, time and cost. Add one by hand, or import a G-code file from your slicer and we will fill in most of the details for you."
+    [announce]="announce()"
+  >
+    <button
+      mat-raised-button
+      color="accent"
+      type="button"
+      routerLink="/prints/new/edit"
+      data-cy="empty-state-add-print"
+      (click)="onAddPrint()"
+    >
+      <mat-icon>add</mat-icon>Add print
+    </button>
+    <button
+      mat-stroked-button
+      type="button"
+      data-cy="empty-state-import-gcode"
+      (click)="onImportGcode()"
+    >
+      <mat-icon>upload_file</mat-icon>Import G-code
+    </button>
+  </app-empty-state>
+}

--- a/src/app/print/print-list/print-empty-state/print-empty-state.component.html
+++ b/src/app/print/print-list/print-empty-state/print-empty-state.component.html
@@ -15,7 +15,30 @@
       <mat-icon>filter_alt_off</mat-icon>Clear filters
     </button>
   </app-empty-state>
-} @else {
+} @else if (hasPrinters() === false) {
+  <!--
+    A print cannot be saved without a printer (printerId is a required control
+    on the print form), so send the user to add a printer first. Import G-code
+    is deliberately omitted here: it lands on that same unsubmittable form.
+  -->
+  <app-empty-state
+    icon="precision_manufacturing"
+    heading="Add a printer to get started"
+    message="You'll need a printer before you can log a print, since every print records the machine that ran it. Add yours and we will bring you straight back here."
+    [announce]="announce()"
+  >
+    <button
+      mat-raised-button
+      color="accent"
+      type="button"
+      routerLink="/printers/new"
+      data-cy="empty-state-add-printer"
+      (click)="onAddPrinter()"
+    >
+      <mat-icon>add</mat-icon>Add printer
+    </button>
+  </app-empty-state>
+} @else if (hasPrinters()) {
   <app-empty-state
     icon="print_disabled"
     heading="Log your first print"

--- a/src/app/print/print-list/print-empty-state/print-empty-state.component.spec.ts
+++ b/src/app/print/print-list/print-empty-state/print-empty-state.component.spec.ts
@@ -1,0 +1,152 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { provideRouter } from '@angular/router';
+import { LoggingService } from 'src/app/core/services/logging.service';
+
+import { PrintEmptyStateComponent } from './print-empty-state.component';
+
+describe('PrintEmptyStateComponent', () => {
+  let fixture: ComponentFixture<PrintEmptyStateComponent>;
+  let component: PrintEmptyStateComponent;
+  let mockLogger: jasmine.SpyObj<LoggingService>;
+
+  const heading = () =>
+    (
+      fixture.debugElement.query(By.css('.empty-state__heading'))
+        .nativeElement as HTMLElement
+    ).textContent.trim();
+
+  const message = () =>
+    (
+      fixture.debugElement.query(By.css('.empty-state__message'))
+        .nativeElement as HTMLElement
+    ).textContent.trim();
+
+  beforeEach(async () => {
+    mockLogger = jasmine.createSpyObj<LoggingService>('LoggingService', [
+      'logEvent',
+      'logException',
+    ]);
+
+    await TestBed.configureTestingModule({
+      imports: [PrintEmptyStateComponent],
+      providers: [
+        provideRouter([]),
+        { provide: LoggingService, useValue: mockLogger },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PrintEmptyStateComponent);
+    component = fixture.componentInstance;
+  });
+
+  describe('when nothing is filtered', () => {
+    beforeEach(() => {
+      fixture.detectChanges();
+    });
+
+    it('should show the first-run heading', () => {
+      expect(component.isFiltered()).toBeFalse();
+      expect(heading()).toEqual('Log your first print');
+    });
+
+    it('should not tell the user to try a different search', () => {
+      expect(message().toLowerCase()).not.toContain('different search');
+    });
+
+    it('should offer add print and import g-code actions', () => {
+      expect(
+        fixture.debugElement.query(By.css('[data-cy="empty-state-add-print"]'))
+      ).toBeTruthy();
+      expect(
+        fixture.debugElement.query(
+          By.css('[data-cy="empty-state-import-gcode"]')
+        )
+      ).toBeTruthy();
+    });
+
+    it('should emit importGcode and log the event', () => {
+      const emitted = jasmine.createSpy('importGcode');
+      component.importGcode.subscribe(emitted);
+
+      (
+        fixture.debugElement.query(
+          By.css('[data-cy="empty-state-import-gcode"]')
+        ).nativeElement as HTMLButtonElement
+      ).click();
+
+      expect(emitted).toHaveBeenCalled();
+      expect(mockLogger.logEvent).toHaveBeenCalledWith(
+        'PrintEmptyState_ImportGcode'
+      );
+    });
+
+    it('should log when the add print action is used', () => {
+      (
+        fixture.debugElement.query(By.css('[data-cy="empty-state-add-print"]'))
+          .nativeElement as HTMLButtonElement
+      ).click();
+
+      expect(mockLogger.logEvent).toHaveBeenCalledWith(
+        'PrintEmptyState_AddPrint'
+      );
+    });
+  });
+
+  describe('when filters are active', () => {
+    it('should mention a single filter in the singular', () => {
+      fixture.componentRef.setInput('activeFilterCount', 1);
+      fixture.detectChanges();
+
+      expect(heading()).toEqual('No prints match your filters');
+      expect(message()).toContain('1 active filter');
+      expect(message()).not.toContain('filters');
+    });
+
+    it('should mention both the filter count and the search term', () => {
+      fixture.componentRef.setInput('activeFilterCount', 3);
+      fixture.componentRef.setInput('searchText', '  benchy  ');
+      fixture.detectChanges();
+
+      expect(message()).toContain('3 active filters');
+      expect(message()).toContain('a search for "benchy"');
+    });
+
+    it('should treat a search term alone as filtered', () => {
+      fixture.componentRef.setInput('searchText', 'benchy');
+      fixture.detectChanges();
+
+      expect(component.isFiltered()).toBeTrue();
+      expect(message()).toContain('a search for "benchy"');
+      expect(message()).not.toContain('active filter');
+    });
+
+    it('should treat whitespace-only search text as no search', () => {
+      fixture.componentRef.setInput('searchText', '   ');
+      fixture.detectChanges();
+
+      expect(component.hasSearch()).toBeFalse();
+      expect(heading()).toEqual('Log your first print');
+    });
+
+    it('should emit clearFilters and log the event', () => {
+      fixture.componentRef.setInput('activeFilterCount', 2);
+      fixture.detectChanges();
+
+      const emitted = jasmine.createSpy('clearFilters');
+      component.clearFilters.subscribe(emitted);
+
+      (
+        fixture.debugElement.query(
+          By.css('[data-cy="empty-state-clear-filters"]')
+        ).nativeElement as HTMLButtonElement
+      ).click();
+
+      expect(emitted).toHaveBeenCalled();
+      expect(mockLogger.logEvent).toHaveBeenCalledWith(
+        'PrintEmptyState_ClearFilters',
+        { activeFilterCount: 2, hasSearch: false }
+      );
+    });
+  });
+});

--- a/src/app/print/print-list/print-empty-state/print-empty-state.component.spec.ts
+++ b/src/app/print/print-list/print-empty-state/print-empty-state.component.spec.ts
@@ -40,8 +40,9 @@ describe('PrintEmptyStateComponent', () => {
     component = fixture.componentInstance;
   });
 
-  describe('when nothing is filtered', () => {
+  describe('when nothing is filtered and the user has printers', () => {
     beforeEach(() => {
+      fixture.componentRef.setInput('hasPrinters', true);
       fixture.detectChanges();
     });
 
@@ -93,6 +94,74 @@ describe('PrintEmptyStateComponent', () => {
     });
   });
 
+  describe('when the user has no printers', () => {
+    beforeEach(() => {
+      fixture.componentRef.setInput('hasPrinters', false);
+      fixture.detectChanges();
+    });
+
+    it('should tell the user to add a printer first and explain why', () => {
+      expect(heading()).toEqual('Add a printer to get started');
+      expect(message()).toContain(
+        "You'll need a printer before you can log a print"
+      );
+    });
+
+    it('should offer add printer as the only action', () => {
+      expect(
+        fixture.debugElement.query(
+          By.css('[data-cy="empty-state-add-printer"]')
+        )
+      ).toBeTruthy();
+      expect(
+        fixture.debugElement.query(By.css('[data-cy="empty-state-add-print"]'))
+      ).toBeFalsy();
+    });
+
+    it('should not offer g-code import, which needs a printer to save', () => {
+      expect(
+        fixture.debugElement.query(
+          By.css('[data-cy="empty-state-import-gcode"]')
+        )
+      ).toBeFalsy();
+    });
+
+    it('should log when the add printer action is used', () => {
+      (
+        fixture.debugElement.query(
+          By.css('[data-cy="empty-state-add-printer"]')
+        ).nativeElement as HTMLButtonElement
+      ).click();
+
+      expect(mockLogger.logEvent).toHaveBeenCalledWith(
+        'PrintEmptyState_AddPrinter'
+      );
+    });
+
+    it('should still show the filtered state when filters are also active', () => {
+      fixture.componentRef.setInput('activeFilterCount', 1);
+      fixture.detectChanges();
+
+      expect(heading()).toEqual('No prints match your filters');
+    });
+  });
+
+  describe('when the printer lookup has not resolved', () => {
+    it('should render nothing rather than guess the first step', () => {
+      fixture.detectChanges();
+
+      expect(component.hasPrinters()).toBeNull();
+      expect(fixture.debugElement.query(By.css('app-empty-state'))).toBeNull();
+    });
+
+    it('should still render the filtered state, which needs no printer info', () => {
+      fixture.componentRef.setInput('searchText', 'benchy');
+      fixture.detectChanges();
+
+      expect(heading()).toEqual('No prints match your filters');
+    });
+  });
+
   describe('when filters are active', () => {
     it('should mention a single filter in the singular', () => {
       fixture.componentRef.setInput('activeFilterCount', 1);
@@ -122,6 +191,7 @@ describe('PrintEmptyStateComponent', () => {
     });
 
     it('should treat whitespace-only search text as no search', () => {
+      fixture.componentRef.setInput('hasPrinters', true);
       fixture.componentRef.setInput('searchText', '   ');
       fixture.detectChanges();
 

--- a/src/app/print/print-list/print-empty-state/print-empty-state.component.ts
+++ b/src/app/print/print-list/print-empty-state/print-empty-state.component.ts
@@ -1,0 +1,83 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  output,
+} from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { RouterLink } from '@angular/router';
+import { LoggingService } from 'src/app/core/services/logging.service';
+import { EmptyStateComponent } from 'src/app/shared/empty-state/empty-state.component';
+
+/**
+ * Empty state for the print list. It tells two very different stories:
+ *
+ * - filters and/or a search term are active, so the user needs a way out; or
+ * - the account genuinely has no prints yet, so the user needs a way in.
+ */
+@Component({
+  selector: 'app-print-empty-state',
+  imports: [EmptyStateComponent, MatButtonModule, MatIconModule, RouterLink],
+  templateUrl: './print-empty-state.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class PrintEmptyStateComponent {
+  /** Number of filters (status, printer, material) currently applied. */
+  readonly activeFilterCount = input(0);
+
+  /** Current free-text search term, if any. */
+  readonly searchText = input('');
+
+  /** Whether the host already provides a polite live region. */
+  readonly announce = input(true);
+
+  /** Requests that every filter and the search term be cleared. */
+  readonly clearFilters = output<void>();
+
+  /** Requests that the hidden G-code file picker be opened. */
+  readonly importGcode = output<void>();
+
+  private readonly loggingService = inject(LoggingService);
+
+  readonly hasSearch = computed(() => this.searchText().trim().length > 0);
+
+  /** True when something the user chose is hiding results. */
+  readonly isFiltered = computed(
+    () => this.activeFilterCount() > 0 || this.hasSearch()
+  );
+
+  readonly filteredMessage = computed(() => {
+    const parts: string[] = [];
+    const count = this.activeFilterCount();
+
+    if (count > 0) {
+      parts.push(`${count} active filter${count === 1 ? '' : 's'}`);
+    }
+
+    if (this.hasSearch()) {
+      parts.push(`a search for "${this.searchText().trim()}"`);
+    }
+
+    return `Nothing matched ${parts.join(' and ')}. Clear them to see your whole print log.`;
+  });
+
+  onClearFilters(): void {
+    this.loggingService.logEvent('PrintEmptyState_ClearFilters', {
+      activeFilterCount: this.activeFilterCount(),
+      hasSearch: this.hasSearch(),
+    });
+    this.clearFilters.emit();
+  }
+
+  onAddPrint(): void {
+    this.loggingService.logEvent('PrintEmptyState_AddPrint');
+  }
+
+  onImportGcode(): void {
+    this.loggingService.logEvent('PrintEmptyState_ImportGcode');
+    this.importGcode.emit();
+  }
+}

--- a/src/app/print/print-list/print-empty-state/print-empty-state.component.ts
+++ b/src/app/print/print-list/print-empty-state/print-empty-state.component.ts
@@ -31,6 +31,13 @@ export class PrintEmptyStateComponent {
   /** Current free-text search term, if any. */
   readonly searchText = input('');
 
+  /**
+   * Whether the user owns at least one printer. `null` means the lookup has
+   * not resolved yet, in which case the first-run branch renders nothing
+   * rather than briefly advising the wrong first step.
+   */
+  readonly hasPrinters = input<boolean | null>(null);
+
   /** Whether the host already provides a polite live region. */
   readonly announce = input(true);
 
@@ -74,6 +81,10 @@ export class PrintEmptyStateComponent {
 
   onAddPrint(): void {
     this.loggingService.logEvent('PrintEmptyState_AddPrint');
+  }
+
+  onAddPrinter(): void {
+    this.loggingService.logEvent('PrintEmptyState_AddPrinter');
   }
 
   onImportGcode(): void {

--- a/src/app/print/print-list/print-grouped-view/print-grouped-view.component.html
+++ b/src/app/print/print-list/print-grouped-view/print-grouped-view.component.html
@@ -3,9 +3,7 @@
     <mat-spinner diameter="40" />
   </div>
 } @else if (!feed()?.items?.length) {
-  <p class="empty-state">
-    No prints found. Try adjusting your search or filters.
-  </p>
+  <ng-content select="[printEmptyState]" />
 } @else {
   <!-- Mobile Card View -->
   <div class="grouped-mobile-card-view" fxHide.gt-sm>
@@ -503,11 +501,6 @@
           by current filters
         </p>
       }
-    }
-    @if (!feed()?.items?.length) {
-      <p class="empty-state">
-        No prints found. Try adjusting your search or filters.
-      </p>
     }
   </div>
 

--- a/src/app/print/print-list/print-grouped-view/print-grouped-view.component.scss
+++ b/src/app/print/print-list/print-grouped-view/print-grouped-view.component.scss
@@ -4,12 +4,6 @@
   padding: 32px;
 }
 
-.empty-state {
-  text-align: center;
-  color: var(--mat-sys-on-surface-variant);
-  padding: 32px;
-}
-
 .project-prints {
   display: flex;
   flex-direction: column;

--- a/src/app/print/print-list/print-list.component.html
+++ b/src/app/print/print-list/print-list.component.html
@@ -176,7 +176,15 @@
       [defaultElectricityKwhRateSetting]="defaultElectricityKwhRateSetting"
       [defaultElectricityWattageSetting]="defaultElectricityWattageSetting"
       [preferredUnit]="preferredFilamentUnit()"
-    />
+    >
+      <app-print-empty-state
+        printEmptyState
+        [activeFilterCount]="activeFilterCount()"
+        [searchText]="searchText"
+        (clearFilters)="resetFilters()"
+        (importGcode)="gcodeInput.click()"
+      />
+    </app-print-grouped-view>
   }
 
   <!-- List view: mobile cards + desktop table + paginator -->
@@ -190,11 +198,6 @@
           (statusChanged)="changeStatus($event.id, $event.status)"
           [preferredUnit]="preferredFilamentUnit()"
         />
-      }
-      @if (totalCount === 0) {
-        <div class="no-prints">
-          No prints found. Add a new print or try a different search.
-        </div>
       }
     </div>
 
@@ -592,10 +595,14 @@
         [attr.cy-print-row]="row.id"
       ></tr>
     </table>
-    @if (totalCount === 0) {
-      <div class="no-prints">
-        No prints found. Add a new print or try a different search.
-      </div>
+    <!-- Shared by both the mobile card view and the desktop table above. -->
+    @if (!isLoading && totalCount === 0) {
+      <app-print-empty-state
+        [activeFilterCount]="activeFilterCount()"
+        [searchText]="searchText"
+        (clearFilters)="resetFilters()"
+        (importGcode)="gcodeInput.click()"
+      />
     }
     <mat-paginator
       [pageIndex]="currentPage - 1"

--- a/src/app/print/print-list/print-list.component.html
+++ b/src/app/print/print-list/print-list.component.html
@@ -181,6 +181,7 @@
         printEmptyState
         [activeFilterCount]="activeFilterCount()"
         [searchText]="searchText"
+        [hasPrinters]="hasPrinters()"
         (clearFilters)="resetFilters()"
         (importGcode)="gcodeInput.click()"
       />
@@ -600,6 +601,7 @@
       <app-print-empty-state
         [activeFilterCount]="activeFilterCount()"
         [searchText]="searchText"
+        [hasPrinters]="hasPrinters()"
         (clearFilters)="resetFilters()"
         (importGcode)="gcodeInput.click()"
       />

--- a/src/app/print/print-list/print-list.component.scss
+++ b/src/app/print/print-list/print-list.component.scss
@@ -161,12 +161,6 @@ table {
   overflow: hidden;
 }
 
-.no-prints {
-  font-size: 16px;
-  line-height: 28px;
-  margin-left: 20px;
-}
-
 .mat-column-more {
   flex: 0 0 1% !important;
   width: 1% !important;

--- a/src/app/print/print-list/print-list.component.spec.ts
+++ b/src/app/print/print-list/print-list.component.spec.ts
@@ -7,7 +7,7 @@ import { By, Title } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ToastrService } from 'ngx-toastr';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { LoggingService } from 'src/app/core/services/logging.service';
 import {
   PrintService,
@@ -285,8 +285,8 @@ describe('PrintListComponent', () => {
     expect(table.length).toEqual(mockPrintPagedResult.items.length);
   });
 
-  it('should display a "No Active Printers" toast if the printerRedirectPromptService should show prompt', () => {
-    // Arrange
+  /** Puts the component in the "user owns no printers" state. */
+  const withNoPrinters = () => {
     const mockPrinterRedirectPromptService = TestBed.inject(
       PrinterRedirectPromptService
     ) as jasmine.SpyObj<PrinterRedirectPromptService>;
@@ -309,6 +309,27 @@ describe('PrintListComponent', () => {
       portal: {} as any,
     });
 
+    return mockToastrService;
+  };
+
+  /** Overrides the resolver payload so the list reports existing prints. */
+  const withExistingPrints = (totalCount: number) => {
+    const mockActivatedRoute = TestBed.inject(ActivatedRoute);
+    mockActivatedRoute.data = of({
+      printList: {
+        items: [],
+        paging: { currentPage: 1, pageSize: 10, totalCount, totalPages: 1 },
+      },
+      printers: [],
+      filaments: [],
+    });
+  };
+
+  it('should display a "No Active Printers" toast when the user has prints but no printer', () => {
+    // Arrange - no empty state renders here, so the toast is the only guidance
+    const mockToastrService = withNoPrinters();
+    withExistingPrints(3);
+
     // Act
     fixture.detectChanges();
 
@@ -318,6 +339,94 @@ describe('PrintListComponent', () => {
       'No Active Printers',
       jasmine.any(Object)
     );
+    expect(component.printerRedirectToast).not.toBeNull();
+  });
+
+  it('should suppress the toast when the empty state already says to add a printer', () => {
+    // Arrange - zero prints and zero printers
+    const mockToastrService = withNoPrinters();
+
+    // Act
+    fixture.detectChanges();
+
+    // Assert
+    expect(component.printerRedirectToast).toBeNull();
+    expect(mockToastrService.remove).not.toHaveBeenCalledWith(
+      jasmine.anything()
+    );
+
+    const emptyState = fixture.debugElement.query(
+      By.directive(PrintEmptyStateComponent)
+    );
+    const heading = emptyState.query(By.css('.empty-state__heading'))
+      .nativeElement as HTMLElement;
+    expect(heading.textContent.trim()).toEqual('Add a printer to get started');
+  });
+
+  it('should keep the toast when a filter empties the list for a user with no printer', async () => {
+    // Arrange - the empty state shows filter guidance, not printer guidance
+    withNoPrinters();
+    fixture.detectChanges();
+    expect(component.printerRedirectToast).toBeNull();
+
+    // Act - assert on component state only; re-running change detection here
+    // would trip NG0100 because searchText is bound with two-way ngModel.
+    component.searchText = 'benchy';
+    await component.updateFilter();
+
+    // Assert
+    expect(component.printerRedirectToast).not.toBeNull();
+  });
+
+  it('should fall back to the add print state when the printer lookup fails', () => {
+    // Arrange
+    const mockPrinterRedirectPromptService = TestBed.inject(
+      PrinterRedirectPromptService
+    ) as jasmine.SpyObj<PrinterRedirectPromptService>;
+    mockPrinterRedirectPromptService.shouldShowAddPrinterPrompt.and.returnValue(
+      throwError(() => new Error('printer lookup failed'))
+    );
+
+    // Act
+    fixture.detectChanges();
+
+    // Assert - a failed lookup must not leave the page blank
+    expect(component.hasPrinters()).toBeTrue();
+    expect(
+      fixture.debugElement.query(By.css('[data-cy="empty-state-add-print"]'))
+    ).toBeTruthy();
+  });
+
+  it('should suppress the toast when the search text is only whitespace', async () => {
+    // Arrange - the empty state still shows printer guidance for blank search
+    withNoPrinters();
+    fixture.detectChanges();
+
+    // Act
+    component.searchText = '   ';
+    await component.updateFilter();
+
+    // Assert
+    expect(component.printerRedirectToast).toBeNull();
+  });
+
+  it('should show the add printer empty state instead of the add print CTA', () => {
+    // Arrange
+    withNoPrinters();
+
+    // Act
+    fixture.detectChanges();
+
+    // Assert
+    expect(
+      fixture.debugElement.query(By.css('[data-cy="empty-state-add-printer"]'))
+    ).toBeTruthy();
+    expect(
+      fixture.debugElement.query(By.css('[data-cy="empty-state-add-print"]'))
+    ).toBeFalsy();
+    expect(
+      fixture.debugElement.query(By.css('[data-cy="empty-state-import-gcode"]'))
+    ).toBeFalsy();
   });
 
   it('should keep the filter panel open when resetFilters is called', () => {
@@ -350,6 +459,9 @@ describe('PrintListComponent', () => {
     mockToastrService.info.and.returnValue({
       onTap: of(true),
     } as any);
+
+    // The toast only renders when no empty state gives the same guidance.
+    withExistingPrints(3);
 
     // Act
     fixture.detectChanges();

--- a/src/app/print/print-list/print-list.component.spec.ts
+++ b/src/app/print/print-list/print-list.component.spec.ts
@@ -21,6 +21,7 @@ import { LocaleDatePipe } from 'src/app/shared/pipes/locale-date.pipe';
 import { PrinterRedirectPromptService } from '../services/printer-redirect-prompt.service';
 
 import { PrintListComponent } from './print-list.component';
+import { PrintEmptyStateComponent } from './print-empty-state/print-empty-state.component';
 
 describe('PrintListComponent', () => {
   let component: PrintListComponent;
@@ -92,6 +93,7 @@ describe('PrintListComponent', () => {
         MatDialogModule,
         MatMenuModule,
         MatTableModule,
+        PrintEmptyStateComponent,
       ],
       providers: [
         { provide: LoggingService, useValue: mockLogger },
@@ -119,33 +121,94 @@ describe('PrintListComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display "No prints found. Add a new print or try a different search." when there are no prints in the list', () => {
-    // Arrange
-    const mockActivatedRoute = TestBed.inject(ActivatedRoute);
-    const mockPrintPagedResult: PagedList<PrintSummary> = {
-      items: [],
-      paging: {
-        currentPage: 1,
-        pageSize: 10,
-        totalCount: 0,
-        totalPages: 1,
-      },
-    };
-
-    (mockActivatedRoute.data = of({
-      printList: mockPrintPagedResult,
-      printers: [],
-      filaments: [],
-    })),
-      // Act
-      fixture.detectChanges();
+  it('should show the first-run empty state when there are no prints and no filters', () => {
+    // Act
+    fixture.detectChanges();
 
     // Assert
-    const message = fixture.debugElement.query(By.css('.no-prints'))
-      .nativeElement as HTMLDivElement;
-    expect(message.innerText).toEqual(
-      'No prints found. Add a new print or try a different search.'
+    const emptyState = fixture.debugElement.query(
+      By.directive(PrintEmptyStateComponent)
     );
+    expect(emptyState).toBeTruthy();
+
+    const heading = emptyState.query(By.css('.empty-state__heading'))
+      .nativeElement as HTMLElement;
+    expect(heading.textContent.trim()).toEqual('Log your first print');
+
+    expect(
+      emptyState.query(By.css('[data-cy="empty-state-add-print"]'))
+    ).toBeTruthy();
+    expect(
+      emptyState.query(By.css('[data-cy="empty-state-import-gcode"]'))
+    ).toBeTruthy();
+    expect(
+      emptyState.query(By.css('[data-cy="empty-state-clear-filters"]'))
+    ).toBeFalsy();
+  });
+
+  it('should show the filtered empty state and mention the active filter count', () => {
+    // Arrange - ngOnInit resets the status filter, so apply filters after it runs
+    fixture.detectChanges();
+    component.filterByStatus.set(PrintStatus.Success);
+    component.filterByPrinterIds.set([7]);
+    component.searchText = 'benchy';
+
+    // Act
+    fixture.detectChanges();
+
+    // Assert
+    const emptyState = fixture.debugElement.query(
+      By.directive(PrintEmptyStateComponent)
+    );
+    const heading = emptyState.query(By.css('.empty-state__heading'))
+      .nativeElement as HTMLElement;
+    const message = emptyState.query(By.css('.empty-state__message'))
+      .nativeElement as HTMLElement;
+
+    expect(heading.textContent.trim()).toEqual('No prints match your filters');
+    expect(message.textContent).toContain('2 active filters');
+    expect(message.textContent).toContain('a search for "benchy"');
+    expect(
+      emptyState.query(By.css('[data-cy="empty-state-add-print"]'))
+    ).toBeFalsy();
+  });
+
+  it('should clear every filter when the empty state clear filters button is used', () => {
+    // Arrange - ngOnInit resets the status filter, so apply filters after it runs
+    fixture.detectChanges();
+    component.filterByStatus.set(PrintStatus.Success);
+    component.searchText = 'benchy';
+    fixture.detectChanges();
+
+    const clearButton = fixture.debugElement.query(
+      By.css('[data-cy="empty-state-clear-filters"]')
+    ).nativeElement as HTMLButtonElement;
+
+    // Act
+    clearButton.click();
+    fixture.detectChanges();
+
+    // Assert
+    expect(component.searchText).toEqual('');
+    expect(component.activeFilterCount()).toEqual(0);
+  });
+
+  it('should open the hidden g-code picker from the empty state import button', () => {
+    // Arrange
+    fixture.detectChanges();
+
+    const fileInput = fixture.debugElement.query(By.css('input[type="file"]'))
+      .nativeElement as HTMLInputElement;
+    const clickSpy = spyOn(fileInput, 'click');
+
+    // Act
+    const importButton = fixture.debugElement.query(
+      By.css('[data-cy="empty-state-import-gcode"]')
+    ).nativeElement as HTMLButtonElement;
+    importButton.click();
+
+    // Assert
+    expect(clickSpy).toHaveBeenCalled();
   });
 
   it('should display a page worth of prints when passed in from the route resolver', () => {

--- a/src/app/print/print-list/print-list.component.ts
+++ b/src/app/print/print-list/print-list.component.ts
@@ -206,7 +206,19 @@ export class PrintListComponent implements OnInit, OnDestroy {
   public sortDirection = SortDirection.Desc;
 
   public printerRedirectToast: ActiveToast<any> | null = null;
-  public printerRedirectSubscription: Subscription;
+  public printerRedirectSubscription: Subscription | null = null;
+
+  /**
+   * Whether the user owns at least one printer. `null` until the lookup that
+   * already drives the "No Active Printers" prompt resolves.
+   */
+  public readonly hasPrinters = signal<boolean | null>(null);
+
+  /**
+   * The toast decision depends on the print count, so it must wait for the
+   * first list load rather than assume the printer lookup resolves second.
+   */
+  private printListLoaded = false;
 
   mobileQuery: MediaQueryList;
 
@@ -363,26 +375,21 @@ export class PrintListComponent implements OnInit, OnDestroy {
     /**
      * Show the Add Printer prompt if needed.
      */
-    this.printerRedirectPromptService
-      .shouldShowAddPrinterPrompt()
-      .subscribe((shouldShowPrompt) => {
-        if (shouldShowPrompt) {
-          this.printerRedirectToast = this.toastrService.info(
-            'Click here to add a new 3D Printer before logging prints.',
-            'No Active Printers',
-            {
-              disableTimeOut: true,
-            }
-          );
-
-          this.printerRedirectSubscription =
-            this.printerRedirectToast.onTap.subscribe(() => {
-              this.loggingService.logEvent('NoActivePrinterPromptClicked');
-              this.router.navigate(['printers', 'new']);
-              this.printerRedirectSubscription?.unsubscribe?.();
-            });
-        }
-      });
+    this.subscriptions.add(
+      this.printerRedirectPromptService.shouldShowAddPrinterPrompt().subscribe({
+        next: (shouldShowPrompt) => {
+          this.hasPrinters.set(!shouldShowPrompt);
+          this.syncAddPrinterPrompt();
+        },
+        error: (error) => {
+          // A failed lookup must not leave the first-run user staring at a
+          // blank page, so assume they have printers and offer Add print.
+          this.loggingService.logException(error);
+          this.hasPrinters.set(true);
+          this.syncAddPrinterPrompt();
+        },
+      })
+    );
 
     this.mobileQuery = this.media.matchMedia('(max-width: 800px)');
 
@@ -454,6 +461,83 @@ export class PrintListComponent implements OnInit, OnDestroy {
     this.currentPage = response.paging.currentPage;
     this.pageSize = response.paging.pageSize;
     this.totalCount = response.paging.totalCount;
+
+    this.printListLoaded = true;
+    this.syncAddPrinterPrompt();
+  }
+
+  /**
+   * True when the empty state itself is telling the user to add a printer.
+   * Only in that case is the toast redundant.
+   */
+  private emptyStateShowsPrinterGuidance(): boolean {
+    return (
+      this.hasPrinters() === false &&
+      this.totalCount === 0 &&
+      this.activeFilterCount() === 0 &&
+      // Trimmed to agree with PrintEmptyStateComponent.hasSearch(), otherwise
+      // whitespace-only search text shows the empty state and the toast.
+      !this.searchText?.trim()
+    );
+  }
+
+  /**
+   * Shows the "No Active Printers" toast unless the empty state is already
+   * giving the same instruction. A user who has prints but no active printer
+   * renders no empty state at all, so the toast must stay.
+   */
+  private syncAddPrinterPrompt(): void {
+    // Wait until both the print count and the printer count are known, so the
+    // toast cannot open and immediately flash away on the slower answer.
+    if (!this.printListLoaded) {
+      return;
+    }
+
+    if (this.hasPrinters() !== false) {
+      this.dismissAddPrinterToast();
+      return;
+    }
+
+    if (this.emptyStateShowsPrinterGuidance()) {
+      this.dismissAddPrinterToast();
+      return;
+    }
+
+    this.showAddPrinterToast();
+  }
+
+  private showAddPrinterToast(): void {
+    if (this.printerRedirectToast) {
+      return;
+    }
+
+    this.printerRedirectToast = this.toastrService.info(
+      'Click here to add a new 3D Printer before logging prints.',
+      'No Active Printers',
+      {
+        disableTimeOut: true,
+      }
+    );
+
+    this.printerRedirectSubscription =
+      this.printerRedirectToast.onTap.subscribe(() => {
+        this.loggingService.logEvent('NoActivePrinterPromptClicked');
+        this.router.navigate(['printers', 'new']);
+        this.printerRedirectSubscription?.unsubscribe?.();
+        this.printerRedirectSubscription = null;
+      });
+  }
+
+  private dismissAddPrinterToast(): void {
+    if (!this.printerRedirectToast) {
+      return;
+    }
+
+    this.toastrService.remove(this.printerRedirectToast.toastId);
+    this.printerRedirectToast = null;
+
+    this.printerRedirectSubscription?.unsubscribe?.();
+    this.printerRedirectSubscription = null;
   }
 
   public sortData(sort: Sort) {

--- a/src/app/print/print-list/print-list.component.ts
+++ b/src/app/print/print-list/print-list.component.ts
@@ -264,11 +264,17 @@ export class PrintListComponent implements OnInit, OnDestroy {
     private readonly gcodeParserService: GcodeFileParserService,
     private readonly newPrintStoreService: NewPrintStoreService
   ) {
-    this.debouncedUpdateFilter = debounce(() => {
-      this.isLoading = true;
+    // Mark the list as loading on the keystroke itself, not when the debounce
+    // finally fires, so the empty state cannot flash stale copy for 400ms.
+    const debouncedFilterUpdate = debounce(() => {
       this.currentPage = 1;
       this.updateFilter();
     }, 400);
+
+    this.debouncedUpdateFilter = () => {
+      this.isLoading = true;
+      debouncedFilterUpdate();
+    };
 
     this.subscriptions.add(
       router.events

--- a/src/app/print/print.module.ts
+++ b/src/app/print/print.module.ts
@@ -28,6 +28,7 @@ import { ProjectChipComponent } from '../shared/project-chip/project-chip.compon
 import { ProjectSelectorComponent } from '../shared/project-selector/project-selector.component';
 import { PrintGroupedViewComponent } from './print-list/print-grouped-view/print-grouped-view.component';
 import { PrintCardComponent } from './print-card/print-card.component';
+import { PrintEmptyStateComponent } from './print-list/print-empty-state/print-empty-state.component';
 
 @NgModule({
   declarations: [
@@ -50,6 +51,7 @@ import { PrintCardComponent } from './print-card/print-card.component';
     PrintGroupedViewComponent,
     PrintCardComponent,
     PrintCommentsComponent,
+    PrintEmptyStateComponent,
   ],
   providers: [
     PrintDetailResolverService,

--- a/src/app/printer/printer-list/printer-list.component.html
+++ b/src/app/printer/printer-list/printer-list.component.html
@@ -170,6 +170,41 @@
       data-cy-printer-row
     ></tr>
   </table>
+  @if (!isLoading && totalCount === 0) {
+    @if (hasActiveSearch) {
+      <app-empty-state
+        icon="filter_alt_off"
+        heading="No printers match your search"
+        [message]="emptyStateFilteredMessage"
+      >
+        <button
+          mat-raised-button
+          color="accent"
+          type="button"
+          data-cy="empty-state-clear-search"
+          (click)="clearSearch()"
+        >
+          <mat-icon>filter_alt_off</mat-icon>Clear search
+        </button>
+      </app-empty-state>
+    } @else {
+      <app-empty-state
+        icon="print"
+        heading="Add your first printer"
+        message="Register the machines you print on so every print records which printer ran it, and so you can track maintenance and running costs."
+      >
+        <button
+          mat-raised-button
+          color="accent"
+          type="button"
+          routerLink="new"
+          data-cy="empty-state-add-printer"
+        >
+          <mat-icon>add</mat-icon>Add printer
+        </button>
+      </app-empty-state>
+    }
+  }
   <mat-paginator
     [length]="totalCount"
     [pageSize]="pageSize"

--- a/src/app/printer/printer-list/printer-list.component.ts
+++ b/src/app/printer/printer-list/printer-list.component.ts
@@ -44,6 +44,11 @@ export class PrinterListComponent implements OnInit {
 
   public debouncedUpdateFilter;
 
+  public isLoading = false;
+
+  /** Guards against an older search response overwriting a newer one. */
+  private latestRequestId = 0;
+
   constructor(
     private activatedRoute: ActivatedRoute,
     private printerService: PrinterService,
@@ -51,7 +56,14 @@ export class PrinterListComponent implements OnInit {
     private readonly toastrService: ToastrService,
     public dialog: MatDialog
   ) {
-    this.debouncedUpdateFilter = debounce(() => this.updateFilter(), 400);
+    // Mark the list as loading on the keystroke itself, not when the debounce
+    // finally fires, so the empty state cannot flash stale copy for 400ms.
+    const debouncedFilterUpdate = debounce(() => this.updateFilter(), 400);
+
+    this.debouncedUpdateFilter = () => {
+      this.isLoading = true;
+      debouncedFilterUpdate();
+    };
   }
 
   ngOnInit() {
@@ -69,6 +81,9 @@ export class PrinterListComponent implements OnInit {
 
     localStorage.setItem('printer_list_page_size', newPageSize.toString(10));
 
+    this.isLoading = true;
+    const requestId = ++this.latestRequestId;
+
     this.printerService
       .getCurrentUserPrinterSummaries(
         newPageNumber,
@@ -77,12 +92,19 @@ export class PrinterListComponent implements OnInit {
         this.includeInactive
       )
       .subscribe((response) => {
+        if (requestId !== this.latestRequestId) {
+          return;
+        }
+
         this.handlePagedList(response);
       });
   }
 
   public async updateFilter() {
     localStorage.setItem('printer_list_page_size', this.pageSize.toString(10));
+
+    this.isLoading = true;
+    const requestId = ++this.latestRequestId;
 
     const response = await lastValueFrom(
       this.printerService.getCurrentUserPrinterSummaries(
@@ -93,7 +115,27 @@ export class PrinterListComponent implements OnInit {
       )
     );
 
+    // A newer search started while this one was in flight; its result wins.
+    if (requestId !== this.latestRequestId) {
+      return;
+    }
+
     this.handlePagedList(response);
+  }
+
+  /** True when a search term is hiding printers the user does have. */
+  public get hasActiveSearch(): boolean {
+    return this.searchText.trim().length > 0;
+  }
+
+  public get emptyStateFilteredMessage(): string {
+    return `Nothing matched a search for "${this.searchText.trim()}". Clear it to see all of your printers.`;
+  }
+
+  public clearSearch() {
+    this.searchText = '';
+    this.currentPage = 1;
+    return this.updateFilter();
   }
 
   public unloadAllFilament(printer: PrinterSummarySimple) {
@@ -108,6 +150,7 @@ export class PrinterListComponent implements OnInit {
   }
 
   private handlePagedList(response: PagedList<PrinterSummarySimple>) {
+    this.isLoading = false;
     this.printers = response.items;
 
     this.currentPage = response.paging.currentPage;

--- a/src/app/printer/printer.module.ts
+++ b/src/app/printer/printer.module.ts
@@ -5,6 +5,7 @@ import { AdsenseModule } from 'ng2-adsense';
 import { SharedModule } from '../shared/shared.module';
 import { PrinterDetailComponent } from './printer-detail/printer-detail.component';
 import { PrinterListComponent } from './printer-list/printer-list.component';
+import { EmptyStateComponent } from '../shared/empty-state/empty-state.component';
 import { PrinterRoutingModule } from './printer-routing.module';
 import { PrinterDetailResolverService } from './resolvers/printer-detail-resolver.service';
 import { PrinterListResolverService } from './resolvers/printer-list-resolver.service';
@@ -17,6 +18,7 @@ import { PrinterListResolverService } from './resolvers/printer-list-resolver.se
     FormsModule,
     ReactiveFormsModule,
     AdsenseModule,
+    EmptyStateComponent,
   ],
   providers: [PrinterListResolverService, PrinterDetailResolverService],
 })

--- a/src/app/shared/empty-state/empty-state.component.html
+++ b/src/app/shared/empty-state/empty-state.component.html
@@ -1,0 +1,10 @@
+<div class="empty-state__inner">
+  <mat-icon class="empty-state__icon" aria-hidden="true">{{ icon() }}</mat-icon>
+  <h2 class="empty-state__heading">{{ heading() }}</h2>
+  @if (message()) {
+    <p class="empty-state__message">{{ message() }}</p>
+  }
+  <div class="empty-state__actions">
+    <ng-content />
+  </div>
+</div>

--- a/src/app/shared/empty-state/empty-state.component.scss
+++ b/src/app/shared/empty-state/empty-state.component.scss
@@ -1,0 +1,57 @@
+:host {
+  display: block;
+  width: 100%;
+}
+
+.empty-state__inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 8px;
+  max-width: 520px;
+  margin: 0 auto;
+  padding: 48px 24px;
+}
+
+.empty-state__icon {
+  --mat-icon-color: var(--mat-sys-on-surface-variant);
+
+  width: 48px;
+  height: 48px;
+  font-size: 48px;
+  line-height: 48px;
+  color: var(--mat-sys-on-surface-variant);
+  opacity: 0.7;
+}
+
+.empty-state__heading {
+  margin: 0;
+  font-size: 20px;
+  line-height: 28px;
+  font-weight: 500;
+  color: var(--mat-sys-on-surface);
+}
+
+.empty-state__message {
+  margin: 0;
+  font-size: 14px;
+  line-height: 22px;
+  color: var(--mat-sys-on-surface-variant);
+  overflow-wrap: anywhere;
+}
+
+.empty-state__actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+
+  &:empty {
+    display: none;
+  }
+}
+
+.empty-state__actions:not(:empty) {
+  margin-top: 8px;
+}

--- a/src/app/shared/empty-state/empty-state.component.spec.ts
+++ b/src/app/shared/empty-state/empty-state.component.spec.ts
@@ -1,0 +1,101 @@
+import { Component } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+
+import { EmptyStateComponent } from './empty-state.component';
+
+@Component({
+  imports: [EmptyStateComponent],
+  template: `<app-empty-state
+    [icon]="icon"
+    [heading]="heading"
+    [message]="message"
+    [announce]="announce"
+  >
+    <button type="button" data-cy="test-action">Do the thing</button>
+  </app-empty-state>`,
+})
+class HostComponent {
+  icon = 'inbox';
+  heading = 'Nothing here yet';
+  message = 'Add something to get started.';
+  announce = true;
+}
+
+describe('EmptyStateComponent', () => {
+  let fixture: ComponentFixture<HostComponent>;
+  let host: HostComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HostComponent);
+    host = fixture.componentInstance;
+  });
+
+  it('should render the icon, heading and message', () => {
+    fixture.detectChanges();
+
+    const icon = fixture.debugElement.query(By.css('.empty-state__icon'))
+      .nativeElement as HTMLElement;
+    const heading = fixture.debugElement.query(By.css('.empty-state__heading'))
+      .nativeElement as HTMLElement;
+    const message = fixture.debugElement.query(By.css('.empty-state__message'))
+      .nativeElement as HTMLElement;
+
+    expect(icon.textContent.trim()).toEqual('inbox');
+    expect(heading.textContent.trim()).toEqual('Nothing here yet');
+    expect(message.textContent.trim()).toEqual('Add something to get started.');
+  });
+
+  it('should hide the icon from assistive technology', () => {
+    fixture.detectChanges();
+
+    const icon = fixture.debugElement.query(By.css('.empty-state__icon'))
+      .nativeElement as HTMLElement;
+
+    expect(icon.getAttribute('aria-hidden')).toEqual('true');
+  });
+
+  it('should omit the message paragraph when no message is supplied', () => {
+    host.message = '';
+    fixture.detectChanges();
+
+    expect(
+      fixture.debugElement.query(By.css('.empty-state__message'))
+    ).toBeNull();
+  });
+
+  it('should project action content', () => {
+    fixture.detectChanges();
+
+    const action = fixture.debugElement.query(
+      By.css('.empty-state__actions [data-cy="test-action"]')
+    );
+
+    expect(action).toBeTruthy();
+  });
+
+  it('should act as a polite live region by default', () => {
+    fixture.detectChanges();
+
+    const emptyState = fixture.debugElement.query(
+      By.directive(EmptyStateComponent)
+    ).nativeElement as HTMLElement;
+
+    expect(emptyState.getAttribute('role')).toEqual('status');
+  });
+
+  it('should drop the live region role when announce is false', () => {
+    host.announce = false;
+    fixture.detectChanges();
+
+    const emptyState = fixture.debugElement.query(
+      By.directive(EmptyStateComponent)
+    ).nativeElement as HTMLElement;
+
+    expect(emptyState.hasAttribute('role')).toBeFalse();
+  });
+});

--- a/src/app/shared/empty-state/empty-state.component.ts
+++ b/src/app/shared/empty-state/empty-state.component.ts
@@ -1,0 +1,43 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+
+/**
+ * Presentational empty state: an icon, a heading, an optional supporting
+ * message and a slot for call-to-action buttons.
+ *
+ * Callers project their own actions:
+ *
+ * ```html
+ * <app-empty-state icon="inbox" heading="Nothing here yet" message="...">
+ *   <button mat-raised-button>Add something</button>
+ * </app-empty-state>
+ * ```
+ */
+@Component({
+  selector: 'app-empty-state',
+  imports: [MatIconModule],
+  templateUrl: './empty-state.component.html',
+  styleUrls: ['./empty-state.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: 'app-empty-state',
+    '[attr.role]': 'announce() ? "status" : null',
+  },
+})
+export class EmptyStateComponent {
+  /** Material icon ligature shown above the heading. */
+  readonly icon = input('inbox');
+
+  /** Short headline describing the state. */
+  readonly heading = input.required<string>();
+
+  /** Optional supporting copy telling the user what to do next. */
+  readonly message = input('');
+
+  /**
+   * Whether the host acts as a polite live region. Set to `false` when the
+   * empty state already sits inside an `aria-live` container so screen
+   * readers do not announce it twice.
+   */
+  readonly announce = input(true);
+}


### PR DESCRIPTION
## What changed and why

The string `No prints found. Add a new print or try a different search.` was hardcoded in four places (print list mobile cards + desktop table, grouped view mobile + desktop). It failed both audiences it served:

1. A brand-new user with zero prints was told to "try a different search" — nonsense, and it was their first impression of the product.
2. A user whose filters matched nothing got no way out; they had to reopen the filter panel and guess which filter was responsible.

This adds a shared standalone `<app-empty-state>` (`src/app/shared/empty-state/`) — icon / heading / message via `input()`, `ng-content` for action buttons, `OnPush`, and an optional polite live region — and uses it to tell those states apart.

## Print list: a three-way branch

| State | Before | After |
| --- | --- | --- |
| Zero prints, **zero printers** | "No prints found. Add a new print or try a different search." **plus** a persistent toast saying to add a printer first — two contradictory instructions at once | **Add a printer to get started** — "You'll need a printer before you can log a print, since every print records the machine that ran it." Single **Add printer** CTA. The toast is suppressed here because the empty state now says the same thing. |
| Zero prints, has printers | Same string | **Log your first print** — with **Add print** and **Import G-code** CTAs. Import triggers the existing hidden `#gcodeInput` picker, a real discovery win since that feature was otherwise buried in an overflow menu. |
| Filtered / no match | Same string, no way out | **No prints match your filters** — names what is hiding results ("Nothing matched 2 active filters and a search for \"benchy\"") with a **Clear filters** button wired to the existing `resetFilters()`. |

The printer state is driven by the **existing** `PrinterRedirectPromptService.shouldShowAddPrinterPrompt()` — no second printer lookup was added.

### Why Import G-code is omitted with zero printers

I checked whether the import path works without a printer. It does not: `parseGcode` navigates to `new/edit`, and `printerId` on that form carries `Validators.required` (`edit-print-detail.component.ts:880-887`). There is no implicit printer creation anywhere on that path, so the user would land on a form they cannot submit. It is therefore dropped from that branch rather than kept as a secondary action.

### Toast suppression is deliberately narrow

The toast is hidden **only** when the empty state renders that same printer guidance: zero printers **and** zero prints **and** no filters **and** no search. Every other combination keeps it. In particular, a user who **has prints but has deactivated all printers** renders no empty state at all, so the toast remains their only guidance — covered by a regression test.

## Other surfaces

**Materials list** — first-run **Add material** CTA; filtered state names the active filter count and search term with **Clear filters**.

**Printers list** — previously rendered *nothing at all* when empty. Now has a first-run **Add printer** state and a filtered **Clear search** state.

**Project list** — no such route or component exists (`/projects` only has `:id`; projects surface through the print list's "Grouped by Project" view), so there was nothing to roll out to.

Both the mobile card view and the desktop table now share a single print empty state instead of two copies (previously the desktop copy had no `fxHide`, so it rendered a second time on mobile). The grouped view receives the same component through content projection, so the copy lives in one place. A dead duplicate empty state in the grouped view's `@else` branch (unreachable — it tested `!items.length` inside a branch that only runs when items exist) was removed.

## Accessibility

The empty state host carries `role="status"` so it is announced when it appears. The desktop tables already set `aria-live="polite"`, but the empty state is a **sibling** of the table rather than a descendant, so there is no nested live region and no double announcement. An `announce` input can switch the role off if a future caller does nest it. The icon is `aria-hidden="true"`.

## Analytics

New events follow the `ComponentName_ActionName` convention: `PrintEmptyState_ClearFilters` (with filter count and whether a search was active), `PrintEmptyState_AddPrint`, `PrintEmptyState_ImportGcode`, `PrintEmptyState_AddPrinter`. The pre-existing `NoActivePrinterPromptClicked` event predates that convention and was **left unrenamed** to preserve historical continuity.

## Note: `hasShownPromptBefore` is dead code — left as-is, deliberately

`PrinterRedirectPromptService.hasShownPromptBefore` is declared at `:13` and read at `:18` but **never assigned `true` anywhere in `src/`**, so the "only show the prompt once per login" comment is not implemented and the toast re-fires on every visit to the list.

I left it alone, and I'd argue against implementing it as written. The service is now the single source of truth for *which empty state renders*, not just whether a toast appears. If it started returning `false` after the first view, a printerless user returning to the list would get `hasPrinters === true` and be shown **"Log your first print"** — actively wrong advice, plus the toast would be gone too. Making the flag live would need the "show once" logic moved into the toast decision rather than the printer lookup. That is a behavior change beyond this PR's scope, so it is flagged here rather than silently changed.

## How it was verified

- `npm run lint:brief` — "No linting issues found ✓"
- `npm run test:brief` — **991 SUCCESS, 0 failures**
- `npm run build:dev` — "Application bundle generation complete"

One run mid-way reported a single failure that did not reproduce across three subsequent full runs and was never attributable to a named spec; this matches the repo's documented random-order Karma flakiness. The final three runs were clean.

Unit coverage: 7 specs for the shared component (rendering, projection, live-region role on/off, message omission); 18 for the print empty state (all three branches, the unresolved-printer-lookup state, singular/plural filter count, whitespace-only search, CTA wiring and analytics); and print-list specs covering all three branches plus toast suppressed / toast retained with prints but no printer / toast retained when a filter empties the list / printer lookup failure fallback.

E2E: `cypress/e2e/prints/print-empty-states.cy.ts`. No existing Cypress spec asserted the old string (grepped `cypress/e2e/` for "No prints found" — zero matches). Cypress was not run locally as it needs a dev server and a logged-in fixture account; CI covers it.

## Codex review

Codex reviewed twice — once on the original diff, once on the printer-branch delta. **All five findings were validated against the code and accepted; none were rejected.**

**Pass 1**

1. **Printer empty state rendered before the request completed** (medium) — **confirmed.** `PrinterListComponent` had no loading flag and branched on a stale `totalCount`; since `hasActiveSearch` is driven by `ngModel` it flips instantly, so clearing a search on an empty result showed "Add your first printer" for the full 400 ms debounce. Codex also spotted a real race: `updateFilter()` had no cancellation, so a slower older response could overwrite a newer one. Fixed with an `isLoading` flag and a monotonic request-id guard in `updateFilter()` and `pageChange()`.
2. **Filtered empty state flashed during the debounce window** (low) — **confirmed.** In the print and materials lists `isLoading = true` was set *inside* the debounced callback, so the filtered copy appeared before any request started and fired a misleading live-region announcement. Fixed by setting `isLoading` on the keystroke and leaving only the request in the debounce, preserving the public `debouncedUpdateFilter` API.

**Pass 2**

3. **A failed printer lookup left the page permanently blank** (major) — **confirmed.** The subscription had no error handler, so if `shouldShowAddPrinterPrompt()` errored, `hasPrinters` stayed `null` forever and both first-run branches render nothing for `null`. Fixed by falling back to `hasPrinters = true` (offering **Add print**, the more useful default) and logging the exception.
4. **Toast could open then flash away on lookup ordering** (minor) — **confirmed as fragile.** In practice `activatedRoute.data` is subscribed before the printer lookup and resolver data arrives synchronously, so `totalCount` is set first — but nothing guaranteed it. Fixed by gating the toast decision on a `printListLoaded` flag so it waits for both answers, removing the ordering dependency entirely.
5. **Parent and child disagreed on whitespace-only search text** (minor) — **confirmed.** The toast check used `!this.searchText` while `PrintEmptyStateComponent.hasSearch()` trims, so `searchText === "   "` showed the printer empty state *and* the toast. Fixed by trimming in the parent; covered by a test.

Codex separately confirmed no issue with the toast open/dismiss ownership, `ngOnDestroy` teardown (toast, tap subscription, and the aggregate subscription that now includes the printer lookup), and the resolved tri-state handling. Lint, tests, and build were re-run green after every change.

## Note for reviewers

This PR overlaps with two sibling print-list PRs developed in parallel and may need a rebase — the contended files are `print-list.component.html`, `print-list.component.ts`, and `print-list.component.spec.ts`.
