### PR TITLE
feat: bump version to 1.46.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "print-log-ui",
-  "version": "1.45.0",
+  "version": "1.46.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --ssl --host 0.0.0.0 ",

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -28,6 +28,34 @@ export class VersionReleaseNoteDialogService {
   private readonly LOCAL_STORAGE_KEY = 'LastLoggedInVersion';
 
   private releaseNotes: ReleaseNoteHistory = {
+    '1.46.0': {
+      title: '1.46.0 - The New Print Page & Bulk Editing',
+      body: `<p>
+<strong>The new print page</strong> is here! Your photos are front and center now, with all the details right next to them: printer, status, times and costs at a glance, every filament you used (shown in its actual color), and a link to the project it belongs to.
+</p>
+<p>
+<strong>Bulk editing</strong> has landed on the print list too. Tick off the prints you want, then mark them all done or delete them in one go. Finished a whole plate overnight? That used to be about eighteen clicks, now it is two. Go check out <a href="/prints">your prints</a>, or read <a href="/docs/prints">the Prints documentation</a>.
+</p>
+<p>
+  <strong>Support development of 3D Print Log:</strong><br />
+  <a href="/subscription">Subscribe to Pro</a> for an ad-free experience and extra cloud storage,
+  buy me a coffee by <a
+    href="https://paypal.me/hoffmanengineering"
+    rel="noreferrer noopener"
+    target="_blank"
+    >donating via PayPal</a
+  >, or by becoming a
+  <a
+    href="https://www.patreon.com/HoffmanEngineering"
+    rel="noreferrer noopener"
+    target="_blank"
+  >
+    Patron of Hoffman Engineering</a
+  >
+  on Patreon.com
+  </p><p>Share <strong>3D Print Log</strong> with a friend, and Happy Printing!
+</p>`,
+    },
     '1.45.0': {
       title: '1.45.0 - The New Analytics Page',
       body: `<p>

--- a/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
+++ b/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
@@ -2,6 +2,193 @@
   <h2>Release Notes</h2>
   <hr />
 
+  <h3 id="v1.46.0">1.46.0 - The New Print Page &amp; Bulk Editing</h3>
+  <p>
+    The print page has been rebuilt. Your photos now lead the page in a proper
+    image hero, and everything about the print sits beside them in a spec rail:
+    an "At a glance" panel for the printer, status, times and costs, a Materials
+    panel showing each filament with its real color, and the project it belongs
+    to as a link you can follow. Prints without any photos no longer reserve a
+    tall empty panel, so they read as one clean column instead. Long material
+    names, project names and display names now wrap instead of spilling out of
+    the panel, the asterisk markers explain themselves to screen readers, and
+    every action target is big enough to hit on a phone.
+  </p>
+  <p>
+    Editing a batch of prints is no longer one menu at a time. The print list
+    now has checkboxes, and selecting rows brings up an action bar that can set
+    the status on all of them or delete them in one go. Marking six prints as
+    Success used to be around eighteen clicks; it is now two. A progress bar
+    tracks the batch as it runs, a single failure never stops the rest, and
+    anything that did fail stays selected so you can retry it.
+  </p>
+  <p>
+    The rest of the release is about not being left staring at a blank or stale
+    page. Opening a print or loading the list now paints a placeholder of the
+    layout that is coming rather than leaving the previous page on screen, and
+    those placeholders only appear if the wait is actually long enough to
+    notice. Refreshing a list you are already looking at keeps your rows in
+    place instead of throwing them away. Empty screens tell you which kind of
+    empty you are looking at: a brand-new account is invited to add a printer or
+    log a first print, while a search that matched nothing tells you what is
+    filtering it out and offers to clear it.
+  </p>
+  <h4>Full List of Changes:</h4>
+  <ul>
+    <li>
+      <strong>Rebuilt print page</strong> - The print detail page is now an
+      image hero with a spec rail beside it ("At a glance", Materials, legend
+      and actions), with notes, files and comments below. Prints with no images
+      drop the hero and render as a single narrow column. (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/81"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #81</a
+      >)
+    </li>
+    <li>
+      <strong>Project link on prints</strong> - A print that belongs to a
+      project now links straight to it from the spec rail. (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/81"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #81</a
+      >)
+    </li>
+    <li>
+      <strong>Filament colors on the print page</strong> - Each material is
+      shown with an accessible swatch of its actual color. (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/81"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #81</a
+      >)
+    </li>
+    <li>
+      <strong>Print page accessibility and overflow fixes</strong> - Asterisk
+      markers resolve to their legend text for screen readers, action targets
+      meet the 44px minimum, the sticky rail respects reduced-motion, and long
+      material, project and user names wrap instead of overflowing the panel.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/81"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #81</a
+      >)
+    </li>
+    <li>
+      <strong>Bulk status and delete on the print list</strong> - Select prints
+      with the new checkbox column and use the action bar to set a status on all
+      of them or delete them together, with a confirmation naming the count.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/84"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #84</a
+      >)
+    </li>
+    <li>
+      <strong>Bulk progress and partial failures</strong> - A progress bar shows
+      "n of N" as the batch runs, one failure never aborts the rest, and the
+      prints that failed stay selected so a retry is one click away. (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/84"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #84</a
+      >)
+    </li>
+    <li>
+      <strong>Loading placeholders for prints</strong> - The print list and
+      print page now paint a skeleton of the layout that is coming instead of
+      leaving the previous page on screen while data loads. (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/83"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #83</a
+      >)
+    </li>
+    <li>
+      <strong>No placeholder flashing on fast loads</strong> - A placeholder
+      only appears if the wait is long enough to notice, and once shown it stays
+      long enough to read, so quick responses no longer flicker. (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/83"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #83</a
+      >)
+    </li>
+    <li>
+      <strong>Refreshing a list keeps your rows</strong> - Changing a filter,
+      sort or page dims the existing rows and shows a progress bar rather than
+      replacing everything you were reading with grey boxes. (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/83"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #83</a
+      >)
+    </li>
+    <li>
+      <strong>Helpful empty states</strong> - Empty print, material and printer
+      lists now tell you which kind of empty they are: a first-run state with
+      the right call to action, or a "nothing matched your filters" state that
+      names the active filters and offers to clear them. The printers list
+      previously rendered nothing at all when empty. (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/82"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #82</a
+      >)
+    </li>
+    <li>
+      <strong>Printerless users are pointed at a printer first</strong> - If you
+      have no printers yet, the print list explains that a printer comes first
+      and offers a single Add printer button, instead of showing a contradictory
+      toast alongside a "try a different search" message. (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/82"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #82</a
+      >)
+    </li>
+    <li>
+      <strong>Public print pages are more robust</strong> - A failed settings,
+      profile or print fetch no longer cancels navigation and bounces logged-out
+      visitors back to the home page. (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/81"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #81</a
+      >,
+      <a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/83"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #83</a
+      >)
+    </li>
+    <li>
+      <strong>Security: access tokens no longer sent to other hosts</strong> -
+      Your API access token is now only attached to requests to the 3D Print Log
+      API. Previously images hosted elsewhere could receive it. (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/69"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #69</a
+      >)
+    </li>
+    <li>
+      <strong>Owner-only data is gated by default</strong> - Filament links and
+      prices on a shared print now default to hidden, so a missed call site
+      cannot expose them to anonymous visitors, and print source links are
+      validated before being rendered. (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/81"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #81</a
+      >)
+    </li>
+  </ul>
+
   <h3 id="v1.45.0">1.45.0 - The New Analytics Page</h3>
   <p>
     Analytics has been rebuilt from the ground up. Instead of a single page of


### PR DESCRIPTION
## Summary

Minor release **1.45.0 → 1.46.0**: *The New Print Page & Bulk Editing*.

Release-notes content only — no functional code changes. Bumps `package.json`, adds the 1.46.0 section to the release notes docs page, and adds the 1.46.0 entry to the version dialog.

## What shipped since v1.45.0

| PR | Change |
|---|---|
| #81 | Rebuilt print detail page (image hero + spec rail), project link, filament color swatches, a11y/overflow fixes, owner-gated filament links and prices, public-route degradation |
| #84 | Bulk status and delete on the print list, with progress and partial-failure handling |
| #83 | Skeleton loading for the print list and detail, deferred timing so fast loads don't flash, rows retained on refetch |
| #82 | Differentiated, actionable empty states; printerless users pointed at adding a printer first |
| #69 | Bearer token attachment gated to the trusted API origin |

PR #85 (persist `devUserId` for the session) is dev-only tooling and is intentionally not in the user-facing notes.

## Dialog copy

Written in plain language (no "hero" / "spec rail" jargon), leading with the print page and bulk editing.

## Verification

- `npx tsc --noEmit` on both `tsconfig.json` and `tsconfig.app.json` — clean
- `npm run lint:brief` — no issues
- `git diff --stat` confirms only the new release-notes lines changed in the HTML (no blanket prettier rewrite)

## After merge

```bash
git tag v1.46.0
git push origin v1.46.0
```