### PR TITLE
feat(prints): bulk add to project, visibility, printer and permissions

### DIFF
--- a/cypress/e2e/prints/print-list-bulk-actions.cy.ts
+++ b/cypress/e2e/prints/print-list-bulk-actions.cy.ts
@@ -1,3 +1,5 @@
+import { apiUrl } from '../../support/api-url';
+
 describe('Print List Bulk Actions', () => {
   beforeEach(() => {
     cy.login();
@@ -122,6 +124,13 @@ describe('Print List Bulk Actions', () => {
       '1 selected'
     );
 
+    // Every action now lives behind one trigger, so that trigger and the menu it
+    // opens are the whole keyboard surface for bulk actions.
+    cy.get('[data-cy-bulk-actions]').focus().type('{enter}');
+    cy.get('[data-cy-bulk-set-status]').should('be.visible').focus();
+    cy.focused().should('have.attr', 'data-cy-bulk-set-status');
+    cy.get('body').type('{esc}');
+
     cy.get('[data-cy-bulk-clear]').focus().type('{enter}');
     cy.get('[data-cy-bulk-action-bar]').should('not.exist');
   });
@@ -184,9 +193,15 @@ describe('Print List Bulk Actions', () => {
     cy.get('[data-cy-bulk-project-confirm]').click();
 
     // One project is created for the whole batch, not one per print.
-    cy.wait('@createProject');
-    cy.get('@createProject.all').should('have.length', 1);
-    cy.wait('@bulkUpdate');
+    cy.wait('@createProject').then((created) => {
+      const projectId = created.response!.body.id;
+      cy.get('@createProject.all').should('have.length', 1);
+      // The id that was created is the id the prints were filed under. Waiting
+      // for the request without reading it would pass with the wrong project.
+      cy.wait('@bulkUpdate')
+        .its('request.body.projectId')
+        .should('equal', projectId);
+    });
 
     cy.contains('2 prints updated').should('exist');
   });
@@ -198,7 +213,7 @@ describe('Print List Bulk Actions', () => {
 
     // Create the project up front, so this test exercises the pick-an-existing-one
     // branch rather than the create-a-new-one branch above.
-    cy.createProject(projectName);
+    cy.createProject(projectName).as('seededProject');
     cy.createPrint(`${prefix} A`);
     cy.createPrint(`${prefix} B`);
 
@@ -215,7 +230,11 @@ describe('Print List Bulk Actions', () => {
     cy.contains('mat-option', projectName).click();
     cy.get('[data-cy-bulk-project-confirm]').click();
 
-    cy.wait('@bulkUpdate');
+    cy.get('@seededProject').then((project: any) => {
+      cy.wait('@bulkUpdate')
+        .its('request.body.projectId')
+        .should('equal', project.id);
+    });
     // Picking an existing project must not create anything.
     cy.get('@createProject.all').should('have.length', 0);
     cy.contains('2 prints updated').should('exist');
@@ -235,11 +254,26 @@ describe('Print List Bulk Actions', () => {
     cy.get('[data-cy-select-all-prints]').click();
     cy.get('[data-cy-bulk-actions]').click();
     cy.contains('.mat-mdc-menu-item', 'Printer').click();
-    cy.get('[data-cy-bulk-printer]').first().click();
+    // Capture which printer was chosen so the request can be checked against it.
+    // "printerId is a number" would pass with every printer in the list.
+    cy.get('[data-cy-bulk-printer]')
+      .first()
+      .invoke('attr', 'data-cy-bulk-printer')
+      .then((printerName) => {
+        cy.get(`[data-cy-bulk-printer="${printerName}"]`).click();
 
-    cy.wait('@bulkUpdate')
-      .its('request.body.printerId')
-      .should('be.a', 'number');
+        cy.wait('@bulkUpdate').then((request) => {
+          cy.request({
+            url: `${apiUrl()}/api/printers/summary?PageNumber=1&PageSize=100`,
+            headers: { 'X-Dev-User-Id': '1' },
+          }).then((response) => {
+            const printer = response.body.items.find(
+              (p: { name: string }) => p.name === printerName
+            );
+            expect(request.request.body.printerId).to.equal(printer.id);
+          });
+        });
+      });
     cy.contains('2 prints updated').should('exist');
   });
 
@@ -259,7 +293,9 @@ describe('Print List Bulk Actions', () => {
     cy.contains('.mat-mdc-menu-item', 'Visibility').click();
     cy.get('[data-cy-bulk-visibility="Public"]').click();
 
-    cy.wait('@bulkUpdate');
+    // 1 is PrintViewStatus.Public. Enums travel as integers, so asserting the
+    // value here is what catches a string ever being sent instead.
+    cy.wait('@bulkUpdate').its('request.body.viewStatus').should('equal', 1);
     cy.contains('2 prints updated').should('exist');
   });
 

--- a/cypress/e2e/prints/print-list-bulk-actions.cy.ts
+++ b/cypress/e2e/prints/print-list-bulk-actions.cy.ts
@@ -27,7 +27,7 @@ describe('Print List Bulk Actions', () => {
     // The bar is contextual — nothing selected, nothing shown.
     cy.get('[data-cy-bulk-action-bar]').should('not.exist');
 
-    cy.intercept('PUT', '/api/Prints/*/status/*').as('updateStatus');
+    cy.intercept('POST', '/api/Prints/bulk-update').as('bulkUpdate');
 
     cy.get('[data-cy-select-all-prints]').click();
     cy.get('[data-cy-bulk-selection-count]').should(
@@ -35,12 +35,12 @@ describe('Print List Bulk Actions', () => {
       '2 selected'
     );
 
+    cy.get('[data-cy-bulk-actions]').click();
     cy.get('[data-cy-bulk-set-status]').click();
     cy.get('[data-cy-bulk-status="Success"]').click();
 
-    // One request per print — there is no batch endpoint.
-    cy.wait('@updateStatus');
-    cy.wait('@updateStatus');
+    // One request for the whole selection - it fits inside a single 25-id chunk.
+    cy.wait('@bulkUpdate');
 
     // Everything succeeded, so the selection is emptied and the bar disappears.
     cy.get('[data-cy-bulk-action-bar]').should('not.exist');
@@ -136,6 +136,7 @@ describe('Print List Bulk Actions', () => {
     showOnly(prefix, 2);
 
     cy.get('[data-cy-select-all-prints]').click();
+    cy.get('[data-cy-bulk-actions]').click();
     cy.get('[data-cy-bulk-delete]').click();
 
     // Cancelling leaves everything alone.
@@ -150,15 +151,135 @@ describe('Print List Bulk Actions', () => {
       '2 selected'
     );
 
-    cy.intercept('DELETE', '/api/Prints/*').as('deletePrint');
+    cy.intercept('POST', '/api/Prints/bulk-delete').as('bulkDelete');
 
+    cy.get('[data-cy-bulk-actions]').click();
     cy.get('[data-cy-bulk-delete]').click();
     cy.contains('.mat-mdc-dialog-container button', 'Delete').click();
 
-    cy.wait('@deletePrint');
-    cy.wait('@deletePrint');
+    cy.wait('@bulkDelete');
 
     cy.get('[data-cy-bulk-action-bar]').should('not.exist');
     cy.get('[cy-print-row]').should('have.length', 0);
+  });
+
+  it('adds several prints to a new project', () => {
+    const ts = new Date().getTime();
+    const prefix = `Bulk Project ${ts}`;
+
+    cy.createPrint(`${prefix} A`);
+    cy.createPrint(`${prefix} B`);
+
+    showOnly(prefix, 2);
+
+    cy.intercept('POST', '/api/Projects').as('createProject');
+    cy.intercept('POST', '/api/Prints/bulk-update').as('bulkUpdate');
+
+    cy.get('[data-cy-select-all-prints]').click();
+    cy.get('[data-cy-bulk-actions]').click();
+    cy.get('[data-cy-bulk-add-to-project]').click();
+
+    cy.get('[data-cy="project-selector-input"]').type(`Project ${ts}`);
+    cy.get('[data-cy="project-new-option"]').click();
+    cy.get('[data-cy-bulk-project-confirm]').click();
+
+    // One project is created for the whole batch, not one per print.
+    cy.wait('@createProject');
+    cy.get('@createProject.all').should('have.length', 1);
+    cy.wait('@bulkUpdate');
+
+    cy.contains('2 prints updated').should('exist');
+  });
+
+  it('adds several prints to an existing project', () => {
+    const ts = new Date().getTime();
+    const prefix = `Bulk Existing Project ${ts}`;
+    const projectName = `Existing Project ${ts}`;
+
+    // Create the project up front, so this test exercises the pick-an-existing-one
+    // branch rather than the create-a-new-one branch above.
+    cy.createProject(projectName);
+    cy.createPrint(`${prefix} A`);
+    cy.createPrint(`${prefix} B`);
+
+    showOnly(prefix, 2);
+
+    cy.intercept('POST', '/api/Projects').as('createProject');
+    cy.intercept('POST', '/api/Prints/bulk-update').as('bulkUpdate');
+
+    cy.get('[data-cy-select-all-prints]').click();
+    cy.get('[data-cy-bulk-actions]').click();
+    cy.get('[data-cy-bulk-add-to-project]').click();
+
+    cy.get('[data-cy="project-selector-input"]').type(projectName);
+    cy.contains('mat-option', projectName).click();
+    cy.get('[data-cy-bulk-project-confirm]').click();
+
+    cy.wait('@bulkUpdate');
+    // Picking an existing project must not create anything.
+    cy.get('@createProject.all').should('have.length', 0);
+    cy.contains('2 prints updated').should('exist');
+  });
+
+  it('reassigns several prints to a different printer', () => {
+    const ts = new Date().getTime();
+    const prefix = `Bulk Printer ${ts}`;
+
+    cy.createPrint(`${prefix} A`);
+    cy.createPrint(`${prefix} B`);
+
+    showOnly(prefix, 2);
+
+    cy.intercept('POST', '/api/Prints/bulk-update').as('bulkUpdate');
+
+    cy.get('[data-cy-select-all-prints]').click();
+    cy.get('[data-cy-bulk-actions]').click();
+    cy.contains('.mat-mdc-menu-item', 'Printer').click();
+    cy.get('[data-cy-bulk-printer]').first().click();
+
+    cy.wait('@bulkUpdate')
+      .its('request.body.printerId')
+      .should('be.a', 'number');
+    cy.contains('2 prints updated').should('exist');
+  });
+
+  it('sets the visibility of several prints in one action', () => {
+    const ts = new Date().getTime();
+    const prefix = `Bulk Visibility ${ts}`;
+
+    cy.createPrint(`${prefix} A`);
+    cy.createPrint(`${prefix} B`);
+
+    showOnly(prefix, 2);
+
+    cy.intercept('POST', '/api/Prints/bulk-update').as('bulkUpdate');
+
+    cy.get('[data-cy-select-all-prints]').click();
+    cy.get('[data-cy-bulk-actions]').click();
+    cy.contains('.mat-mdc-menu-item', 'Visibility').click();
+    cy.get('[data-cy-bulk-visibility="Public"]').click();
+
+    cy.wait('@bulkUpdate');
+    cy.contains('2 prints updated').should('exist');
+  });
+
+  it('removes several prints from their project', () => {
+    const ts = new Date().getTime();
+    const prefix = `Bulk Unfile ${ts}`;
+
+    cy.createPrint(`${prefix} A`);
+
+    showOnly(prefix, 1);
+
+    cy.intercept('POST', '/api/Prints/bulk-update').as('bulkUpdate');
+
+    cy.get('[data-cy-select-all-prints]').click();
+    cy.get('[data-cy-bulk-actions]').click();
+    cy.get('[data-cy-bulk-add-to-project]').click();
+    cy.get('[data-cy-bulk-project-remove]').click();
+
+    cy.wait('@bulkUpdate')
+      .its('request.body.clear')
+      .should('deep.equal', ['projectId']);
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -133,6 +133,21 @@ Cypress.Commands.add('seedPublicPrintFixture', () => {
   });
 });
 
+// Seeds a project directly through the API so a test can exercise the
+// pick-an-existing-project branch without driving the create flow first.
+// `status: 1` is ProjectStatus.InProgress and `viewStatus: 3` is
+// ProjectViewStatus.Private - the API takes enums as their numeric value.
+Cypress.Commands.add('createProject', (name) => {
+  return cy
+    .request({
+      method: 'POST',
+      url: `${apiUrl()}/api/Projects`,
+      headers: { 'X-Dev-User-Id': '1' },
+      body: { name, status: 1, viewStatus: 3 },
+    })
+    .then((response) => response.body);
+});
+
 Cypress.Commands.add('openFilterPanel', () => {
   cy.get('#filter-panel').then(($panel) => {
     if (!$panel.hasClass('filter-panel--open')) {

--- a/cypress/support/index.d.ts
+++ b/cypress/support/index.d.ts
@@ -4,6 +4,7 @@ declare namespace Cypress {
     createPrint(title: string, options?: { printer?: string }): Chainable<void>;
     openFilterPanel(): Chainable<void>;
     seedPublicPrintFixture(): Chainable<any>;
+    createProject(name: string): Chainable<any>;
     checkA11yWithReport(
       context?: any,
       options?: import('axe-core').RunOptions & {

--- a/src/app/core/services/print.service.spec.ts
+++ b/src/app/core/services/print.service.spec.ts
@@ -7,7 +7,8 @@ import {
   provideHttpClient,
   withInterceptorsFromDi,
 } from '@angular/common/http';
-import { PrintService } from './print.service';
+import { BulkPrintResult, PrintService, PrintStatus } from './print.service';
+import { environment } from 'src/environments/environment';
 
 describe('PrintService', () => {
   let service: PrintService;
@@ -173,6 +174,63 @@ describe('PrintService', () => {
         expect(result.usesDefaultWattage).toBeTrue();
         expect(result.wattageW).toBe(150);
       }
+    });
+  });
+
+  // Scoped so httpMock.verify() applies only to the requests these specs make.
+  describe('bulk endpoints', () => {
+    let httpMock: HttpTestingController;
+
+    beforeEach(() => {
+      httpMock = TestBed.inject(HttpTestingController);
+    });
+
+    afterEach(() => httpMock.verify());
+
+    it('posts a bulk update with numeric enum values', () => {
+      const result: BulkPrintResult = { succeeded: [1, 2], failed: [] };
+      let actual: BulkPrintResult | undefined;
+
+      service
+        .bulkUpdatePrints({
+          printIds: [1, 2],
+          status: PrintStatus.Success,
+          projectId: 'a-project-id',
+        })
+        .subscribe((r) => (actual = r));
+
+      const req = httpMock.expectOne(
+        `${environment.printLogApiUrl}/api/Prints/bulk-update`
+      );
+      expect(req.request.method).toBe('POST');
+      // The API registers no string enum converter - enums must go over the wire as numbers.
+      expect(req.request.body).toEqual({
+        printIds: [1, 2],
+        status: 3,
+        projectId: 'a-project-id',
+      });
+
+      req.flush(result);
+      expect(actual).toEqual(result);
+    });
+
+    it('posts a bulk delete', () => {
+      const result: BulkPrintResult = {
+        succeeded: [1],
+        failed: [{ id: 2, reason: 'Forbidden' }],
+      };
+      let actual: BulkPrintResult | undefined;
+
+      service.bulkDeletePrints([1, 2]).subscribe((r) => (actual = r));
+
+      const req = httpMock.expectOne(
+        `${environment.printLogApiUrl}/api/Prints/bulk-delete`
+      );
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({ printIds: [1, 2] });
+
+      req.flush(result);
+      expect(actual).toEqual(result);
     });
   });
 });

--- a/src/app/core/services/print.service.spec.ts
+++ b/src/app/core/services/print.service.spec.ts
@@ -7,7 +7,12 @@ import {
   provideHttpClient,
   withInterceptorsFromDi,
 } from '@angular/common/http';
-import { BulkPrintResult, PrintService, PrintStatus } from './print.service';
+import {
+  BulkPrintResult,
+  PrintService,
+  PrintStatus,
+  PrintViewStatus,
+} from './print.service';
 import { environment } from 'src/environments/environment';
 
 describe('PrintService', () => {
@@ -212,6 +217,20 @@ describe('PrintService', () => {
 
       req.flush(result);
       expect(actual).toEqual(result);
+    });
+
+    it('sends viewStatus as a number too', () => {
+      // status was already covered; viewStatus is a separate enum and would
+      // serialize just as wrongly on its own if a converter were added.
+      service
+        .bulkUpdatePrints({ printIds: [1], viewStatus: PrintViewStatus.Public })
+        .subscribe();
+
+      const req = httpMock.expectOne(
+        `${environment.printLogApiUrl}/api/Prints/bulk-update`
+      );
+      expect(req.request.body).toEqual({ printIds: [1], viewStatus: 1 });
+      req.flush({ succeeded: [1], failed: [] });
     });
 
     it('posts a bulk delete', () => {

--- a/src/app/core/services/print.service.ts
+++ b/src/app/core/services/print.service.ts
@@ -36,6 +36,33 @@ export enum PrintViewStatus {
   Private = 3,
 }
 
+/**
+ * One set of field values to apply to many prints. Every field is optional; omitted
+ * fields are left untouched. Enums serialize as their numeric value, matching the API,
+ * which registers no string enum converter.
+ */
+export interface BulkUpdatePrintsRequest {
+  printIds: number[];
+  status?: PrintStatus;
+  projectId?: string;
+  viewStatus?: PrintViewStatus;
+  printerId?: number;
+  allowComments?: boolean;
+  allowFileDownloads?: boolean;
+  /** Fields to reset to null. Only `projectId` is clearable. */
+  clear?: 'projectId'[];
+}
+
+/**
+ * The per-id outcome of a bulk operation. The request is a 200 even when some ids could
+ * not be acted on, so this body is what says which. `reason` is either "NotFound" or
+ * "Forbidden".
+ */
+export interface BulkPrintResult {
+  succeeded: number[];
+  failed: { id: number; reason: string }[];
+}
+
 export enum PrintFilamentSourceMeasurement {
   AsRecorded = 0,
   Weight = 1,
@@ -459,6 +486,26 @@ export class PrintService {
   public updatePrintStatus(id: number, newStatus: PrintStatus) {
     const url = `${this.baseApi}/api/Prints/${id}/status/${newStatus}`;
     return this.http.put<any>(url, {});
+  }
+
+  /**
+   * Applies one set of field values to many prints in a single request. Individual ids
+   * that could not be acted on come back in `failed`; the request itself is still a 200.
+   */
+  public bulkUpdatePrints(
+    request: BulkUpdatePrintsRequest
+  ): Observable<BulkPrintResult> {
+    const url = `${this.baseApi}/api/Prints/bulk-update`;
+    return this.http.post<BulkPrintResult>(url, request);
+  }
+
+  /**
+   * Deletes many prints in a single request. An id that no longer exists comes back in
+   * `succeeded` - the goal state is that the print is gone.
+   */
+  public bulkDeletePrints(printIds: number[]): Observable<BulkPrintResult> {
+    const url = `${this.baseApi}/api/Prints/bulk-delete`;
+    return this.http.post<BulkPrintResult>(url, { printIds });
   }
 
   deletePrint(id: number): Observable<any> {

--- a/src/app/documentation/docs/docs-prints/docs-prints.component.html
+++ b/src/app/documentation/docs/docs-prints/docs-prints.component.html
@@ -121,27 +121,51 @@
   </p>
   <p>
     As soon as one print is selected, a chip showing how many prints are
-    selected appears next to the view toggle, along with these actions:
+    selected appears next to the view toggle, along with an
+    <mat-icon inline="true">checklist</mat-icon> <strong>Actions</strong> button
+    and a <mat-icon inline="true">close</mat-icon> <strong>Clear</strong> button.
+    The Actions button carries the count, so you can always see how many prints
+    you are about to change, and the menu repeats it at the top. Clear deselects
+    everything.
   </p>
+  <p>The Actions menu offers:</p>
   <ul>
     <li>
       <strong>Set status</strong> - Applies the status you pick to every
       selected print.
     </li>
     <li>
-      <mat-icon inline="true">delete</mat-icon> <strong>Delete</strong> - Asks
-      you to confirm, then permanently deletes every selected print.
+      <strong>Add to project</strong> - Files every selected print under one
+      project. Pick a project you already have, or type a new name and it will
+      be created for you. Prints already in another project will be moved.
     </li>
     <li>
-      <mat-icon inline="true">close</mat-icon>
-      <strong>Clear</strong> - Deselects everything.
+      <strong>Visibility</strong> - Sets every selected print to Public,
+      Unlisted, or Private.
+    </li>
+    <li>
+      <strong>Printer</strong> - Moves every selected print onto a different
+      printer, for when a batch was logged against the wrong machine.
+    </li>
+    <li>
+      <strong>Permissions</strong> - Allows or disallows comments and file
+      downloads across the selection.
+    </li>
+    <li>
+      <strong>Delete</strong> - Asks you to confirm, then permanently deletes
+      every selected print.
     </li>
   </ul>
   <p>
-    Prints are updated one at a time, and a progress bar shows how far along the
-    batch is. If one print cannot be updated, the rest of the batch still runs.
-    You will see how many succeeded and how many failed, and the prints that
-    failed stay selected so you can try them again.
+    To take prints back out of a project, open <strong>Add to project</strong>
+    and choose <strong>Remove from project</strong>. The prints keep everything
+    else about them; they simply stop belonging to a project.
+  </p>
+  <p>
+    A progress bar shows how far along the batch is. If one print cannot be
+    updated, the rest of the batch still runs. You will see how many succeeded
+    and how many failed, and the prints that failed stay selected so you can try
+    them again.
   </p>
   <p>
     The header checkbox only covers the page in front of you, but your selection

--- a/src/app/documentation/docs/docs-prints/docs-prints.component.spec.ts
+++ b/src/app/documentation/docs/docs-prints/docs-prints.component.spec.ts
@@ -21,4 +21,17 @@ describe('DocsPrintsComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  // "The component can be created" would still pass with the whole bulk actions
+  // section deleted, so this asserts on the copy itself.
+  it('documents the bulk actions', () => {
+    const text: string = fixture.nativeElement.textContent;
+
+    expect(text).toContain('Add to project');
+    expect(text).toContain('Prints already in another project will be moved');
+    expect(text).toContain('Remove from project');
+    expect(text).toContain('Visibility');
+    expect(text).toContain('Printer');
+    expect(text).toContain('Permissions');
+  });
 });

--- a/src/app/print/print-list/print-bulk-action-bar/print-bulk-action-bar.component.html
+++ b/src/app/print/print-list/print-bulk-action-bar/print-bulk-action-bar.component.html
@@ -68,6 +68,120 @@
       <button
         mat-stroked-button
         type="button"
+        [disabled]="bulkActions.isRunning() || !bulkActions.hasSelection()"
+        (click)="addToProject()"
+        attr.aria-label="Add {{ bulkActions.selectedCount() }} selected {{
+          bulkActions.selectedCount() === 1 ? 'print' : 'prints'
+        }} to a project"
+        data-cy-bulk-add-to-project
+      >
+        <mat-icon>folder</mat-icon>
+        Add to project ({{ bulkActions.selectedCount() }})
+      </button>
+
+      <button
+        mat-stroked-button
+        type="button"
+        [matMenuTriggerFor]="bulkMoreMenu"
+        [disabled]="bulkActions.isRunning() || !bulkActions.hasSelection()"
+        attr.aria-label="More actions for {{
+          bulkActions.selectedCount()
+        }} selected {{
+          bulkActions.selectedCount() === 1 ? 'print' : 'prints'
+        }}"
+        data-cy-bulk-more
+      >
+        <mat-icon>more_horiz</mat-icon>
+        More ({{ bulkActions.selectedCount() }})
+      </button>
+      <mat-menu #bulkMoreMenu="matMenu">
+        <button mat-menu-item [matMenuTriggerFor]="bulkVisibilityMenu">
+          <mat-icon>visibility</mat-icon>Visibility
+        </button>
+        @if (printers().length > 0) {
+          <button mat-menu-item [matMenuTriggerFor]="bulkPrinterMenu">
+            <mat-icon>print</mat-icon>Printer
+          </button>
+        }
+        <button mat-menu-item [matMenuTriggerFor]="bulkPermissionsMenu">
+          <mat-icon>tune</mat-icon>Permissions
+        </button>
+      </mat-menu>
+
+      <mat-menu #bulkVisibilityMenu="matMenu">
+        @for (option of visibilityOptions; track option.viewStatus) {
+          <button
+            type="button"
+            mat-menu-item
+            attr.aria-label="{{ option.label }} - set the visibility of {{
+              bulkActions.selectedCount()
+            }} selected {{
+              bulkActions.selectedCount() === 1 ? 'print' : 'prints'
+            }}"
+            attr.data-cy-bulk-visibility="{{ option.label }}"
+            (click)="setVisibility(option)"
+          >
+            <mat-icon>{{ option.icon }}</mat-icon>{{ option.label }}
+          </button>
+        }
+      </mat-menu>
+
+      <mat-menu #bulkPrinterMenu="matMenu">
+        @for (printer of printers(); track printer.id) {
+          <button
+            type="button"
+            mat-menu-item
+            attr.aria-label="{{ printer.name }} - reassign {{
+              bulkActions.selectedCount()
+            }} selected {{
+              bulkActions.selectedCount() === 1 ? 'print' : 'prints'
+            }} to this printer"
+            attr.data-cy-bulk-printer="{{ printer.name }}"
+            (click)="setPrinter(printer)"
+          >
+            <mat-icon>print</mat-icon>{{ printer.name }}
+          </button>
+        }
+      </mat-menu>
+
+      <mat-menu #bulkPermissionsMenu="matMenu">
+        <button
+          type="button"
+          mat-menu-item
+          (click)="setPermission({ allowComments: true })"
+          data-cy-bulk-permission="allow-comments"
+        >
+          <mat-icon>chat</mat-icon>Allow comments
+        </button>
+        <button
+          type="button"
+          mat-menu-item
+          (click)="setPermission({ allowComments: false })"
+          data-cy-bulk-permission="disallow-comments"
+        >
+          <mat-icon>chat_bubble_outline</mat-icon>Don't allow comments
+        </button>
+        <button
+          type="button"
+          mat-menu-item
+          (click)="setPermission({ allowFileDownloads: true })"
+          data-cy-bulk-permission="allow-downloads"
+        >
+          <mat-icon>download</mat-icon>Allow file downloads
+        </button>
+        <button
+          type="button"
+          mat-menu-item
+          (click)="setPermission({ allowFileDownloads: false })"
+          data-cy-bulk-permission="disallow-downloads"
+        >
+          <mat-icon>file_download_off</mat-icon>Don't allow file downloads
+        </button>
+      </mat-menu>
+
+      <button
+        mat-stroked-button
+        type="button"
         color="warn"
         [disabled]="bulkActions.isRunning() || !bulkActions.hasSelection()"
         (click)="deleteSelected()"

--- a/src/app/print/print-list/print-bulk-action-bar/print-bulk-action-bar.component.html
+++ b/src/app/print/print-list/print-bulk-action-bar/print-bulk-action-bar.component.html
@@ -28,24 +28,105 @@
         }
       </span>
 
-      <!-- The count is repeated in every label: a bare "Delete" sitting in the
-           toolbar reads as a global action, and the chip alone is easy to skip
-           past on the way to the button. -->
+      <!-- One trigger rather than a row of them. Every action the bar offers now
+           lives behind it, which is what keeps the strip one row tall and keeps
+           Clear on screen no matter how many actions get added later. The count
+           rides on the trigger AND on the menu header, so "this affects N prints"
+           is visible both before the menu opens and while the choice is made. -->
       <button
         mat-stroked-button
         type="button"
-        [matMenuTriggerFor]="bulkStatusMenu"
+        [matMenuTriggerFor]="bulkActionsMenu"
         [disabled]="bulkActions.isRunning() || !bulkActions.hasSelection()"
-        attr.aria-label="Set status of {{
-          bulkActions.selectedCount()
-        }} selected {{
+        attr.aria-label="Actions for {{ bulkActions.selectedCount() }} selected {{
           bulkActions.selectedCount() === 1 ? 'print' : 'prints'
         }}"
-        data-cy-bulk-set-status
+        data-cy-bulk-actions
       >
-        <mat-icon>flag</mat-icon>
-        Set status ({{ bulkActions.selectedCount() }})
+        <mat-icon>checklist</mat-icon>
+        Actions ({{ bulkActions.selectedCount() }})
       </button>
+      <mat-menu #bulkActionsMenu="matMenu">
+        <div class="bulk-menu__header" aria-hidden="true">
+          {{ bulkActions.selectedCount() }} selected
+        </div>
+        <button
+          type="button"
+          mat-menu-item
+          [matMenuTriggerFor]="bulkStatusMenu"
+          attr.aria-label="Set status of {{
+            bulkActions.selectedCount()
+          }} selected {{
+            bulkActions.selectedCount() === 1 ? 'print' : 'prints'
+          }}"
+          data-cy-bulk-set-status
+        >
+          <mat-icon>flag</mat-icon>Set status
+        </button>
+        <button
+          type="button"
+          mat-menu-item
+          (click)="addToProject()"
+          attr.aria-label="Add {{ bulkActions.selectedCount() }} selected {{
+            bulkActions.selectedCount() === 1 ? 'print' : 'prints'
+          }} to a project"
+          data-cy-bulk-add-to-project
+        >
+          <mat-icon>folder</mat-icon>Add to project
+        </button>
+        <button
+          type="button"
+          mat-menu-item
+          [matMenuTriggerFor]="bulkVisibilityMenu"
+          attr.aria-label="Set visibility of {{
+            bulkActions.selectedCount()
+          }} selected {{
+            bulkActions.selectedCount() === 1 ? 'print' : 'prints'
+          }}"
+        >
+          <mat-icon>visibility</mat-icon>Visibility
+        </button>
+        @if (printers().length > 0) {
+          <button
+            type="button"
+            mat-menu-item
+            [matMenuTriggerFor]="bulkPrinterMenu"
+            attr.aria-label="Reassign {{
+              bulkActions.selectedCount()
+            }} selected {{
+              bulkActions.selectedCount() === 1 ? 'print' : 'prints'
+            }} to another printer"
+          >
+            <mat-icon>print</mat-icon>Printer
+          </button>
+        }
+        <button
+          type="button"
+          mat-menu-item
+          [matMenuTriggerFor]="bulkPermissionsMenu"
+          attr.aria-label="Set permissions on {{
+            bulkActions.selectedCount()
+          }} selected {{
+            bulkActions.selectedCount() === 1 ? 'print' : 'prints'
+          }}"
+        >
+          <mat-icon>tune</mat-icon>Permissions
+        </button>
+        <mat-divider />
+        <button
+          type="button"
+          mat-menu-item
+          class="bulk-menu__danger"
+          (click)="deleteSelected()"
+          attr.aria-label="Delete {{ bulkActions.selectedCount() }} selected {{
+            bulkActions.selectedCount() === 1 ? 'print' : 'prints'
+          }}"
+          data-cy-bulk-delete
+        >
+          <mat-icon>delete</mat-icon>Delete
+        </button>
+      </mat-menu>
+
       <mat-menu #bulkStatusMenu="matMenu">
         @for (option of statusOptions; track option.status) {
           <button
@@ -59,53 +140,9 @@
             attr.data-cy-bulk-status="{{ option.label }}"
             (click)="setStatus(option)"
           >
-            <mat-icon>{{ option.icon }}</mat-icon
-            >{{ option.label }}
+            <mat-icon>{{ option.icon }}</mat-icon>{{ option.label }}
           </button>
         }
