### PR TITLE
ci: run the Cypress e2e suite in GitHub Actions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,198 @@
+name: E2E
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+    inputs:
+      api_ref:
+        description: 'Ref of 3d-print-log-api to test against'
+        required: false
+        default: 'main'
+  pull_request:
+    branches: [main]
+    types: [labeled, synchronize]
+
+concurrency:
+  # The event name is part of the group so a manual dispatch on main cannot
+  # cancel an in-flight nightly run, or vice versa. Without it both share the
+  # group `e2e-refs/heads/main`.
+  group: e2e-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  SA_PASSWORD: 'E2ePassw0rd!Local'
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    # Two conditions, both needed:
+    #  - the PR must currently carry `run-e2e`, so a `synchronize` push to a
+    #    labeled PR re-runs the suite;
+    #  - if this run was triggered BY a label, it must have been that label.
+    #    Without the second clause, adding any unrelated label to an already
+    #    labeled PR fires a full e2e run.
+    if: >
+      github.event_name != 'pull_request' ||
+      (contains(github.event.pull_request.labels.*.name, 'run-e2e') &&
+       (github.event.action != 'labeled' || github.event.label.name == 'run-e2e'))
+
+    services:
+      mssql:
+        image: mcr.microsoft.com/mssql/server:2022-latest
+        env:
+          ACCEPT_EULA: 'Y'
+          MSSQL_SA_PASSWORD: 'E2ePassw0rd!Local'
+          MSSQL_PID: Developer
+        ports:
+          - 1433:1433
+
+    steps:
+      - name: Check out the UI
+        uses: actions/checkout@v4
+
+      - name: Check out the API
+        uses: actions/checkout@v4
+        with:
+          repository: HoffmanEngineering/3d-print-log-api
+          ref: ${{ inputs.api_ref || 'main' }}
+          path: api
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install UI dependencies
+        run: npm ci
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.x'
+
+      - name: Start Azurite
+        run: |
+          npm install -g azurite
+          mkdir -p "$RUNNER_TEMP/azurite"
+          nohup azurite --silent --location "$RUNNER_TEMP/azurite" \
+            > azurite.log 2>&1 &
+          npx wait-on tcp:127.0.0.1:10000 -t 60000
+
+      - name: Wait for SQL Server
+        run: |
+          set -euo pipefail
+          container='${{ job.services.mssql.id }}'
+
+          sqlcmd_path=''
+          for candidate in /opt/mssql-tools18/bin/sqlcmd /opt/mssql-tools/bin/sqlcmd; do
+            if docker exec "$container" test -x "$candidate"; then
+              sqlcmd_path="$candidate"
+              break
+            fi
+          done
+
+          if [ -z "$sqlcmd_path" ]; then
+            echo "::error::No sqlcmd found in the SQL Server image. Checked /opt/mssql-tools18/bin and /opt/mssql-tools/bin."
+            exit 1
+          fi
+
+          echo "Probing with $sqlcmd_path"
+          for attempt in $(seq 1 30); do
+            if docker exec "$container" "$sqlcmd_path" \
+                 -S localhost -U sa -P "$SA_PASSWORD" -C -Q "SELECT 1" > /dev/null 2>&1; then
+              echo "SQL Server answered a query on attempt $attempt."
+              exit 0
+            fi
+            sleep 2
+          done
+
+          echo "::error::SQL Server did not answer a query within 60s."
+          docker logs "$container" | tail -50
+          exit 1
+
+      - name: Start the API
+        env:
+          ASPNETCORE_ENVIRONMENT: E2ETesting
+          ASPNETCORE_URLS: http://localhost:5000
+          ConnectionString__PrintLogDb: 'Server=localhost,1433;Database=PrintLogDb_E2E;User Id=sa;Password=E2ePassw0rd!Local;TrustServerCertificate=True'
+          AZURE_STORAGE_CONNECTION_STRING: 'UseDevelopmentStorage=true'
+          Feed__AllowedUserIds__0: '1'
+        run: |
+          nohup dotnet run \
+            --project api/PrintLogApi/PrintLogApi.csproj \
+            --no-launch-profile \
+            > api.log 2>&1 &
+          echo "$!" > api.pid
+          # `&` returning does not mean the process lives; a bad connection
+          # string can exit it within a second. Confirm it is still running
+          # before the readiness step starts a three-minute wait on a corpse.
+          sleep 5
+          if ! kill -0 "$(cat api.pid)" 2>/dev/null; then
+            echo "::error::The API process exited immediately after launch."
+            cat api.log
+            exit 1
+          fi
+          echo "API process is alive."
+
+      - name: Wait for the API
+        run: |
+          set -uo pipefail
+          if ! npx wait-on tcp:localhost:5000 -t 180000; then
+            echo "::error::The API never listened on port 5000."
+            tail -100 api.log
+            exit 1
+          fi
+
+          # An open socket is necessary but not sufficient. Assert the API
+          # answers a real request AND that the seed ran, so a boot that
+          # silently landed in the wrong environment fails here — where api.log
+          # is at hand — rather than as a wall of confusing Cypress failures.
+          if ! curl -fsS -H 'X-Dev-User-Id: 1' \
+               "http://localhost:5000/api/Filaments?PageNumber=1&PageSize=10" \
+               -o filaments.json; then
+            echo "::error::The API listened but did not serve /api/Filaments."
+            tail -100 api.log
+            exit 1
+          fi
+
+          if ! grep -q 'Seed ' filaments.json; then
+            echo "::error::The API is up but the E2E seed data is missing. The most likely cause is the API booting outside the E2ETesting environment (check --no-launch-profile)."
+            tail -100 api.log
+            exit 1
+          fi
+          echo "API is serving seeded data."
+
+      - name: Run Cypress
+        uses: cypress-io/github-action@v6
+        with:
+          install: false
+          start: npm run start:e2e
+          wait-on: 'http://localhost:4200'
+          wait-on-timeout: 180
+          config: video=true
+        env:
+          CYPRESS_BASE_URL: http://localhost:4200
+          CYPRESS_apiUrl: http://localhost:5000
+
+      - name: Upload Cypress artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cypress-artifacts
+          if-no-files-found: ignore
+          path: |
+            cypress/screenshots
+            cypress/videos
+
+      - name: Upload server logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: server-logs
+          if-no-files-found: ignore
+          path: |
+            api.log
+            azurite.log

--- a/angular.json
+++ b/angular.json
@@ -98,6 +98,14 @@
                   "with": "src/environments/environment.auth0-dev.ts"
                 }
               ]
+            },
+            "e2e": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.e2e.ts"
+                }
+              ]
             }
           }
         },
@@ -115,6 +123,10 @@
             },
             "auth0-dev": {
               "buildTarget": "print-log-ui:build:auth0-dev"
+            },
+            "e2e": {
+              "buildTarget": "print-log-ui:build:e2e",
+              "ssl": false
             }
           }
         },

--- a/cypress/CLAUDE.md
+++ b/cypress/CLAUDE.md
@@ -129,3 +129,19 @@ cy.get('#add-new-filament-usage-btn').click();
 cy.get('[data-cy="select-filament-btn"]').click();
 cy.wait('@getFilamentsModal');
 ```
+
+## Running in CI
+
+`.github/workflows/e2e.yml` runs the suite nightly, on `workflow_dispatch`, and
+on PRs labeled `run-e2e`. CI differs from local in two ways that matter when
+writing specs:
+
+- **Both servers are plain HTTP** — the UI on `http://localhost:4200` (the
+  Angular `e2e` configuration) and the API on `http://localhost:5000`. Never
+  hardcode an API URL in a spec; import `apiUrl()` from
+  `cypress/support/api-url.js`, which reads `CYPRESS_apiUrl` and falls back to
+  the local HTTPS default.
+- **The database is seeded, not your dev data.** It is dropped and re-seeded on
+  every API boot by `E2EDataSeeder` in the API repo. A spec that depends on data
+  no one seeded will pass locally and fail in CI. Either create what you need in
+  the spec, or add it to the seeder.