-      </mat-menu>
-
-      <button
-        mat-stroked-button
-        type="button"
-        [disabled]="bulkActions.isRunning() || !bulkActions.hasSelection()"
-        (click)="addToProject()"
-        attr.aria-label="Add {{ bulkActions.selectedCount() }} selected {{
-          bulkActions.selectedCount() === 1 ? 'print' : 'prints'
-        }} to a project"
-        data-cy-bulk-add-to-project
-      >
-        <mat-icon>folder</mat-icon>
-        Add to project ({{ bulkActions.selectedCount() }})
-      </button>
-
-      <button
-        mat-stroked-button
-        type="button"
-        [matMenuTriggerFor]="bulkMoreMenu"
-        [disabled]="bulkActions.isRunning() || !bulkActions.hasSelection()"
-        attr.aria-label="More actions for {{
-          bulkActions.selectedCount()
-        }} selected {{
-          bulkActions.selectedCount() === 1 ? 'print' : 'prints'
-        }}"
-        data-cy-bulk-more
-      >
-        <mat-icon>more_horiz</mat-icon>
-        More ({{ bulkActions.selectedCount() }})
-      </button>
-      <mat-menu #bulkMoreMenu="matMenu">
-        <button mat-menu-item [matMenuTriggerFor]="bulkVisibilityMenu">
-          <mat-icon>visibility</mat-icon>Visibility
-        </button>
-        @if (printers().length > 0) {
-          <button mat-menu-item [matMenuTriggerFor]="bulkPrinterMenu">
-            <mat-icon>print</mat-icon>Printer
-          </button>
-        }
-        <button mat-menu-item [matMenuTriggerFor]="bulkPermissionsMenu">
-          <mat-icon>tune</mat-icon>Permissions
-        </button>
       </mat-menu>
 
       <mat-menu #bulkVisibilityMenu="matMenu">
@@ -178,21 +215,6 @@
           <mat-icon>file_download_off</mat-icon>Don't allow file downloads
         </button>
       </mat-menu>
-
-      <button
-        mat-stroked-button
-        type="button"
-        color="warn"
-        [disabled]="bulkActions.isRunning() || !bulkActions.hasSelection()"
-        (click)="deleteSelected()"
-        attr.aria-label="Delete {{ bulkActions.selectedCount() }} selected {{
-          bulkActions.selectedCount() === 1 ? 'print' : 'prints'
-        }}"
-        data-cy-bulk-delete
-      >
-        <mat-icon>delete</mat-icon>
-        Delete ({{ bulkActions.selectedCount() }})
-      </button>
 
       <button
         mat-button

--- a/src/app/print/print-list/print-bulk-action-bar/print-bulk-action-bar.component.html
+++ b/src/app/print/print-list/print-bulk-action-bar/print-bulk-action-bar.component.html
@@ -186,6 +186,9 @@
           type="button"
           mat-menu-item
           (click)="setPermission({ allowComments: true })"
+          attr.aria-label="Allow comments on {{ bulkActions.selectedCount() }} selected {{
+            bulkActions.selectedCount() === 1 ? 'print' : 'prints'
+          }}"
           data-cy-bulk-permission="allow-comments"
         >
           <mat-icon>chat</mat-icon>Allow comments
@@ -194,6 +197,9 @@
           type="button"
           mat-menu-item
           (click)="setPermission({ allowComments: false })"
+          attr.aria-label="Do not allow comments on {{ bulkActions.selectedCount() }} selected {{
+            bulkActions.selectedCount() === 1 ? 'print' : 'prints'
+          }}"
           data-cy-bulk-permission="disallow-comments"
         >
           <mat-icon>chat_bubble_outline</mat-icon>Don't allow comments
@@ -202,6 +208,9 @@
           type="button"
           mat-menu-item
           (click)="setPermission({ allowFileDownloads: true })"
+          attr.aria-label="Allow file downloads on {{ bulkActions.selectedCount() }} selected {{
+            bulkActions.selectedCount() === 1 ? 'print' : 'prints'
+          }}"
           data-cy-bulk-permission="allow-downloads"
         >
           <mat-icon>download</mat-icon>Allow file downloads
@@ -210,6 +219,9 @@
           type="button"
           mat-menu-item
           (click)="setPermission({ allowFileDownloads: false })"
+          attr.aria-label="Do not allow file downloads on {{ bulkActions.selectedCount() }} selected {{
+            bulkActions.selectedCount() === 1 ? 'print' : 'prints'
+          }}"
           data-cy-bulk-permission="disallow-downloads"
         >
           <mat-icon>file_download_off</mat-icon>Don't allow file downloads

--- a/src/app/print/print-list/print-bulk-action-bar/print-bulk-action-bar.component.scss
+++ b/src/app/print/print-list/print-bulk-action-bar/print-bulk-action-bar.component.scss
@@ -46,6 +46,25 @@
   color: var(--app-text-strong);
 }
 