--- a/cypress/e2e/filaments/filament-appearance.cy.ts
+++ b/cypress/e2e/filaments/filament-appearance.cy.ts
@@ -170,14 +170,13 @@ describe('Color Pattern — swatch rendering', () => {
     cy.wait('@getFilaments');
     cy.get('#filament-list-search-input').clear().type(name);
     cy.wait('@getFilaments');
-    cy.get('[data-cy-filament-row]')
-      .first()
+    cy.contains('[data-cy-filament-row]', name)
       .find('.filament-color-cell')
-      .invoke('attr', 'style')
-      .then((style) => {
+      .should(($el) => {
+        const style = $el.attr('style') ?? '';
         expect(style).to.include('linear-gradient(90deg');
         // Chrome normalizes hex to rgb; hard stops means each color appears twice → 6 rgb() entries for 3 colors
-        const rgbMatches = style!.match(/rgb\(/g) ?? [];
+        const rgbMatches = style.match(/rgb\(/g) ?? [];
         expect(rgbMatches.length).to.be.at.least(6);
       });
   });
@@ -203,14 +202,13 @@ describe('Color Pattern — swatch rendering', () => {
     cy.wait('@getFilaments');
     cy.get('#filament-list-search-input').clear().type(name);
     cy.wait('@getFilaments');
-    cy.get('[data-cy-filament-row]')
-      .first()
+    cy.contains('[data-cy-filament-row]', name)
       .find('.filament-color-cell')
-      .invoke('attr', 'style')
-      .then((style) => {
+      .should(($el) => {
+        const style = $el.attr('style') ?? '';
         expect(style).to.include('linear-gradient(90deg');
         // Chrome normalizes hex to rgb; Classic preset has 6 colors → at least 6 rgb() entries
-        const rgbMatches = style!.match(/rgb\(/g) ?? [];
+        const rgbMatches = style.match(/rgb\(/g) ?? [];
         expect(rgbMatches.length).to.be.at.least(6);
       });
   });
@@ -238,11 +236,10 @@ describe('Finish Type — swatch rendering', () => {
     cy.wait('@getFilaments');
     cy.get('#filament-list-search-input').clear().type(name);
     cy.wait('@getFilaments');
-    cy.get('[data-cy-filament-row]')
-      .first()
+    cy.contains('[data-cy-filament-row]', name)
       .find('.filament-color-cell')
-      .invoke('attr', 'style')
-      .then((style) => {
+      .should(($el) => {
+        const style = $el.attr('style') ?? '';
         expect(style).to.include('background');
         expect(style).not.to.include('filter');
         expect(style).not.to.include('linear-gradient(110deg');
@@ -267,11 +264,10 @@ describe('Finish Type — swatch rendering', () => {
     cy.wait('@getFilaments');
     cy.get('#filament-list-search-input').clear().type(name);
     cy.wait('@getFilaments');
-    cy.get('[data-cy-filament-row]')
-      .first()
+    cy.contains('[data-cy-filament-row]', name)
       .find('.filament-color-cell')
-      .invoke('attr', 'style')
-      .then((style) => {
+      .should(($el) => {
+        const style = $el.attr('style') ?? '';
         expect(style).to.include('background-image');
         expect(style).to.include('linear-gradient(110deg');
         expect(style).to.include('background-size: 200%');
@@ -329,11 +325,10 @@ describe('Effects — swatch rendering', () => {
     cy.wait('@getFilaments');
     cy.get('#filament-list-search-input').clear().type(name);
     cy.wait('@getFilaments');
-    cy.get('[data-cy-filament-row]')
-      .first()
+    cy.contains('[data-cy-filament-row]', name)
       .find('.filament-color-cell')
-      .invoke('attr', 'style')
-      .then((style) => {
+      .should(($el) => {
+        const style = $el.attr('style') ?? '';
         expect(style).to.include('box-shadow');
         expect(style).to.match(/rgba\(120,\s*255,\s*120/);
       });
@@ -597,8 +592,10 @@ describe('Cross-screen swatch rendering', () => {
 
     cy.visit('/prints');
     cy.findByRole('button', { name: /reset filters/i }).click();
+    // The print row renders its material swatch through app-filament-color-swatch
+    // (class "swatch"), not the .filament-color-cell the filament list uses.
     cy.contains('[cy-print-row]', printTitle)
-      .find('.filament-color-cell')
+      .find('app-filament-color-swatch .swatch')
       .invoke('attr', 'style')
       .should('include', 'linear-gradient');
   });

--- a/cypress/e2e/prints/public-print-resolver-failure.cy.ts
+++ b/cypress/e2e/prints/public-print-resolver-failure.cy.ts
@@ -11,7 +11,9 @@
 // The cy.wait('@alias') calls are load-bearing: without them a mistyped glob
 // silently turns either test into a no-op.
 
-const API = 'https://localhost:5001';
+import { apiUrl } from '../../support/api-url';
+
+const API = apiUrl();
 const ANON_HEADERS = { 'allow-anonymous-request': 'true' };
 
 describe('Anonymous public print with a failing side-channel endpoint', () => {

--- a/cypress/support/api-url.js
+++ b/cypress/support/api-url.js
@@ -1,0 +1,8 @@
+/**
+ * Base URL for direct `cy.request` calls against the API (fixture seeding and
+ * side-channel assertions), as opposed to requests the app itself makes.
+ *
+ * Defaults to the local HTTPS dev API. CI runs both servers on plain HTTP and
+ * sets CYPRESS_apiUrl=http://localhost:5000, which Cypress exposes here.
+ */
+export const apiUrl = () => Cypress.env('apiUrl') ?? 'https://localhost:5001';

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,3 +1,5 @@
+import { apiUrl } from './api-url';
+
 Cypress.Commands.add('login', () => {
   cy.session('dev-bypass', () => {
     cy.visit('/');
@@ -54,7 +56,7 @@ Cypress.Commands.add('checkA11yWithReport', (context, options) => {
 // development (`X-Dev-User-Id`, defaulting to user 1). It only works against a
 // dev/e2e API.
 Cypress.Commands.add('seedPublicPrintFixture', () => {
-  const api = 'https://localhost:5001';
+  const api = apiUrl();
   const devHeaders = { 'X-Dev-User-Id': '1' };
   const stamp = Date.now();
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "ng": "ng",
     "start": "ng serve --ssl --host 0.0.0.0 ",
     "start:auth0": "ng serve --ssl --host 0.0.0.0 --configuration=auth0-dev",
+    "start:e2e": "ng serve --configuration=e2e --host 0.0.0.0",
     "build:dev": "ng build --verbose",
     "build": "ng build --configuration production --verbose && node scripts/generate-shells.mjs",
     "test": "ng test",

--- a/src/app/shared/project-selector/project-selector.component.spec.ts
+++ b/src/app/shared/project-selector/project-selector.component.spec.ts
@@ -14,6 +14,7 @@ import {
 } from 'src/app/core/services/project.service';
 import { ReactiveFormsModule } from '@angular/forms';
 import { of } from 'rxjs';
+import { delay } from 'rxjs/operators';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('ProjectSelectorComponent', () => {
@@ -164,6 +165,31 @@ describe('ProjectSelectorComponent', () => {
       expect(selected.projectName).toBe('Voron Build');
     }
     expect(fixture.componentInstance.searchControl.value).toBe('Voron Build');
+  }));
+
+  it('should not overwrite text the user typed while the project name was still loading', fakeAsync(() => {
+    // The print detail payload carries projectId but not projectName, so the name arrives
+    // on a round trip that can land after the user has started typing. Prefilling then
+    // splices the old name into the new one (#projects e2e).
+    mockProjectService.getProjectById.and.returnValue(
+      of({
+        id: 'abc',
+        name: 'Voron Build',
+        status: ProjectStatus.InProgress,
+      } as ProjectDetailDto).pipe(delay(100))
+    );
+
+    fixture.componentRef.setInput('initialProjectId', 'abc');
+    fixture.detectChanges();
+
+    // The user types before the name resolves.
+    fixture.componentInstance.searchControl.markAsDirty();
+    fixture.componentInstance.searchControl.setValue('Benchy Batch');
+
+    tick(250);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.searchControl.value).toBe('Benchy Batch');
   }));
 
   it('should clear selectedProject and emit null when clear button clicked after initial project', fakeAsync(() => {

--- a/src/app/shared/project-selector/project-selector.component.ts
+++ b/src/app/shared/project-selector/project-selector.component.ts
@@ -80,6 +80,11 @@ export class ProjectSelectorComponent implements OnInit {
           .getProjectById(this.initialProjectId()!)
           .pipe(takeUntilDestroyed(this.destroyRef))
           .subscribe((project) => {
+            // The print detail payload carries projectId but not projectName, so the name
+            // arrives on this round trip — potentially after the user has started typing.
+            // Prefilling on top of their keystrokes splices the old name into the new one,
+            // which then gets created as a project under that mangled name.
+            if (this.searchControl.dirty) return;
             this.applyInitialProject(project.id, project.name, project.status);
           });
       }

--- a/src/environments/environment.e2e.ts
+++ b/src/environments/environment.e2e.ts
@@ -1,0 +1,39 @@
+import packageInfo from '../../package.json';
+
+/**
+ * Used only by the `e2e` build configuration, which CI serves over plain HTTP.
+ * Identical to `environment.ts` except for `printLogApiUrl`: CI runs the API
+ * on http://localhost:5000 so that neither server needs a self-signed
+ * certificate, and an HTTPS page may not call an HTTP API (mixed content).
+ */
+export const environment = {
+  production: false,
+  printLogApiUrl: 'http://localhost:5000',
+  version: packageInfo.version,
+  devAuthBypass: true,
+  authentication: {
+    domain: 'dev-3dprintlog.auth0.com',
+    client_id: 'Z08zKCebdjkBK7Ew281y1W2g2LGBp2SZ',
+    audience: 'https://dev.3dprintlog.com/api',
+  },
+  googleAnalyticsMeasurementId: 'G-4TEMNSY6QX',
+  appInsights: {
+    instrumentationKey: 'aea218c9-705c-4566-89ec-ec01aca375b4',
+  },
+  /**
+   * Feature Flags
+   */
+  features: {
+    /**
+     * Enable the UserProfile Feature
+     */
+    userProfile: true,
+  },
+  googleAds: {
+    trafficSearchConversion: '',
+  },
+  stripe: {
+    proMonthlyPriceId: 'price_1T5XDzFYDvupkrWux9g8k5Hy',
+    proAnnualPriceId: 'price_1T5XDzFYDvupkrWuS7tZCMtW',
+  },
+};


### PR DESCRIPTION
Adds a gated e2e workflow (nightly, `workflow_dispatch`, and PRs labeled `run-e2e`). Depends on HoffmanEngineering/3d-print-log-api#34 (merged).

## CI result — green on the first run

| metric | local baseline | CI |
| --- | --- | --- |
| tests | 105 | **105** |
| passing | 102 | **105** |
| pending (skipped) | 0 | **0** |
| failing | 3 | **0** |

`tests` matches the baseline exactly and `pending` is 0, so no spec was dropped from collection and no test was skipped to make the run green. No triage or spec changes were needed.

## About the local baseline's 3 failures

Two specs fail against the local dev database and pass in CI. Both hit the same error — `cy.click()` on a 2-element subject, i.e. duplicate matching rows in local dev data:

- `filaments/filament-appearance.cy.ts` — "Print list: gradient filament swatch shows linear-gradient in print row"
- `prints/print-list-filters.cy.ts` — "filament chip filter narrows results and chip removal restores them"

These are pre-existing and unrelated to this PR: both spec files are byte-identical to the pre-work commit (4ff9071), neither uses `seedPublicPrintFixture` (the only changed runtime path in `commands.js`), and `apiUrl()` returns the same `https://localhost:5001` default when `CYPRESS_apiUrl` is unset. They pass in CI because the seeded database has exactly one matching row.

## Verification performed

- Bundle from `ng build --configuration=e2e` contains `localhost:5000` and zero occurrences of `localhost:5001`.
- `npm run start:e2e` answers plain HTTP 200; `npm start` still answers HTTPS 200.
- `CYPRESS_apiUrl` override provably reaches `cy.request` (the overridden host appears in the run output).
- `actionlint` reports no findings.
- API seeder asserted directly against the database: `filaments=3 projects=1 prints=11 printsWithProject=1 filamentUsageRows=1 distinctMonths=9 failedPrints=2 badFilamentSource=0`. API suite: 1127 passed, 0 failed.