+// The count again, at the moment the action is chosen. The trigger already
+// carries it, but the menu covers the trigger once it opens.
+.bulk-menu__header {
+  padding: 8px 16px;
+  font-size: 12px;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  opacity: 0.7;
+}
+
+.bulk-menu__danger {
+  color: var(--mat-sys-error, #b3261e);
+
+  mat-icon {
+    color: inherit;
+  }
+}
+
 .bulk-bar__clear {
   min-width: unset;
   padding: 0 8px;

--- a/src/app/print/print-list/print-bulk-action-bar/print-bulk-action-bar.component.spec.ts
+++ b/src/app/print/print-list/print-bulk-action-bar/print-bulk-action-bar.component.spec.ts
@@ -103,24 +103,34 @@ describe('PrintBulkActionBarComponent', () => {
     ).toContain('2 prints selected across all pages');
   });
 
-  it('carries the count into every action label', () => {
+  it('carries the count into the actions trigger and the open menu', () => {
     bulkActions.toggleSelectAllOnPage([printOne, printTwo]);
     fixture.detectChanges();
 
-    const bar = fixture.nativeElement.querySelector(
-      '[data-cy-bulk-action-bar]'
-    );
     // A bare "Delete" next to the table reads as a global action; the count is
-    // what ties the button to the selection.
-    expect(bar.querySelector('[data-cy-bulk-delete]').textContent).toContain(
-      'Delete (2)'
+    // what ties the actions to the selection. It has to be readable before the
+    // menu opens and again while the choice is being made, because the open
+    // menu covers the trigger that carried it.
+    const trigger = fixture.nativeElement.querySelector(
+      '[data-cy-bulk-actions]'
+    );
+    expect(trigger.textContent).toContain('Actions (2)');
+
+    trigger.click();
+    fixture.detectChanges();
+
+    const menu = document.querySelector('.mat-mdc-menu-panel')!;
+    expect(menu.querySelector('.bulk-menu__header')!.textContent).toContain(
+      '2 selected'
     );
     expect(
-      bar.querySelector('[data-cy-bulk-set-status]').textContent
-    ).toContain('Set status (2)');
-    expect(
-      bar.querySelector('[data-cy-bulk-delete]').getAttribute('aria-label')
+      menu.querySelector('[data-cy-bulk-delete]')!.getAttribute('aria-label')
     ).toBe('Delete 2 selected prints');
+    expect(
+      menu
+        .querySelector('[data-cy-bulk-set-status]')!
+        .getAttribute('aria-label')
+    ).toBe('Set status of 2 selected prints');
   });
 
   it('keeps the strip in the layout while nothing is selected', () => {

--- a/src/app/print/print-list/print-bulk-action-bar/print-bulk-action-bar.component.spec.ts
+++ b/src/app/print/print-list/print-bulk-action-bar/print-bulk-action-bar.component.spec.ts
@@ -8,7 +8,9 @@ import {
   PrintService,
   PrintStatus,
   PrintSummary,
+  PrintViewStatus,
 } from 'src/app/core/services/print.service';
+import { PrinterSummary } from 'src/app/core/services/printer.service';
 import {
   BulkActionResult,
   PrintBulkActionsService,
@@ -229,5 +231,114 @@ describe('PrintBulkActionBarComponent', () => {
     component.clearSelection();
 
     expect(bulkActions.hasSelection()).toBeFalse();
+  });
+
+  describe('the new field actions', () => {
+    /**
+     * Selects a print and stubs the batch method under test. The TestBed provides the
+     * REAL PrintBulkActionsService, so its methods are ordinary functions, not spies -
+     * and every action returns immediately when nothing is selected, so a test that
+     * forgets the selection asserts nothing.
+     */
+    function selectAndStub(method: keyof PrintBulkActionsService): jasmine.Spy {
+      bulkActions.toggleSelection(printOne);
+      fixture.detectChanges();
+      return spyOn(bulkActions, method as never).and.resolveTo({
+        succeededIds: [printOne.id],
+        failedIds: [],
+        failuresRetained: false,
+        errorMessage: null,
+      } as never);
+    }
+
+    it('opens the project dialog and assigns the chosen project', async () => {
+      const setProject = selectAndStub('setProjectForSelected');
+      dialogRef.afterClosed.and.returnValue(
+        of({ projectId: 'chosen-id', projectName: 'Benchies', created: false })
+      );
+
+      await component.addToProject();
+
+      expect(setProject).toHaveBeenCalledWith('chosen-id');
+    });
+
+    it('removes the project when the dialog asks for it', async () => {
+      const removeProject = selectAndStub('removeProjectFromSelected');
+      dialogRef.afterClosed.and.returnValue(of({ remove: true }));
+
+      await component.addToProject();
+
+      expect(removeProject).toHaveBeenCalled();
+    });
+
+    it('does nothing when the project dialog is cancelled', async () => {
+      const setProject = selectAndStub('setProjectForSelected');
+      dialogRef.afterClosed.and.returnValue(of(undefined));
+
+      await component.addToProject();
+
+      expect(setProject).not.toHaveBeenCalled();
+    });
+
+    it('names the newly created project when the assignment fails', async () => {
+      bulkActions.toggleSelection(printOne);
+      fixture.detectChanges();
+      spyOn(bulkActions, 'setProjectForSelected').and.resolveTo({
+        succeededIds: [],
+        failedIds: [printOne.id],
+        failuresRetained: true,
+        errorMessage: null,
+      });
+      dialogRef.afterClosed.and.returnValue(
+        of({ projectId: 'created-id', projectName: 'New Batch', created: true })
+      );
+
+      await component.addToProject();
+
+      // The project survives a failed assignment, so the message has to name it -
+      // otherwise the retry creates a second project with the same name.
+      expect(component.resultMessage()).toContain('New Batch');
+    });
+
+    it('sets visibility from the overflow menu', async () => {
+      const setViewStatus = selectAndStub('setViewStatusForSelected');
+
+      await component.setVisibility(component.visibilityOptions[0]);
+
+      expect(setViewStatus).toHaveBeenCalledWith(PrintViewStatus.Public);
+    });
+
+    it('reassigns the printer from the overflow menu', async () => {
+      const setPrinter = selectAndStub('setPrinterForSelected');
+
+      await component.setPrinter({ id: 7, name: 'Ender 3' } as PrinterSummary);
+
+      expect(setPrinter).toHaveBeenCalledWith(7);
+    });
+
+    it('sets permissions from the overflow menu', async () => {
+      const setPermissions = selectAndStub('setPermissionsForSelected');
+
+      await component.setPermission({ allowComments: true });
+
+      expect(setPermissions).toHaveBeenCalledWith({ allowComments: true });
+    });
+
+    it('does nothing when nothing is selected', async () => {
+      const setProject = spyOn(
+        bulkActions,
+        'setProjectForSelected'
+      ).and.resolveTo({
+        succeededIds: [],
+        failedIds: [],
+        failuresRetained: false,
+        errorMessage: null,
+      });
+
+      await component.addToProject();
+
+      expect(dialog.open).not.toHaveBeenCalled();
+      expect(setProject).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/print/print-list/print-bulk-action-bar/print-bulk-action-bar.component.spec.ts
+++ b/src/app/print/print-list/print-bulk-action-bar/print-bulk-action-bar.component.spec.ts
@@ -39,8 +39,8 @@ describe('PrintBulkActionBarComponent', () => {
 
   beforeEach(async () => {
     printService = jasmine.createSpyObj<PrintService>('PrintService', [
-      'updatePrintStatus',
-      'deletePrint',
+      'bulkUpdatePrints',
+      'bulkDeletePrints',
     ]);
     toastr = jasmine.createSpyObj<ToastrService>('ToastrService', [
       'success',
@@ -131,22 +131,25 @@ describe('PrintBulkActionBarComponent', () => {
 
   describe('set status', () => {
     it('updates every selected print and reports success', async () => {
-      printService.updatePrintStatus.and.returnValue(of({}));
+      printService.bulkUpdatePrints.and.returnValue(
+        of({ succeeded: [printOne.id, printTwo.id], failed: [] })
+      );
       bulkActions.toggleSelectAllOnPage([printOne, printTwo]);
 
       await component.setStatus(successStatusOption());
 
-      expect(printService.updatePrintStatus).toHaveBeenCalledTimes(2);
+      expect(printService.bulkUpdatePrints).toHaveBeenCalledTimes(1);
       expect(toastr.success).toHaveBeenCalled();
       expect(toastr.error).not.toHaveBeenCalled();
       expect(component.resultMessage()).toBe('2 prints updated.');
     });
 
     it('reports a partial failure and says the failures stay selected', async () => {
-      printService.updatePrintStatus.and.callFake((id: number) =>
-        id === printTwo.id
-          ? throwError(() => new Error('boom'))
-          : (of({}) as any)
+      printService.bulkUpdatePrints.and.returnValue(
+        of({
+          succeeded: [printOne.id],
+          failed: [{ id: printTwo.id, reason: 'Forbidden' }],
+        })
       );
       bulkActions.toggleSelectAllOnPage([printOne, printTwo]);
 
@@ -160,7 +163,9 @@ describe('PrintBulkActionBarComponent', () => {
     });
 
     it('emits batchCompleted so the list can refresh', async () => {
-      printService.updatePrintStatus.and.returnValue(of({}));
+      printService.bulkUpdatePrints.and.returnValue(
+        of({ succeeded: [printOne.id], failed: [] })
+      );
       bulkActions.toggleSelection(printOne);
 
       let emitted: BulkActionResult | null = null;
@@ -172,13 +177,16 @@ describe('PrintBulkActionBarComponent', () => {
         succeededIds: [printOne.id],
         failedIds: [],
         failuresRetained: false,
+        errorMessage: null,
       });
     });
   });
 
   describe('delete', () => {
     it('confirms with a dialog naming the count before deleting', async () => {
-      printService.deletePrint.and.returnValue(of({}));
+      printService.bulkDeletePrints.and.returnValue(
+        of({ succeeded: [printOne.id, printTwo.id], failed: [] })
+      );
       bulkActions.toggleSelectAllOnPage([printOne, printTwo]);
 
       await component.deleteSelected();
@@ -187,11 +195,16 @@ describe('PrintBulkActionBarComponent', () => {
       expect(dialogRef.componentInstance['title']).toBe('Delete?');
       expect(dialogRef.componentInstance['body']).toContain('2 prints');
       expect(dialogRef.componentInstance['yesText']).toBe('Delete');
-      expect(printService.deletePrint).toHaveBeenCalledTimes(2);
+      expect(printService.bulkDeletePrints).toHaveBeenCalledWith([
+        printOne.id,
+        printTwo.id,
+      ]);
     });
 
     it('uses the singular noun for a single print', async () => {
-      printService.deletePrint.and.returnValue(of({}));
+      printService.bulkDeletePrints.and.returnValue(
+        of({ succeeded: [printOne.id], failed: [] })
+      );
       bulkActions.toggleSelection(printOne);
 
       await component.deleteSelected();
@@ -205,7 +218,7 @@ describe('PrintBulkActionBarComponent', () => {
 
       await component.deleteSelected();
 
-      expect(printService.deletePrint).not.toHaveBeenCalled();
+      expect(printService.bulkDeletePrints).not.toHaveBeenCalled();
       expect(bulkActions.selectedCount()).toBe(2);
     });
   });

--- a/src/app/print/print-list/print-bulk-action-bar/print-bulk-action-bar.component.ts
+++ b/src/app/print/print-list/print-bulk-action-bar/print-bulk-action-bar.component.ts
@@ -163,7 +163,11 @@ export class PrintBulkActionBarComponent {
       const retryHint = result.failuresRetained
         ? ' The prints that failed are still selected.'
         : '';
-      const message = `${succeeded} ${pastTenseVerb}, ${failed} failed.${retryHint}`;
+      // A 400 means the API refused the request itself and said why - its reason is
+      // more useful than a count of prints that never got sent.
+      const message = result.errorMessage
+        ? `${result.errorMessage}${retryHint}`
+        : `${succeeded} ${pastTenseVerb}, ${failed} failed.${retryHint}`;
       this.resultMessage.set(message);
       this.toastrService.error(
         message,

--- a/src/app/print/print-list/print-bulk-action-bar/print-bulk-action-bar.component.ts
+++ b/src/app/print/print-list/print-bulk-action-bar/print-bulk-action-bar.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   inject,
+  input,
   output,
   signal,
 } from '@angular/core';
@@ -14,12 +15,20 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { ToastrService } from 'ngx-toastr';
 import { firstValueFrom } from 'rxjs';
 import { LoggingService } from 'src/app/core/services/logging.service';
-import { PrintStatus } from 'src/app/core/services/print.service';
+import {
+  PrintStatus,
+  PrintViewStatus,
+} from 'src/app/core/services/print.service';
+import { PrinterSummary } from 'src/app/core/services/printer.service';
 import { SimpleDialogComponent } from 'src/app/shared/simple-dialog/simple-dialog.component';
 import {
   BulkActionResult,
   PrintBulkActionsService,
 } from '../../services/print-bulk-actions.service';
+import {
+  PrintBulkProjectDialogComponent,
+  PrintBulkProjectDialogResult,
+} from '../print-bulk-project-dialog/print-bulk-project-dialog.component';
 
 interface StatusOption {
   status: PrintStatus;
@@ -27,10 +36,17 @@ interface StatusOption {
   icon: string;
 }
 
+interface VisibilityOption {
+  viewStatus: PrintViewStatus;
+  label: string;
+  icon: string;
+}
+
 /**
  * Contextual controls shown in the print list toolbar while one or more prints are
- * selected. Offers a bulk status change and a bulk delete, both of which run as
- * sequential batches against the single-item API endpoints.
+ * selected. Offers a bulk status change, an add-to-project, a delete, and an overflow
+ * menu for visibility, printer and permissions - all of which run as chunked requests
+ * against the bulk API endpoints.
  *
  * The host keeps a constant height and the progress bar is overlaid rather than
  * stacked, so nothing here moves the table when a selection appears or clears.
@@ -54,8 +70,17 @@ export class PrintBulkActionBarComponent {
   private readonly toastrService = inject(ToastrService);
   private readonly loggingService = inject(LoggingService);
 
+  /** The user's printers, passed down from the list's resolver data - no extra request. */
+  public readonly printers = input<PrinterSummary[]>([]);
+
   /** Emitted after a batch finishes so the list can reload its current page. */
   public readonly batchCompleted = output<BulkActionResult>();
+
+  public readonly visibilityOptions: VisibilityOption[] = [
+    { viewStatus: PrintViewStatus.Public, label: 'Public', icon: 'public' },
+    { viewStatus: PrintViewStatus.Unlisted, label: 'Unlisted', icon: 'link' },
+    { viewStatus: PrintViewStatus.Private, label: 'Private', icon: 'lock' },
+  ];
 
   /** The result sentence, mirrored into the live region for screen readers. */
   public readonly resultMessage = signal('');
@@ -103,6 +128,116 @@ export class PrintBulkActionBarComponent {
 
     const result = await this.bulkActions.setStatusForSelected(option.status);
     this.reportOutcome(result, `set to ${option.label}`, 'updated');
+  }
+
+  /**
+   * Opens the project picker and files the selection under whatever it returns. The dialog
+   * resolves a typed-in name to a created project before it closes, so this only ever
+   * deals in ids - a chunked batch cannot create one project per chunk.
+   */
+  public async addToProject(): Promise<void> {
+    const attempted = this.bulkActions.selectedCount();
+    if (attempted === 0 || this.bulkActions.isRunning()) {
+      return;
+    }
+
+    this.loggingService.logEvent('PrintBulkActionBar_SetProjectStarted', {
+      count: attempted,
+    });
+
+    const dialogRef = this.dialog.open(PrintBulkProjectDialogComponent, {
+      width: '420px',
+      data: { count: attempted },
+    });
+
+    const choice: PrintBulkProjectDialogResult | undefined =
+      await firstValueFrom(dialogRef.afterClosed());
+
+    if (!choice) {
+      return;
+    }
+
+    this.resultMessage.set('');
+
+    if ('remove' in choice) {
+      this.loggingService.logEvent('PrintBulkActionBar_RemoveProjectStarted', {
+        count: attempted,
+      });
+      const removed = await this.bulkActions.removeProjectFromSelected();
+      this.reportOutcome(removed, 'removed from their project', 'updated');
+      return;
+    }
+
+    const result = await this.bulkActions.setProjectForSelected(
+      choice.projectId
+    );
+
+    // A project created for this batch outlives a failed assignment on purpose - deleting
+    // it would be destructive on a guess, since part of the batch may already be filed.
+    // Naming it is what stops the retry from creating a second one under the same name.
+    if (choice.created && result.succeededIds.length === 0) {
+      this.resultMessage.set(
+        `The project "${choice.projectName}" was created, but no prints could be added to it. ` +
+          'Pick it from the list to try again.'
+      );
+      this.toastrService.error(
+        this.resultMessage(),
+        'Could not add to the project'
+      );
+      this.batchCompleted.emit(result);
+      return;
+    }
+
+    this.reportOutcome(result, 'added to the project', 'updated');
+  }
+
+  /** Sets who can see every selected print. */
+  public async setVisibility(option: VisibilityOption): Promise<void> {
+    const attempted = this.bulkActions.selectedCount();
+    if (attempted === 0 || this.bulkActions.isRunning()) {
+      return;
+    }
+    this.loggingService.logEvent('PrintBulkActionBar_SetVisibilityStarted', {
+      count: attempted,
+      visibility: option.label,
+    });
+    this.resultMessage.set('');
+    const result = await this.bulkActions.setViewStatusForSelected(
+      option.viewStatus
+    );
+    this.reportOutcome(result, `set to ${option.label}`, 'updated');
+  }
+
+  /** Moves every selected print onto another of the user's printers. */
+  public async setPrinter(printer: PrinterSummary): Promise<void> {
+    const attempted = this.bulkActions.selectedCount();
+    if (attempted === 0 || this.bulkActions.isRunning()) {
+      return;
+    }
+    this.loggingService.logEvent('PrintBulkActionBar_SetPrinterStarted', {
+      count: attempted,
+    });
+    this.resultMessage.set('');
+    const result = await this.bulkActions.setPrinterForSelected(printer.id);
+    this.reportOutcome(result, `moved to ${printer.name}`, 'updated');
+  }
+
+  /** Sets only the permissions named in `patch`; the others are left alone. */
+  public async setPermission(patch: {
+    allowComments?: boolean;
+    allowFileDownloads?: boolean;
+  }): Promise<void> {
+    const attempted = this.bulkActions.selectedCount();
+    if (attempted === 0 || this.bulkActions.isRunning()) {
+      return;
+    }
+    this.loggingService.logEvent('PrintBulkActionBar_SetPermissionsStarted', {
+      count: attempted,
+      fields: Object.keys(patch).join(','),
+    });
+    this.resultMessage.set('');
+    const result = await this.bulkActions.setPermissionsForSelected(patch);
+    this.reportOutcome(result, 'updated', 'updated');
   }
 
   public async deleteSelected(): Promise<void> {

--- a/src/app/print/print-list/print-bulk-action-bar/print-bulk-action-bar.component.ts
+++ b/src/app/print/print-list/print-bulk-action-bar/print-bulk-action-bar.component.ts
@@ -8,6 +8,7 @@ import {
 } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog } from '@angular/material/dialog';
+import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatProgressBarModule } from '@angular/material/progress-bar';
@@ -58,6 +59,7 @@ interface VisibilityOption {
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     MatButtonModule,
+    MatDividerModule,
     MatIconModule,
     MatMenuModule,
     MatProgressBarModule,

--- a/src/app/print/print-list/print-bulk-project-dialog/print-bulk-project-dialog.component.html
+++ b/src/app/print/print-list/print-bulk-project-dialog/print-bulk-project-dialog.component.html
@@ -17,6 +17,7 @@
   <button
     mat-button
     type="button"
+    [disabled]="isSaving()"
     (click)="removeFromProject()"
     attr.aria-label="Remove {{ data.count }} selected {{
       data.count === 1 ? 'print' : 'prints'
@@ -25,7 +26,11 @@
   >
     Remove from project
   </button>
-  <button mat-button type="button" (click)="cancel()">Cancel</button>
+  <!-- Disabled while the create is in flight: closing now would leave a project
+       created and nothing assigned to it. -->
+  <button mat-button type="button" [disabled]="isSaving()" (click)="cancel()">
+    Cancel
+  </button>
   <button
     mat-flat-button
     type="button"

--- a/src/app/print/print-list/print-bulk-project-dialog/print-bulk-project-dialog.component.html
+++ b/src/app/print/print-list/print-bulk-project-dialog/print-bulk-project-dialog.component.html
@@ -1,0 +1,39 @@
+<h2 mat-dialog-title>Add to project</h2>
+
+<mat-dialog-content>
+  <p>
+    {{ data.count }} {{ data.count === 1 ? 'print' : 'prints' }} will be filed
+    under the project you pick. Prints already in another project will be moved.
+  </p>
+
+  <app-project-selector (projectSelected)="onSelection($event)" />
+
+  @if (errorMessage()) {
+    <p class="dialog__error" role="alert">{{ errorMessage() }}</p>
+  }
+</mat-dialog-content>
+
+<mat-dialog-actions align="end">
+  <button
+    mat-button
+    type="button"
+    (click)="removeFromProject()"
+    attr.aria-label="Remove {{ data.count }} selected {{
+      data.count === 1 ? 'print' : 'prints'
+    }} from their project"
+    data-cy-bulk-project-remove
+  >
+    Remove from project
+  </button>
+  <button mat-button type="button" (click)="cancel()">Cancel</button>
+  <button
+    mat-flat-button
+    type="button"
+    color="primary"
+    [disabled]="!selection() || isSaving()"
+    (click)="confirm()"
+    data-cy-bulk-project-confirm
+  >
+    Add to project
+  </button>
+</mat-dialog-actions>

--- a/src/app/print/print-list/print-bulk-project-dialog/print-bulk-project-dialog.component.scss
+++ b/src/app/print/print-list/print-bulk-project-dialog/print-bulk-project-dialog.component.scss
@@ -1,0 +1,4 @@
+.dialog__error {
+  color: var(--mat-sys-error, #b3261e);
+  margin-top: 0.5rem;
+}

--- a/src/app/print/print-list/print-bulk-project-dialog/print-bulk-project-dialog.component.spec.ts
+++ b/src/app/print/print-list/print-bulk-project-dialog/print-bulk-project-dialog.component.spec.ts
@@ -1,0 +1,111 @@
+import { TestBed } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { of, throwError } from 'rxjs';
+import {
+  ProjectService,
+  ProjectStatus,
+  ProjectViewStatus,
+} from 'src/app/core/services/project.service';
+import { PrintBulkProjectDialogComponent } from './print-bulk-project-dialog.component';
+
+describe('PrintBulkProjectDialogComponent', () => {
+  let projectService: jasmine.SpyObj<ProjectService>;
+  let dialogRef: jasmine.SpyObj<MatDialogRef<PrintBulkProjectDialogComponent>>;
+
+  beforeEach(async () => {
+    projectService = jasmine.createSpyObj<ProjectService>('ProjectService', [
+      'createProject',
+      'getProjectSummaries',
+    ]);
+    // ProjectSelectorComponent calls getProjectSummaries on init and expects a PagedList.
+    projectService.getProjectSummaries.and.returnValue(
+      of({
+        paging: { currentPage: 1, totalPages: 1, pageSize: 25, totalCount: 0 },
+        items: [],
+      })
+    );
+    dialogRef = jasmine.createSpyObj<
+      MatDialogRef<PrintBulkProjectDialogComponent>
+    >('MatDialogRef', ['close']);
+
+    await TestBed.configureTestingModule({
+      imports: [PrintBulkProjectDialogComponent, NoopAnimationsModule],
+      providers: [
+        { provide: ProjectService, useValue: projectService },
+        { provide: MatDialogRef, useValue: dialogRef },
+        { provide: MAT_DIALOG_DATA, useValue: { count: 3 } },
+      ],
+    }).compileComponents();
+  });
+
+  function createComponent() {
+    const fixture = TestBed.createComponent(PrintBulkProjectDialogComponent);
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('closes with the id when an existing project is chosen', async () => {
+    const fixture = createComponent();
+    const component = fixture.componentInstance;
+
+    component.onSelection({
+      type: 'existing',
+      projectId: 'existing-id',
+      projectName: 'Benchies',
+    });
+    await component.confirm();
+
+    expect(projectService.createProject).not.toHaveBeenCalled();
+    expect(dialogRef.close).toHaveBeenCalledWith({
+      projectId: 'existing-id',
+      projectName: 'Benchies',
+      created: false,
+    });
+  });
+
+  it('creates the project once when a new name is typed, then closes with its id', async () => {
+    projectService.createProject.and.returnValue(
+      of({ id: 'created-id', name: 'New Batch' } as never)
+    );
+    const fixture = createComponent();
+    const component = fixture.componentInstance;
+
+    component.onSelection({ type: 'new', newProjectName: 'New Batch' });
+    await component.confirm();
+
+    expect(projectService.createProject).toHaveBeenCalledTimes(1);
+    expect(projectService.createProject).toHaveBeenCalledWith({
+      name: 'New Batch',
+      status: ProjectStatus.InProgress,
+      viewStatus: ProjectViewStatus.Private,
+    });
+    expect(dialogRef.close).toHaveBeenCalledWith({
+      projectId: 'created-id',
+      projectName: 'New Batch',
+      created: true,
+    });
+  });
+
+  it('keeps the dialog open and shows an error when creating the project fails', async () => {
+    projectService.createProject.and.returnValue(
+      throwError(() => new Error('boom'))
+    );
+    const fixture = createComponent();
+    const component = fixture.componentInstance;
+
+    component.onSelection({ type: 'new', newProjectName: 'New Batch' });
+    await component.confirm();
+
+    expect(dialogRef.close).not.toHaveBeenCalled();
+    expect(component.errorMessage()).toContain('could not be created');
+  });
+
+  it('closes with a remove instruction', () => {
+    const fixture = createComponent();
+
+    fixture.componentInstance.removeFromProject();
+
+    expect(dialogRef.close).toHaveBeenCalledWith({ remove: true });
+  });
+});

--- a/src/app/print/print-list/print-bulk-project-dialog/print-bulk-project-dialog.component.ts
+++ b/src/app/print/print-list/print-bulk-project-dialog/print-bulk-project-dialog.component.ts
@@ -86,8 +86,14 @@ export class PrintBulkProjectDialogComponent {
       });
     } catch {
       // Stay open so the name is not lost and the user can retry or pick an existing one.
+      //
+      // The copy deliberately does not promise nothing was created. A request that
+      // times out or loses its response may well have committed, and telling the
+      // user "nothing was changed" is what sends them straight into creating a
+      // second project under the same name. Point them at the list instead.
       this.errorMessage.set(
-        `The project "${selection.newProjectName}" could not be created. Nothing was changed.`
+        `"${selection.newProjectName}" could not be created, and no prints were changed. ` +
+          'Search the list before trying again - if the project is there, pick it.'
       );
     } finally {
       this.isSaving.set(false);

--- a/src/app/print/print-list/print-bulk-project-dialog/print-bulk-project-dialog.component.ts
+++ b/src/app/print/print-list/print-bulk-project-dialog/print-bulk-project-dialog.component.ts
@@ -1,0 +1,104 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  signal,
+} from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogModule,
+  MatDialogRef,
+} from '@angular/material/dialog';
+import { firstValueFrom } from 'rxjs';
+import {
+  ProjectService,
+  ProjectStatus,
+  ProjectViewStatus,
+} from 'src/app/core/services/project.service';
+import {
+  ProjectSelection,
+  ProjectSelectorComponent,
+} from 'src/app/shared/project-selector/project-selector.component';
+
+export type PrintBulkProjectDialogResult =
+  | { projectId: string; projectName: string; created: boolean }
+  | { remove: true };
+
+/**
+ * Picks the project a bulk selection should be filed under.
+ *
+ * The "type a new name" branch is resolved here rather than on the wire: the dialog creates
+ * the project once and closes with its id, so the bulk endpoint only ever receives ids and
+ * a chunked batch cannot create one project per chunk.
+ */
+@Component({
+  selector: 'app-print-bulk-project-dialog',
+  templateUrl: './print-bulk-project-dialog.component.html',
+  styleUrls: ['./print-bulk-project-dialog.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [MatButtonModule, MatDialogModule, ProjectSelectorComponent],
+})
+export class PrintBulkProjectDialogComponent {
+  private readonly dialogRef =
+    inject<MatDialogRef<PrintBulkProjectDialogComponent>>(MatDialogRef);
+  private readonly projectService = inject(ProjectService);
+
+  public readonly data = inject<{ count: number }>(MAT_DIALOG_DATA);
+
+  public readonly selection = signal<ProjectSelection | null>(null);
+  public readonly isSaving = signal(false);
+  public readonly errorMessage = signal('');
+
+  public onSelection(selection: ProjectSelection | null): void {
+    this.selection.set(selection);
+    this.errorMessage.set('');
+  }
+
+  public async confirm(): Promise<void> {
+    const selection = this.selection();
+    if (!selection || this.isSaving()) {
+      return;
+    }
+
+    if (selection.type === 'existing') {
+      this.dialogRef.close({
+        projectId: selection.projectId,
+        projectName: selection.projectName,
+        created: false,
+      });
+      return;
+    }
+
+    this.isSaving.set(true);
+    try {
+      const created = await firstValueFrom(
+        this.projectService.createProject({
+          name: selection.newProjectName,
+          status: ProjectStatus.InProgress,
+          viewStatus: ProjectViewStatus.Private,
+        })
+      );
+      this.dialogRef.close({
+        projectId: created.id,
+        projectName: created.name,
+        created: true,
+      });
+    } catch {
+      // Stay open so the name is not lost and the user can retry or pick an existing one.
+      this.errorMessage.set(
+        `The project "${selection.newProjectName}" could not be created. Nothing was changed.`
+      );
+    } finally {
+      this.isSaving.set(false);
+    }
+  }
+
+  public removeFromProject(): void {
+    this.dialogRef.close({ remove: true });
+  }
+
+  public cancel(): void {
+    this.dialogRef.close();
+  }
+}

--- a/src/app/print/print-list/print-list.component.html
+++ b/src/app/print/print-list/print-list.component.html
@@ -169,6 +169,7 @@
       <!-- Desktop only, matching the table's breakpoint -->
       <app-print-bulk-action-bar
         fxHide.lt-md
+        [printers]="printers"
         (batchCompleted)="onBulkActionCompleted()"
       />
     }

--- a/src/app/print/services/print-bulk-actions.service.spec.ts
+++ b/src/app/print/services/print-bulk-actions.service.spec.ts
@@ -1,3 +1,4 @@
+import { HttpErrorResponse } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
 import { LoggingService } from 'src/app/core/services/logging.service';
@@ -5,6 +6,7 @@ import {
   PrintService,
   PrintStatus,
   PrintSummary,
+  PrintViewStatus,
 } from 'src/app/core/services/print.service';
 import { PrintBulkActionsService } from './print-bulk-actions.service';
 
@@ -23,8 +25,8 @@ describe('PrintBulkActionsService', () => {
 
   beforeEach(() => {
     printService = jasmine.createSpyObj<PrintService>('PrintService', [
-      'updatePrintStatus',
-      'deletePrint',
+      'bulkUpdatePrints',
+      'bulkDeletePrints',
     ]);
     logger = jasmine.createSpyObj<LoggingService>('LoggingService', [
       'logEvent',
@@ -127,25 +129,72 @@ describe('PrintBulkActionsService', () => {
     });
   });
 
+  function makePrints(count: number): PrintSummary[] {
+    return Array.from({ length: count }, (_, i) => makePrint(i + 1));
+  }
+
   describe('setStatusForSelected', () => {
-    it('calls the single-item endpoint once per selected print', async () => {
-      printService.updatePrintStatus.and.returnValue(of({}));
-      service.toggleSelectAllOnPage([printOne, printTwo]);
+    it('sends one request per 25-id chunk', async () => {
+      const prints = makePrints(60);
+      printService.bulkUpdatePrints.and.callFake((request) =>
+        of({ succeeded: request.printIds, failed: [] })
+      );
+      service.toggleSelectAllOnPage(prints);
 
       const result = await service.setStatusForSelected(PrintStatus.Success);
 
-      expect(printService.updatePrintStatus).toHaveBeenCalledTimes(2);
-      expect(printService.updatePrintStatus).toHaveBeenCalledWith(
-        printOne.id,
+      expect(printService.bulkUpdatePrints).toHaveBeenCalledTimes(3);
+      const sizes = printService.bulkUpdatePrints.calls
+        .allArgs()
+        .map(([request]) => request.printIds.length);
+      expect(sizes).toEqual([25, 25, 10]);
+      expect(printService.bulkUpdatePrints.calls.first().args[0].status).toBe(
         PrintStatus.Success
       );
-      expect(result.succeededIds).toEqual([printOne.id, printTwo.id]);
+      expect(result.succeededIds.length).toBe(60);
       expect(result.failedIds).toEqual([]);
-      expect(result.failuresRetained).toBeFalse();
+    });
+
+    // The off-by-one that matters: 25 must be one request, not two.
+    [
+      { count: 24, expected: [24] },
+      { count: 25, expected: [25] },
+      { count: 26, expected: [25, 1] },
+    ].forEach(({ count, expected }) => {
+      it(`splits ${count} ids into chunks of ${expected.join(' + ')}`, async () => {
+        printService.bulkUpdatePrints.and.callFake((request) =>
+          of({ succeeded: request.printIds, failed: [] })
+        );
+        service.toggleSelectAllOnPage(makePrints(count));
+
+        await service.setStatusForSelected(PrintStatus.Success);
+
+        const sizes = printService.bulkUpdatePrints.calls
+          .allArgs()
+          .map(([request]) => request.printIds.length);
+        expect(sizes).toEqual(expected);
+      });
+    });
+
+    it('sends a single request when the selection fits one chunk', async () => {
+      printService.bulkUpdatePrints.and.returnValue(
+        of({ succeeded: [1, 2], failed: [] })
+      );
+      service.toggleSelectAllOnPage([printOne, printTwo]);
+
+      await service.setStatusForSelected(PrintStatus.Success);
+
+      expect(printService.bulkUpdatePrints).toHaveBeenCalledTimes(1);
+      expect(printService.bulkUpdatePrints).toHaveBeenCalledWith({
+        printIds: [1, 2],
+        status: PrintStatus.Success,
+      });
     });
 
     it('clears the selection when everything succeeds', async () => {
-      printService.updatePrintStatus.and.returnValue(of({}));
+      printService.bulkUpdatePrints.and.returnValue(
+        of({ succeeded: [1, 2], failed: [] })
+      );
       service.toggleSelectAllOnPage([printOne, printTwo]);
 
       await service.setStatusForSelected(PrintStatus.Success);
@@ -153,62 +202,100 @@ describe('PrintBulkActionsService', () => {
       expect(service.hasSelection()).toBeFalse();
     });
 
-    it('continues the batch after a failure and keeps only the failures selected', async () => {
-      printService.updatePrintStatus.and.callFake((id: number) =>
-        id === printTwo.id
-          ? throwError(() => new Error('boom'))
-          : (of({}) as any)
+    it('reports per-id failures from the response and keeps them selected', async () => {
+      printService.bulkUpdatePrints.and.returnValue(
+        of({ succeeded: [1], failed: [{ id: 2, reason: 'Forbidden' }] })
       );
-      service.toggleSelectAllOnPage([printOne, printTwo, printThree]);
+      service.toggleSelectAllOnPage([printOne, printTwo]);
 
-      const result = await service.setStatusForSelected(PrintStatus.Failed);
+      const result = await service.setStatusForSelected(PrintStatus.Success);
 
-      // The failure in the middle did not abort the batch.
-      expect(printService.updatePrintStatus).toHaveBeenCalledTimes(3);
-      expect(result.succeededIds).toEqual([printOne.id, printThree.id]);
-      expect(result.failedIds).toEqual([printTwo.id]);
+      expect(result.succeededIds).toEqual([1]);
+      expect(result.failedIds).toEqual([2]);
       expect(result.failuresRetained).toBeTrue();
+      expect(service.isSelected(2)).toBeTrue();
+      expect(service.isSelected(1)).toBeFalse();
+    });
 
-      expect(service.selectedCount()).toBe(1);
-      expect(service.isSelected(printTwo.id)).toBeTrue();
+    it('fails only the chunk that errored and keeps going', async () => {
+      const prints = makePrints(30);
+      let call = 0;
+      printService.bulkUpdatePrints.and.callFake((request) => {
+        call++;
+        return call === 1
+          ? throwError(() => new HttpErrorResponse({ status: 500 }))
+          : of({ succeeded: request.printIds, failed: [] });
+      });
+      service.toggleSelectAllOnPage(prints);
+
+      const result = await service.setStatusForSelected(PrintStatus.Success);
+
+      expect(printService.bulkUpdatePrints).toHaveBeenCalledTimes(2);
+      expect(result.failedIds.length).toBe(25);
+      expect(result.succeededIds.length).toBe(5);
+    });
+
+    it('stops sending after a 400 and keeps completed chunks intact', async () => {
+      const prints = makePrints(75);
+      let call = 0;
+      printService.bulkUpdatePrints.and.callFake((request) => {
+        call++;
+        return call === 2
+          ? throwError(
+              () =>
+                new HttpErrorResponse({
+                  status: 400,
+                  error: { detail: 'Project not found.' },
+                })
+            )
+          : of({ succeeded: request.printIds, failed: [] });
+      });
+      service.toggleSelectAllOnPage(prints);
+
+      const result = await service.setStatusForSelected(PrintStatus.Success);
+
+      // Chunk one committed; chunk two failed; chunk three was never sent.
+      expect(printService.bulkUpdatePrints).toHaveBeenCalledTimes(2);
+      expect(result.succeededIds.length).toBe(25);
+      expect(result.failedIds.length).toBe(50);
+      expect(result.errorMessage).toBe('Project not found.');
     });
 
     it('leaves the selection alone when the user clears it mid-batch, and says so', async () => {
-      printService.updatePrintStatus.and.callFake((id: number) => {
+      printService.bulkUpdatePrints.and.callFake((request) => {
         // The user changes the result set (which clears the selection) while
         // the batch is still running.
         service.clearSelection();
-        return id === printOne.id
-          ? throwError(() => new Error('boom'))
-          : (of({}) as any);
+        return of({
+          succeeded: [],
+          failed: request.printIds.map((id) => ({ id, reason: 'Forbidden' })),
+        });
       });
       service.toggleSelectAllOnPage([printOne, printTwo]);
 
       const result = await service.setStatusForSelected(PrintStatus.Success);
 
       // The batch still finished from its own snapshot...
-      expect(result.failedIds).toEqual([printOne.id]);
+      expect(result.failedIds).toEqual([printOne.id, printTwo.id]);
       // ...but the user's clear wins, and the caller is told not to promise a retry.
       expect(result.failuresRetained).toBeFalse();
       expect(service.hasSelection()).toBeFalse();
     });
 
-    it('never swallows an error - each failure is logged', async () => {
-      printService.updatePrintStatus.and.returnValue(
-        throwError(() => new Error('boom'))
+    it('never swallows an error - each failed request is logged', async () => {
+      printService.bulkUpdatePrints.and.returnValue(
+        throwError(() => new HttpErrorResponse({ status: 500 }))
       );
       service.toggleSelectAllOnPage([printOne, printTwo]);
 
       await service.setStatusForSelected(PrintStatus.Failed);
 
-      expect(logger.logException).toHaveBeenCalledTimes(2);
+      expect(logger.logException).toHaveBeenCalledTimes(1);
     });
 
     it('logs the outcome with counts', async () => {
-      printService.updatePrintStatus.and.callFake((id: number) =>
-        id === printOne.id
-          ? throwError(() => new Error('boom'))
-          : (of({}) as any)
+      printService.bulkUpdatePrints.and.returnValue(
+        of({ succeeded: [1], failed: [{ id: 2, reason: 'NotFound' }] })
       );
       service.toggleSelectAllOnPage([printOne, printTwo]);
 
@@ -221,7 +308,9 @@ describe('PrintBulkActionsService', () => {
     });
 
     it('reports determinate progress and stops running when finished', async () => {
-      printService.updatePrintStatus.and.returnValue(of({}));
+      printService.bulkUpdatePrints.and.returnValue(
+        of({ succeeded: [1, 2], failed: [] })
+      );
       service.toggleSelectAllOnPage([printOne, printTwo]);
 
       const pending = service.setStatusForSelected(PrintStatus.Success);
@@ -238,31 +327,114 @@ describe('PrintBulkActionsService', () => {
     it('does nothing when nothing is selected', async () => {
       const result = await service.setStatusForSelected(PrintStatus.Success);
 
-      expect(printService.updatePrintStatus).not.toHaveBeenCalled();
+      expect(printService.bulkUpdatePrints).not.toHaveBeenCalled();
       expect(result).toEqual({
         succeededIds: [],
         failedIds: [],
         failuresRetained: false,
+        errorMessage: null,
+      });
+    });
+  });
+
+  describe('setProjectForSelected', () => {
+    it('sends the project id', async () => {
+      printService.bulkUpdatePrints.and.returnValue(
+        of({ succeeded: [1], failed: [] })
+      );
+      service.toggleSelection(printOne);
+
+      await service.setProjectForSelected('a-project-id');
+
+      expect(printService.bulkUpdatePrints).toHaveBeenCalledWith({
+        printIds: [1],
+        projectId: 'a-project-id',
+      });
+    });
+  });
+
+  describe('removeProjectFromSelected', () => {
+    it('sends the clear list', async () => {
+      printService.bulkUpdatePrints.and.returnValue(
+        of({ succeeded: [1], failed: [] })
+      );
+      service.toggleSelection(printOne);
+
+      await service.removeProjectFromSelected();
+
+      expect(printService.bulkUpdatePrints).toHaveBeenCalledWith({
+        printIds: [1],
+        clear: ['projectId'],
+      });
+    });
+
+    it('logs its own event, not the assignment one', async () => {
+      printService.bulkUpdatePrints.and.returnValue(
+        of({ succeeded: [1], failed: [] })
+      );
+      service.toggleSelection(printOne);
+
+      await service.removeProjectFromSelected();
+
+      expect(logger.logEvent).toHaveBeenCalledWith(
+        'PrintBulkActionBar_RemoveProjectCompleted',
+        jasmine.anything()
+      );
+    });
+  });
+
+  describe('the remaining field actions', () => {
+    beforeEach(() => {
+      printService.bulkUpdatePrints.and.returnValue(
+        of({ succeeded: [1], failed: [] })
+      );
+      service.toggleSelection(printOne);
+    });
+
+    it('sets visibility', async () => {
+      await service.setViewStatusForSelected(PrintViewStatus.Public);
+
+      expect(printService.bulkUpdatePrints).toHaveBeenCalledWith({
+        printIds: [1],
+        viewStatus: PrintViewStatus.Public,
+      });
+    });
+
+    it('reassigns the printer', async () => {
+      await service.setPrinterForSelected(7);
+
+      expect(printService.bulkUpdatePrints).toHaveBeenCalledWith({
+        printIds: [1],
+        printerId: 7,
+      });
+    });
+
+    it('sets only the permission that was passed', async () => {
+      await service.setPermissionsForSelected({ allowFileDownloads: false });
+
+      expect(printService.bulkUpdatePrints).toHaveBeenCalledWith({
+        printIds: [1],
+        allowFileDownloads: false,
       });
     });
   });
 
   describe('deleteSelected', () => {
-    it('deletes each selected print sequentially', async () => {
-      printService.deletePrint.and.returnValue(of({}));
+    it('posts the ids to the bulk delete endpoint', async () => {
+      printService.bulkDeletePrints.and.returnValue(
+        of({ succeeded: [1, 2], failed: [] })
+      );
       service.toggleSelectAllOnPage([printOne, printTwo]);
 
       const result = await service.deleteSelected();
 
-      expect(printService.deletePrint).toHaveBeenCalledTimes(2);
-      expect(result.succeededIds).toEqual([printOne.id, printTwo.id]);
+      expect(printService.bulkDeletePrints).toHaveBeenCalledWith([1, 2]);
+      expect(result.succeededIds).toEqual([1, 2]);
     });
 
-    it('keeps failed deletions selected and logs the outcome', async () => {
-      printService.deletePrint.and.callFake((id: number) =>
-        id === printOne.id
-          ? throwError(() => new Error('boom'))
-          : (of({}) as any)
+    it('keeps refused deletions selected and logs the outcome', async () => {
+      printService.bulkDeletePrints.and.returnValue(
+        of({ succeeded: [2], failed: [{ id: 1, reason: 'Forbidden' }] })
       );
       service.toggleSelectAllOnPage([printOne, printTwo]);
 

--- a/src/app/print/services/print-bulk-actions.service.spec.ts
+++ b/src/app/print/services/print-bulk-actions.service.spec.ts
@@ -169,10 +169,15 @@ describe('PrintBulkActionsService', () => {
 
         await service.setStatusForSelected(PrintStatus.Success);
 
-        const sizes = printService.bulkUpdatePrints.calls
+        const batches = printService.bulkUpdatePrints.calls
           .allArgs()
-          .map(([request]) => request.printIds.length);
-        expect(sizes).toEqual(expected);
+          .map(([request]) => request.printIds);
+        expect(batches.map((ids) => ids.length)).toEqual(expected);
+
+        // Sizes alone would pass with the ids shuffled, duplicated across
+        // chunks, or dropped. Every id must appear exactly once, in order.
+        const allIds = ([] as number[]).concat(...batches);
+        expect(allIds).toEqual(Array.from({ length: count }, (_, i) => i + 1));
       });
     });
 
@@ -335,6 +340,41 @@ describe('PrintBulkActionsService', () => {
         errorMessage: null,
       });
     });
+  });
+
+  it('sends the same project id in every chunk', async () => {
+    // The dialog creates the project once and hands over an id, so a 60-print
+    // assignment must reuse that one id rather than creating anything per chunk.
+    printService.bulkUpdatePrints.and.callFake((request) =>
+      of({ succeeded: request.printIds, failed: [] })
+    );
+    service.toggleSelectAllOnPage(makePrints(60));
+
+    await service.setProjectForSelected('one-project-id');
+
+    const projectIds = printService.bulkUpdatePrints.calls
+      .allArgs()
+      .map(([request]) => request.projectId);
+    expect(projectIds).toEqual([
+      'one-project-id',
+      'one-project-id',
+      'one-project-id',
+    ]);
+  });
+
+  it('treats an id the response never mentions as failed', async () => {
+    // A truncated or version-skewed body must not quietly deselect a print
+    // that may not have been changed at all.
+    printService.bulkUpdatePrints.and.returnValue(
+      of({ succeeded: [1], failed: [] })
+    );
+    service.toggleSelectAllOnPage([printOne, printTwo]);
+
+    const result = await service.setStatusForSelected(PrintStatus.Success);
+
+    expect(result.succeededIds).toEqual([1]);
+    expect(result.failedIds).toEqual([2]);
+    expect(service.isSelected(2)).toBeTrue();
   });
 
   describe('setProjectForSelected', () => {

--- a/src/app/print/services/print-bulk-actions.service.ts
+++ b/src/app/print/services/print-bulk-actions.service.ts
@@ -1,10 +1,13 @@
+import { HttpErrorResponse } from '@angular/common/http';
 import { Injectable, computed, inject, signal } from '@angular/core';
 import { Observable, firstValueFrom } from 'rxjs';
 import { LoggingService } from 'src/app/core/services/logging.service';
 import {
+  BulkPrintResult,
   PrintService,
   PrintStatus,
   PrintSummary,
+  PrintViewStatus,
 } from 'src/app/core/services/print.service';
 
 /**
@@ -19,12 +22,46 @@ export interface BulkActionResult {
    * choice wins, and the caller must not claim the failures are still selected.
    */
   failuresRetained: boolean;
+  /**
+   * Set when the request itself was rejected (a 400), so the caller can show the API's
+   * reason rather than a generic count. Null when the batch ran normally.
+   */
+  errorMessage: string | null;
 }
 
 /**
  * The kind of batch currently running, used for the progress copy and the analytics event name.
  */
-export type BulkActionKind = 'status' | 'delete';
+export type BulkActionKind =
+  | 'status'
+  | 'delete'
+  | 'project'
+  // Removal is its own kind, not a 'project' with an empty value: it needs its own
+  // progress copy and its own analytics event.
+  | 'removeProject'
+  | 'visibility'
+  | 'printer'
+  | 'permissions';
+
+const PROGRESS_VERBS: Record<BulkActionKind, string> = {
+  status: 'Updating status',
+  delete: 'Deleting',
+  project: 'Assigning to project',
+  removeProject: 'Removing from project',
+  visibility: 'Updating visibility',
+  printer: 'Reassigning printer',
+  permissions: 'Updating permissions',
+};
+
+const COMPLETED_EVENTS: Record<BulkActionKind, string> = {
+  status: 'SetStatusCompleted',
+  delete: 'DeleteCompleted',
+  project: 'SetProjectCompleted',
+  removeProject: 'RemoveProjectCompleted',
+  visibility: 'SetVisibilityCompleted',
+  printer: 'SetPrinterCompleted',
+  permissions: 'SetPermissionsCompleted',
+};
 
 /**
  * Owns multi-select state for the print list and runs bulk actions against the
@@ -87,7 +124,8 @@ export class PrintBulkActionsService {
     if (!this.running()) {
       return '';
     }
-    const verb = this.kind() === 'delete' ? 'Deleting' : 'Updating status';
+    const kind = this.kind();
+    const verb = kind ? PROGRESS_VERBS[kind] : 'Working';
     return `${verb}: ${this.processed()} of ${this.total()}`;
   });
 
@@ -165,71 +203,154 @@ export class PrintBulkActionsService {
   }
 
   /**
-   * Applies `newStatus` to every selected print, one request at a time.
-   * Individual failures never abort the batch.
+   * Ids per request. Well under the API's 200 cap, and small enough that the determinate
+   * progress bar still moves several times on a large selection.
    */
+  private static readonly CHUNK_SIZE = 25;
+
+  /** Applies `newStatus` to every selected print. */
   public setStatusForSelected(
     newStatus: PrintStatus
   ): Promise<BulkActionResult> {
-    return this.runBatch('status', (print) =>
-      this.printService.updatePrintStatus(print.id, newStatus)
+    return this.runBulk('status', (printIds) =>
+      this.printService.bulkUpdatePrints({ printIds, status: newStatus })
+    );
+  }
+
+  /** Assigns every selected print to an existing project, moving any that were in another. */
+  public setProjectForSelected(projectId: string): Promise<BulkActionResult> {
+    return this.runBulk('project', (printIds) =>
+      this.printService.bulkUpdatePrints({ printIds, projectId })
+    );
+  }
+
+  /** Takes every selected print out of whatever project it was in. */
+  public removeProjectFromSelected(): Promise<BulkActionResult> {
+    return this.runBulk('removeProject', (printIds) =>
+      this.printService.bulkUpdatePrints({ printIds, clear: ['projectId'] })
+    );
+  }
+
+  /** Sets who can see every selected print. */
+  public setViewStatusForSelected(
+    viewStatus: PrintViewStatus
+  ): Promise<BulkActionResult> {
+    return this.runBulk('visibility', (printIds) =>
+      this.printService.bulkUpdatePrints({ printIds, viewStatus })
+    );
+  }
+
+  /** Moves every selected print onto another of the user's printers. */
+  public setPrinterForSelected(printerId: number): Promise<BulkActionResult> {
+    return this.runBulk('printer', (printIds) =>
+      this.printService.bulkUpdatePrints({ printIds, printerId })
+    );
+  }
+
+  /** Sets only the permissions named in `patch`; the others are left alone. */
+  public setPermissionsForSelected(patch: {
+    allowComments?: boolean;
+    allowFileDownloads?: boolean;
+  }): Promise<BulkActionResult> {
+    return this.runBulk('permissions', (printIds) =>
+      this.printService.bulkUpdatePrints({ printIds, ...patch })
     );
   }
 
   /**
-   * Deletes every selected print, one request at a time. The caller is
-   * responsible for confirming first.
+   * Deletes every selected print. The caller is responsible for confirming first.
    */
   public deleteSelected(): Promise<BulkActionResult> {
-    return this.runBatch('delete', (print) =>
-      this.printService.deletePrint(print.id)
+    return this.runBulk('delete', (printIds) =>
+      this.printService.bulkDeletePrints(printIds)
     );
   }
 
-  private async runBatch(
+  /**
+   * Runs one bulk action over the selection, 25 ids per request.
+   *
+   * Chunking is what keeps the progress bar determinate: `processed` advances by a whole
+   * chunk as each response lands. A chunk that errors marks its whole chunk failed and the
+   * run continues - the API writes a request all-or-nothing, so that report is accurate
+   * rather than merely pessimistic. A 400 means the request shape itself was rejected, so
+   * every remaining chunk would fail the same way and the run stops sending.
+   */
+  private async runBulk(
     kind: BulkActionKind,
-    operation: (print: PrintSummary) => Observable<unknown>
+    operation: (printIds: number[]) => Observable<BulkPrintResult>
   ): Promise<BulkActionResult> {
     const prints = this.selectedPrints();
     const result: BulkActionResult = {
       succeededIds: [],
       failedIds: [],
       failuresRetained: false,
+      errorMessage: null,
     };
 
     if (prints.length === 0 || this.running()) {
       return result;
     }
 
-    // The batch works from this snapshot, so the restore below must come from it
-    // too - reading the live selection back would lose the failures if the user
-    // changed the result set (which clears the selection) mid-batch.
+    // The batch works from this snapshot, so the restore below must come from it too -
+    // reading the live selection back would lose the failures if the user changed the
+    // result set (which clears the selection) mid-batch.
     const startEpoch = this.selectionEpoch;
+    const allIds = prints.map((print) => print.id);
+
+    const chunks: number[][] = [];
+    for (
+      let i = 0;
+      i < allIds.length;
+      i += PrintBulkActionsService.CHUNK_SIZE
+    ) {
+      chunks.push(allIds.slice(i, i + PrintBulkActionsService.CHUNK_SIZE));
+    }
 
     this.kind.set(kind);
-    this.total.set(prints.length);
+    this.total.set(allIds.length);
     this.processed.set(0);
     this.running.set(true);
 
     try {
-      for (const print of prints) {
+      for (let i = 0; i < chunks.length; i++) {
+        const chunk = chunks[i];
         try {
-          await firstValueFrom(operation(print));
-          result.succeededIds.push(print.id);
+          const response = await firstValueFrom(operation(chunk));
+          result.succeededIds.push(...response.succeeded);
+          result.failedIds.push(
+            ...response.failed.map((failure) => failure.id)
+          );
         } catch (error) {
-          result.failedIds.push(print.id);
+          result.failedIds.push(...chunk);
           this.loggingService.logException(error);
+
+          if (error instanceof HttpErrorResponse && error.status === 400) {
+            // The request shape was rejected; the remaining chunks are identical apart
+            // from their ids, so sending them would only repeat the same rejection.
+            result.errorMessage =
+              error.error?.detail ??
+              error.error?.title ??
+              'The request was rejected.';
+            const unsent = chunks.slice(i + 1).flat();
+            result.failedIds.push(...unsent);
+            this.processed.set(allIds.length);
+            break;
+          }
         } finally {
-          this.processed.update((count) => count + 1);
+          // The 400 branch above already jumped the counter to the end, so this must not
+          // push it past the total.
+          this.processed.update((count) =>
+            Math.min(count + chunk.length, allIds.length)
+          );
         }
       }
     } finally {
       this.running.set(false);
     }
 
-    // Keep only the failures selected so the user can retry them directly. If the
-    // user touched the selection while the batch ran, their choice wins and we
-    // leave it alone - the result then says the failures were not retained.
+    // Keep only the failures selected so the user can retry them directly. If the user
+    // touched the selection while the batch ran, their choice wins and we leave it alone -
+    // the result then says the failures were not retained.
     if (this.selectionEpoch === startEpoch) {
       const failedIds = new Set(result.failedIds);
       const retained = new Map<number, PrintSummary>();
@@ -243,11 +364,9 @@ export class PrintBulkActionsService {
     }
 
     this.loggingService.logEvent(
-      kind === 'delete'
-        ? 'PrintBulkActionBar_DeleteCompleted'
-        : 'PrintBulkActionBar_SetStatusCompleted',
+      `PrintBulkActionBar_${COMPLETED_EVENTS[kind]}`,
       {
-        attempted: prints.length,
+        attempted: allIds.length,
         succeeded: result.succeededIds.length,
         failed: result.failedIds.length,
       }

--- a/src/app/print/services/print-bulk-actions.service.ts
+++ b/src/app/print/services/print-bulk-actions.service.ts
@@ -274,6 +274,12 @@ export class PrintBulkActionsService {
    * run continues - the API writes a request all-or-nothing, so that report is accurate
    * rather than merely pessimistic. A 400 means the request shape itself was rejected, so
    * every remaining chunk would fail the same way and the run stops sending.
+   *
+   * The loop is deliberately NOT cancelled when the list component is destroyed.
+   * The service is scoped to that component, so navigating away mid-batch would
+   * abandon the run - leaving, say, 25 of 60 prints updated with nobody told
+   * which. Finishing the work the user asked for is the safer half of that
+   * trade; the signal writes that outlive the component are inert.
    */
   private async runBulk(
     kind: BulkActionKind,
@@ -320,6 +326,16 @@ export class PrintBulkActionsService {
           result.failedIds.push(
             ...response.failed.map((failure) => failure.id)
           );
+
+          // The API reports every id it was sent. If one comes back in neither
+          // list - a version skew, a truncated body - treat it as failed rather
+          // than dropping it: an unreported id would otherwise be deselected as
+          // though it had succeeded, and the user would never learn it did not.
+          const reported = new Set([
+            ...response.succeeded,
+            ...response.failed.map((failure) => failure.id),
+          ]);
+          result.failedIds.push(...chunk.filter((id) => !reported.has(id)));
         } catch (error) {
           result.failedIds.push(...chunk);
           this.loggingService.logException(error);

--- a/src/app/shared/project-selector/project-selector.component.html
+++ b/src/app/shared/project-selector/project-selector.component.html
@@ -32,12 +32,6 @@
         }
       </mat-option>
     }
-    @if (loadFailed()) {
-      <mat-option disabled data-cy="project-lookup-failed">
-        <span role="alert">Projects could not be loaded.</span>
-        <button mat-button type="button" (click)="retry()">Try again</button>
-      </mat-option>
-    }
     @if (showNewOption()) {
       <mat-option
         [value]="searchControl.value"
@@ -49,3 +43,20 @@
     }
   </mat-autocomplete>
 </mat-form-field>
+
+<!-- Outside the autocomplete panel on purpose. A <button> nested in a disabled
+     <mat-option> is not reachable by keyboard: the option is an ARIA option, not
+     a focus container, and a disabled one is skipped entirely. -->
+@if (loadFailed()) {
+  <p class="project-selector-error" data-cy="project-lookup-failed">
+    <span role="alert">Projects could not be loaded.</span>
+    <button
+      mat-button
+      type="button"
+      (click)="retry()"
+      data-cy="project-lookup-retry"
+    >
+      Try again
+    </button>
+  </p>
+}

--- a/src/app/shared/project-selector/project-selector.component.html
+++ b/src/app/shared/project-selector/project-selector.component.html
@@ -32,6 +32,12 @@
         }
       </mat-option>
     }
+    @if (loadFailed()) {
+      <mat-option disabled data-cy="project-lookup-failed">
+        <span role="alert">Projects could not be loaded.</span>
+        <button mat-button type="button" (click)="retry()">Try again</button>
+      </mat-option>
+    }
     @if (showNewOption()) {
       <mat-option
         [value]="searchControl.value"

--- a/src/app/shared/project-selector/project-selector.component.scss
+++ b/src/app/shared/project-selector/project-selector.component.scss
@@ -13,3 +13,12 @@
   color: var(--mat-sys-on-surface-variant);
   font-style: italic;
 }
+
+.project-selector-error {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: -8px 0 8px;
+  color: var(--mat-sys-error, #b3261e);
+  font-size: 12px;
+}

--- a/src/app/shared/project-selector/project-selector.component.spec.ts
+++ b/src/app/shared/project-selector/project-selector.component.spec.ts
@@ -219,6 +219,10 @@ describe('ProjectSelectorComponent', () => {
     tick(250);
 
     expect(fixture.componentInstance.loadFailed()).toBeTrue();
+    // A failed lookup returns an empty list, which must not be read as
+    // "that name is free" - offering to create is how duplicates happen.
+    expect(fixture.componentInstance.showNewOption()).toBeFalse();
+    fixture.detectChanges();
 
     mockProjectService.getProjectSummaries.and.returnValue(
       of({
@@ -228,7 +232,15 @@ describe('ProjectSelectorComponent', () => {
     );
     const callsBefore = mockProjectService.getProjectSummaries.calls.count();
 
-    fixture.componentInstance.retry();
+    // Clicked through the DOM on purpose. Calling retry() directly would pass
+    // even with the button nested somewhere it cannot be reached.
+    const retryButton: HTMLButtonElement = fixture.nativeElement.querySelector(
+      '[data-cy="project-lookup-retry"]'
+    );
+    expect(retryButton)
+      .withContext('the retry control must be in the DOM')
+      .toBeTruthy();
+    retryButton.click();
     tick(250);
 
     expect(mockProjectService.getProjectSummaries.calls.count()).toBe(

--- a/src/app/shared/project-selector/project-selector.component.spec.ts
+++ b/src/app/shared/project-selector/project-selector.component.spec.ts
@@ -13,7 +13,7 @@ import {
   ProjectViewStatus,
 } from 'src/app/core/services/project.service';
 import { ReactiveFormsModule } from '@angular/forms';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { delay } from 'rxjs/operators';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -207,5 +207,34 @@ describe('ProjectSelectorComponent', () => {
 
     expect(fixture.componentInstance.selectedProject()).toBeNull();
     expect(emitted[0]).toBeNull();
+  }));
+
+  it('reports a failed lookup and clears the message once a retry succeeds', fakeAsync(() => {
+    // Without a handler the failure would leave an empty autocomplete with no
+    // explanation, and the stream would be dead for the rest of the dialog's life.
+    mockProjectService.getProjectSummaries.and.returnValue(
+      throwError(() => new Error('boom'))
+    );
+    fixture.detectChanges();
+    tick(250);
+
+    expect(fixture.componentInstance.loadFailed()).toBeTrue();
+
+    mockProjectService.getProjectSummaries.and.returnValue(
+      of({
+        paging: { currentPage: 1, totalPages: 1, pageSize: 25, totalCount: 1 },
+        items: [{ id: 'p1', name: 'Recovered', status: 1 }],
+      } as any)
+    );
+    const callsBefore = mockProjectService.getProjectSummaries.calls.count();
+
+    fixture.componentInstance.retry();
+    tick(250);
+
+    expect(mockProjectService.getProjectSummaries.calls.count()).toBe(
+      callsBefore + 1
+    );
+    expect(fixture.componentInstance.loadFailed()).toBeFalse();
+    expect(fixture.componentInstance.filteredProjects().length).toBe(1);
   }));
 });

--- a/src/app/shared/project-selector/project-selector.component.ts
+++ b/src/app/shared/project-selector/project-selector.component.ts
@@ -92,13 +92,22 @@ export class ProjectSelectorComponent implements OnInit {
         this.projectService
           .getProjectById(this.initialProjectId()!)
           .pipe(takeUntilDestroyed(this.destroyRef))
-          .subscribe((project) => {
-            // The print detail payload carries projectId but not projectName, so the name
-            // arrives on this round trip — potentially after the user has started typing.
-            // Prefilling on top of their keystrokes splices the old name into the new one,
-            // which then gets created as a project under that mangled name.
-            if (this.searchControl.dirty) return;
-            this.applyInitialProject(project.id, project.name, project.status);
+          .subscribe({
+            next: (project) => {
+              // The print detail payload carries projectId but not projectName, so the name
+              // arrives on this round trip — potentially after the user has started typing.
+              // Prefilling on top of their keystrokes splices the old name into the new one,
+              // which then gets created as a project under that mangled name.
+              if (this.searchControl.dirty) return;
+              this.applyInitialProject(
+                project.id,
+                project.name,
+                project.status
+              );
+            },
+            // Without this the failure is an unhandled error and the field silently
+            // shows no project at all, which reads as "this print has none".
+            error: () => this.loadFailed.set(true),
           });
       }
     }
@@ -149,8 +158,14 @@ export class ProjectSelectorComponent implements OnInit {
       .subscribe((result) => {
         this.filteredProjects.set(result.items);
         const q = (this.searchControl.value ?? '').trim().toLowerCase();
+        // "No project matched, so offer to create one" is only true if the lookup
+        // actually answered. After a failure the list is empty because the request
+        // failed, and offering to create is how you end up with a duplicate of a
+        // project that already exists.
         this.showNewOption.set(
-          q.length > 0 && !result.items.some((p) => p.name.toLowerCase() === q)
+          !this.loadFailed() &&
+            q.length > 0 &&
+            !result.items.some((p) => p.name.toLowerCase() === q)
         );
       });
   }

--- a/src/app/shared/project-selector/project-selector.component.ts
+++ b/src/app/shared/project-selector/project-selector.component.ts
@@ -16,12 +16,17 @@ import { MatInputModule } from '@angular/material/input';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 
+import { Subject, merge, of } from 'rxjs';
 import {
+  catchError,
   debounceTime,
   distinctUntilChanged,
+  map,
   startWith,
   switchMap,
+  tap,
 } from 'rxjs/operators';
+import { PagedList } from 'src/app/core/types/paging';
 import {
   ProjectService,
   ProjectSummaryDto,
@@ -67,6 +72,14 @@ export class ProjectSelectorComponent implements OnInit {
   selectedProject = signal<ProjectSelection | null>(null);
   showNewOption = signal(false);
   isDefaultView = signal(true);
+  /** True when the last lookup failed, so the empty list has an explanation. */
+  loadFailed = signal(false);
+
+  /**
+   * Re-runs the current search on demand. `valueChanges` cannot do this: the retry re-uses
+   * the same term, and `distinctUntilChanged` would swallow it.
+   */
+  private readonly retry$ = new Subject<void>();
 
   ngOnInit(): void {
     if (this.initialProjectId()) {
@@ -90,22 +103,46 @@ export class ProjectSelectorComponent implements OnInit {
       }
     }
 
-    this.searchControl.valueChanges
-      .pipe(
+    merge(
+      this.searchControl.valueChanges.pipe(
         startWith(this.searchControl.value ?? ''),
         debounceTime(250),
-        distinctUntilChanged(),
+        distinctUntilChanged()
+      ),
+      this.retry$.pipe(map(() => this.searchControl.value ?? ''))
+    )
+      .pipe(
+        // Clear the previous failure as each new lookup starts, or one bad response
+        // leaves the message up for the rest of the dialog's life.
+        tap(() => this.loadFailed.set(false)),
         switchMap((value) => {
           const q = (value ?? '').trim();
-          if (q.length === 0) {
-            this.isDefaultView.set(true);
-            return this.projectService.getProjectSummaries(1, 25, {
-              status: ProjectStatus.InProgress,
-              sortBy: 'updatedDate',
-            });
-          }
-          this.isDefaultView.set(false);
-          return this.projectService.getProjectSummaries(1, 25, { search: q });
+          const lookup =
+            q.length === 0
+              ? (this.isDefaultView.set(true),
+                this.projectService.getProjectSummaries(1, 25, {
+                  status: ProjectStatus.InProgress,
+                  sortBy: 'updatedDate',
+                }))
+              : (this.isDefaultView.set(false),
+                this.projectService.getProjectSummaries(1, 25, { search: q }));
+
+          // catchError sits on the INNER observable. On the outer pipe it would
+          // terminate the stream and the input would stop searching altogether.
+          return lookup.pipe(
+            catchError(() => {
+              this.loadFailed.set(true);
+              return of({
+                paging: {
+                  currentPage: 1,
+                  totalPages: 0,
+                  pageSize: 25,
+                  totalCount: 0,
+                },
+                items: [],
+              } as PagedList<ProjectSummaryDto>);
+            })
+          );
         }),
         takeUntilDestroyed(this.destroyRef)
       )
@@ -152,6 +189,11 @@ export class ProjectSelectorComponent implements OnInit {
     };
     this.selectedProject.set(selection);
     this.projectSelected.emit(selection);
+  }
+
+  /** Re-runs the lookup that failed, using whatever is currently typed. */
+  retry(): void {
+    this.retry$.next();
   }
 
   clearProject(): void {


### PR DESCRIPTION
Closes #88.

**Blocked on HoffmanEngineering/3d-print-log-api#96 — do not merge until the bulk endpoints are deployed.**

## What this adds

"Add to project" as a bulk action, plus visibility, printer and permissions, and it moves the two existing bulk actions off their per-print request loops.

Issue #88 asked for a `PUT /Prints/{id}/project/{projectId}` and a loop. That loop is not just slow, it is wrong for this feature: the project selector lets you type a new name, and creating one project per print would produce N projects with the same name. The dialog now resolves a typed name to a created project **once**, before anything is sent, so the requests only ever carry ids.

## The bulk endpoints

`PrintBulkActionsService` sends one request per **25 ids** instead of one per print. Chunking rather than a single request is what preserves the existing UX: progress stays determinate (the bar advances a chunk at a time), individual failures don't abort the run, and prints that fail stay selected so a retry is one click.

Error handling follows what each status actually means. A 500 fails only its own chunk and the run continues — the API writes a request all-or-nothing, so reporting the whole chunk failed is accurate, not merely pessimistic. A **400** means the request shape itself was rejected, so every remaining chunk would fail identically: the run stops sending and surfaces the API's `detail` instead of a count.

## The action bar

Four top-level buttons plus the view toggle overflowed the toolbar row and pushed **Clear** off screen — the e2e suite caught it. Everything now sits behind one `Actions (N)` trigger: Set status, Add to project, Visibility, Printer, Permissions, then Delete below a divider. The count rides on the trigger **and** repeats as the menu's header, because the open menu covers the trigger that carried it. Adding an action costs no toolbar width now.

## Fixes to existing code found on the way

- `ProjectSelectorComponent` had no error handling on its search. A failed lookup left an empty autocomplete with no explanation — and, worse, still offered "Create project", since an empty list reads as "that name is free". It now says so and offers a retry, and suppresses the create option when the lookup didn't answer.
- The retry control had to live outside the autocomplete panel: a `<button>` nested in a disabled `<mat-option>` is unreachable by keyboard, because an ARIA option is not a focus container.
- The bulk project dialog disables Cancel and Remove while a create is in flight, so it cannot close leaving a project created and nothing filed under it. Its failure copy no longer claims nothing was created — a lost response may well have committed one, and telling the user otherwise is how they end up with two.

## Testing

1131 unit tests. 31/31 print Cypress specs pass against a live API on the E2E profile.

The e2e specs assert the `projectId`, `printerId` and `viewStatus` actually sent rather than that a request happened; a 60-print assignment proves one project id is reused across all three chunks; the chunk cases assert id membership and order at the 24/25/26 boundary, not just batch sizes.

Documentation in `src/documentation` covers every new action, and its test asserts the copy renders — verified by deleting the section and watching it fail.
