### PR TITLE
feat(filaments): show remaining material and the prints that used it on the material detail page

### DIFF
--- a/cypress/e2e/filaments/filament-remaining.cy.ts
+++ b/cypress/e2e/filaments/filament-remaining.cy.ts
@@ -1,0 +1,114 @@
+describe('Material detail — remaining and prints', () => {
+  beforeEach(() => {
+    cy.login();
+  });
+
+  // Creates a weight-tracked material and yields its id, so every assertion runs
+  // against a spool this spec owns rather than whatever happens to sort first.
+  function createTrackedFilament(name: string): Cypress.Chainable<string> {
+    cy.visit('/filament');
+    cy.get('#add-new-filament').click();
+
+    cy.get('#edit-filament-name').type(name);
+
+    cy.get('mat-select[formControlName="materialCategoryNickname"]')
+      .click()
+      .get('mat-option')
+      .first()
+      .click();
+
+    cy.get('#edit-filament-material-type').type('PLA');
+    cy.get('#edit-filament-density')
+      .clear({ force: true })
+      .type('1.24', { force: true });
+    cy.get('#filament-inital-nominal-weight')
+      .clear({ force: true })
+      .type('1000', { force: true });
+
+    cy.intercept('POST', '/api/Filaments').as('createFilament');
+    cy.get('#edit-filament-submit-btn').click();
+
+    return cy
+      .wait('@createFilament')
+      .then((interception) => interception.response!.body.id as string);
+  }
+
+  it('shows remaining material and the prints panel on a saved spool', () => {
+    createTrackedFilament('Remaining E2E - ' + new Date().getTime()).then(
+      (id) => {
+        cy.visit(`/filament/${id}`);
+
+        cy.get('app-filament-remaining-card').should('be.visible');
+        cy.get('app-filament-remaining-card').should('contain.text', '1,000');
+        cy.get('app-filament-prints-panel').should(
+          'contain.text',
+          'No prints have used this material yet'
+        );
+      }
+    );
+  });
+
+  it('previews an unsaved adjustment and leaves the form clean until edited', () => {
+    createTrackedFilament('Projection E2E - ' + new Date().getTime()).then(
+      (id) => {
+        cy.visit(`/filament/${id}`);
+
+        // Pristine: the card shows the server's figure with no "after saving" note.
+        cy.get('app-filament-remaining-card').should(
+          'not.contain.text',
+          'after saving'
+        );
+
+        cy.contains('button', 'Add New Adjustment').click();
+        cy.get('input[formcontrolname="amountG"]')
+          .last()
+          .type('-32', { force: true });
+
+        cy.get('app-filament-remaining-card').should(
+          'contain.text',
+          'after saving'
+        );
+        cy.get('app-filament-remaining-card').should('contain.text', '968');
+      }
+    );
+  });
+
+  it('keeps the stats card pinned while scrolling the form', () => {
+    cy.viewport(1440, 900);
+
+    createTrackedFilament('Sticky E2E - ' + new Date().getTime()).then((id) => {
+      cy.visit(`/filament/${id}`);
+
+      // Scroll the long form far enough that a non-sticky card would be well
+      // above the viewport, then require the card to be pinned at its sticky
+      // offset and to STAY there through a second, larger scroll.
+      // `should('be.visible')` alone would pass for a card that simply scrolled
+      // along with the page, which is the failure sticky has: it no-ops silently
+      // when an ancestor clips or scrolls unexpectedly.
+      const STICKY_TOP = 16;
+
+      cy.contains('h2', 'Purchase Details').scrollIntoView();
+      cy.get('app-filament-remaining-card').should(($after) => {
+        expect($after[0].getBoundingClientRect().top).to.be.closeTo(
+          STICKY_TOP,
+          2
+        );
+      });
+
+      cy.scrollTo('bottom');
+      cy.get('app-filament-remaining-card').should(($atBottom) => {
+        expect($atBottom[0].getBoundingClientRect().top).to.be.closeTo(
+          STICKY_TOP,
+          2
+        );
+      });
+    });
+  });
+
+  it('shows neither card in add mode', () => {
+    cy.visit('/filament/new');
+
+    cy.get('app-filament-remaining-card').should('not.exist');
+    cy.get('app-filament-prints-panel').should('not.exist');
+  });
+});

--- a/cypress/e2e/filaments/filament-remaining.cy.ts
+++ b/cypress/e2e/filaments/filament-remaining.cy.ts
@@ -73,7 +73,7 @@ describe('Material detail — remaining and prints', () => {
     );
   });
 
-  it('keeps the stats card pinned while scrolling the form', () => {
+  it('keeps the stats card and prints panel pinned while scrolling the form', () => {
     cy.viewport(1440, 900);
 
     createTrackedFilament('Sticky E2E - ' + new Date().getTime()).then((id) => {
@@ -85,7 +85,9 @@ describe('Material detail — remaining and prints', () => {
       // `should('be.visible')` alone would pass for a card that simply scrolled
       // along with the page, which is the failure sticky has: it no-ops silently
       // when an ancestor clips or scrolls unexpectedly.
-      const STICKY_TOP = 16;
+      // The offset clears the 64px fixed navbar — pinning any higher tucks the
+      // top of the card underneath it.
+      const STICKY_TOP = 80;
 
       cy.contains('h2', 'Purchase Details').scrollIntoView();
       cy.get('app-filament-remaining-card').should(($after) => {
@@ -101,6 +103,19 @@ describe('Material detail — remaining and prints', () => {
           STICKY_TOP,
           2
         );
+      });
+
+      // The prints panel travels with the card: it rides directly below it and
+      // stays fully inside the viewport instead of stranding itself mid-page or
+      // sliding under the pinned card.
+      cy.get('app-filament-prints-panel').should(($panel) => {
+        const panel = $panel[0].getBoundingClientRect();
+        const card = Cypress.$(
+          'app-filament-remaining-card'
+        )[0].getBoundingClientRect();
+
+        expect(panel.top).to.be.at.least(card.bottom - 1);
+        expect(panel.bottom).to.be.at.most(900);
       });
     });
   });

--- a/cypress/e2e/filaments/filament-usage-calculations.cy.ts
+++ b/cypress/e2e/filaments/filament-usage-calculations.cy.ts
@@ -1,0 +1,398 @@
+import { apiUrl } from '../../support/api-url';
+
+/**
+ * Remaining-material arithmetic across combinations the rest of the suite does not reach:
+ * several prints against one spool, several usage rows inside one print, usage recorded in
+ * length or volume rather than weight, and materials whose own nominal figure was entered as
+ * a length or a volume.
+ *
+ * Fixtures are seeded through the API rather than driven through the print form. The subject
+ * here is what the numbers come out as, and a UI-driven setup would spend most of each test
+ * re-testing the form - and could not express a usage row recorded in volume against a resin
+ * at all without first walking the whole print editor.
+ */
+describe('Material usage calculations', () => {
+  const DEV_HEADERS = { 'X-Dev-User-Id': '1' };
+
+  // Source enums, numeric on the wire for both entities: Weight = 1, Length = 2, Volume = 3.
+  const WEIGHT = 1;
+  const LENGTH = 2;
+  const VOLUME = 3;
+
+  const PLA_DENSITY = 1.24;
+  const DIAMETER = 1.75;
+
+  /** mg for a length of filament, the same formula the API converts with. */
+  const mgFromLength = (meters: number, density = PLA_DENSITY, d = DIAMETER) =>
+    250 * Math.PI * density * d * d * meters;
+
+  /** mg for a volume of material. */
+  const mgFromVolume = (ml: number, density = PLA_DENSITY) =>
+    ml * density * 1000;
+
+  const request = (method: string, path: string, body?: Cypress.RequestBody) =>
+    cy.request({
+      method,
+      url: `${apiUrl()}${path}`,
+      headers: DEV_HEADERS,
+      body,
+    });
+
+  /**
+   * The card renders Length and Volume through `number: '1.0-1'`, whose minimum is ZERO
+   * fraction digits: 806.45 reads "806.5" but 250 reads "250", not "250.0". Expectations are
+   * formatted the same way rather than with toFixed(1), which only agrees by luck.
+   */
+  const oneDecimal = (value: number) =>
+    (Math.round(value * 10) / 10).toLocaleString('en-US', {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 1,
+    });
+
+  interface MaterialOptions {
+    source?: number;
+    density?: number;
+    diameterMm?: number | null;
+    categoryNickname?: string;
+    initialNominalWeightMg?: number | null;
+    initialNominalLengthM?: number | null;
+    initialNominalVolumeMl?: number | null;
+  }
+
+  /**
+   * A material owned by this spec. Every test seeds its own so that a figure asserted here can
+   * only have come from the usage this test logged.
+   */
+  const createMaterial = (
+    displayName: string,
+    options: MaterialOptions = {}
+  ): Cypress.Chainable<string> =>
+    request('POST', '/api/Filaments/', {
+      displayName: `${displayName} ${Date.now()}`,
+      brand: 'E2E Usage',
+      materialCategoryNickname: options.categoryNickname ?? 'filament',
+      materialType: 'PLA',
+      materialDensityGramPerCubicCm: options.density ?? PLA_DENSITY,
+      colorName: 'Usage Blue',
+      colorHex: '0000FF',
+      colors: ['0000FF'],
+      effects: [],
+      diameterMm:
+        options.diameterMm === undefined ? DIAMETER : options.diameterMm,
+      source: options.source ?? WEIGHT,
+      initialNominalWeightMg:
+        options.initialNominalWeightMg === undefined
+          ? 1000000
+          : options.initialNominalWeightMg,
+      initialNominalLengthM: options.initialNominalLengthM ?? null,
+      initialNominalVolumeMl: options.initialNominalVolumeMl ?? null,
+      isActive: true,
+      filamentAdjustments: [],
+    }).then((response) => response.body.id as string);
+
+  type UsageRow = Record<string, unknown>;
+
+  /**
+   * Logs one print carrying the given usage rows. Two calls on purpose: POST creates the print
+   * but does not attach a filament to a usage row, PUT is what persists filamentId - the same
+   * shape `seedPublicPrintFixture` uses.
+   */
+  const logPrint = (title: string, usage: UsageRow[]) =>
+    request('GET', '/api/printers/summary?PageNumber=1&PageSize=1').then(
+      (printerResponse) => {
+        const printer = printerResponse.body.items[0];
+        expect(printer, 'a printer exists to attach usage to').to.exist;
+
+        return request('POST', '/api/Prints/', {
+          title: `${title} ${Date.now()}`,
+          status: 3,
+          viewStatus: 1,
+          printerId: printer.id,
+          startDate: '2026-08-01T00:00:00Z',
+          allowComments: true,
+          filamentUsage: [],
+        }).then((createResponse) => {
+          const created = createResponse.body;
+          return request('PUT', `/api/Prints/${created.id}`, {
+            ...created,
+            printerId: printer.id,
+            filamentUsage: usage,
+          });
+        });
+      }
+    );
+
+  const weightRow = (filamentId: string, grams: number): UsageRow => ({
+    filamentId,
+    amountMg: Math.round(grams * 1000),
+    source: WEIGHT,
+  });
+
+  const lengthRow = (filamentId: string, meters: number): UsageRow => ({
+    filamentId,
+    lengthInM: meters,
+    source: LENGTH,
+  });
+
+  const volumeRow = (filamentId: string, ml: number): UsageRow => ({
+    filamentId,
+    volumeMl: ml,
+    source: VOLUME,
+  });
+
+  /** The value beside a label in the remaining card's Length/Volume/Used/Prints list. */
+  const stat = (label: string) =>
+    cy.contains('app-filament-remaining-card dt', label).next('dd');
+
+  /** Asserts a stat is absent - the card omits the whole row rather than rendering a zero. */
+  const noStat = (label: string) =>
+    cy
+      .get('app-filament-remaining-card')
+      .find('dt')
+      .should('not.contain.text', label);
+
+  const openMaterial = (id: string) => {
+    cy.visit(`/filament/${id}`);
+    cy.get('app-filament-remaining-card').should('be.visible');
+  };
+
+  beforeEach(() => {
+    cy.login();
+  });
+
+  it('counts several prints against one spool', () => {
+    createMaterial('Multi Print Spool').then((id) => {
+      logPrint('Usage Calc A', [weightRow(id, 25)]);
+      logPrint('Usage Calc B', [weightRow(id, 25)]);
+      logPrint('Usage Calc C', [weightRow(id, 25)]);
+
+      openMaterial(id);
+
+      cy.get('app-filament-remaining-card').should('contain.text', '925 g');
+      stat('Used').should('have.text', '75 g');
+      stat('Prints').should('have.text', '3');
+    });
+  });
+
+  it('sums several usage rows inside one print but counts the print once', () => {
+    // There is no unique index on (PrintId, FilamentId), so one print can hold two rows for
+    // the same spool - a filament change mid-print, or the same spool loaded in two tools.
+    // Used counts rows; Prints counts prints.
+    createMaterial('Two Rows One Print').then((id) => {
+      logPrint('Usage Calc Two Rows', [weightRow(id, 30), weightRow(id, 20)]);
+
+      openMaterial(id);
+
+      cy.get('app-filament-remaining-card').should('contain.text', '950 g');
+      stat('Used').should('have.text', '50 g');
+      stat('Prints').should('have.text', '1');
+    });
+  });
+
+  it('converts usage recorded as a length', () => {
+    const usedMg = mgFromLength(10);
+    const remainingG = Math.round((1000000 - usedMg) / 1000);
+
+    createMaterial('Length Usage Spool').then((id) => {
+      logPrint('Usage Calc Length', [lengthRow(id, 10)]);
+
+      openMaterial(id);
+
+      // 10 m of 1.75mm PLA at 1.24 g/cm3 is ~29.8 g, so the spool reads ~970 g.
+      cy.get('app-filament-remaining-card').should(
+        'contain.text',
+        `${remainingG} g`
+      );
+      stat('Used').should('have.text', `${Math.round(usedMg / 1000)} g`);
+    });
+  });
+
+  it('converts usage recorded as a volume', () => {
+    createMaterial('Volume Usage Spool').then((id) => {
+      logPrint('Usage Calc Volume', [volumeRow(id, 20)]);
+
+      // 20 ml at 1.24 g/cm3 is 24.8 g.
+      openMaterial(id);
+
+      cy.get('app-filament-remaining-card').should('contain.text', '975 g');
+      stat('Used').should('have.text', '25 g');
+    });
+  });
+
+  it('keeps weight, length and volume in agreement across mixed usage sources', () => {
+    // The regression this spec exists for: the three readings used to be accumulated on
+    // separate bases, so a spool could report a weight and a volume that described different
+    // amounts of material - or a negative volume. They are now one number, converted.
+    const usedMg = 25000 + mgFromLength(10) + mgFromVolume(20);
+    const remainingMg = 1000000 - usedMg;
+
+    createMaterial('Mixed Source Spool').then((id) => {
+      logPrint('Usage Calc Mixed W', [weightRow(id, 25)]);
+      logPrint('Usage Calc Mixed L', [lengthRow(id, 10)]);
+      logPrint('Usage Calc Mixed V', [volumeRow(id, 20)]);
+
+      openMaterial(id);
+
+      stat('Prints').should('have.text', '3');
+
+      cy.get('app-filament-remaining-card').should(
+        'contain.text',
+        `${Math.round(remainingMg / 1000)} g`
+      );
+
+      const expectedMl = remainingMg / 1000 / PLA_DENSITY;
+      const expectedM =
+        remainingMg / (250 * Math.PI * PLA_DENSITY * DIAMETER * DIAMETER);
+
+      stat('Volume').should('have.text', `${oneDecimal(expectedMl)} ml`);
+      stat('Length').should('have.text', `${oneDecimal(expectedM)} m`);
+    });
+  });
+
+  it('tracks a material whose nominal figure was entered as a length', () => {
+    // Source = Length: the user entered 300 m and the server derived the weight from it.
+    // Usage still counts the same, and all three readings stay in step.
+    const nominalMg = mgFromLength(300);
+    const usedMg = mgFromLength(50);
+    const remainingMg = nominalMg - usedMg;
+
+    createMaterial('Length Source Spool', {
+      source: LENGTH,
+      initialNominalWeightMg: null,
+      initialNominalLengthM: 300,
+    }).then((id) => {
+      logPrint('Usage Calc Length Source', [lengthRow(id, 50)]);
+
+      openMaterial(id);
+
+      cy.get('app-filament-remaining-card').should(
+        'contain.text',
+        `${Math.round(remainingMg / 1000)} g`
+      );
+      stat('Length').should('have.text', '250 m');
+      stat('Volume').should(
+        'have.text',
+        `${oneDecimal(remainingMg / 1000 / PLA_DENSITY)} ml`
+      );
+    });
+  });
+
+  it('tracks a resin whose nominal figure was entered as a volume, and shows no length', () => {
+    // Resin has no diameter, so it has no length to report. A 0.0 m beside a full bottle
+    // reads as an empty one.
+    const density = 1.1;
+    const nominalMg = mgFromVolume(1000, density);
+    const usedMg = mgFromVolume(150, density);
+    const remainingMg = nominalMg - usedMg;
+
+    createMaterial('Volume Source Resin', {
+      categoryNickname: 'resin',
+      source: VOLUME,
+      density,
+      diameterMm: null,
+      initialNominalWeightMg: null,
+      initialNominalVolumeMl: 1000,
+    }).then((id) => {
+      logPrint('Usage Calc Resin', [volumeRow(id, 150)]);
+
+      openMaterial(id);
+
+      cy.get('app-filament-remaining-card').should(
+        'contain.text',
+        `${Math.round(remainingMg / 1000)} g`
+      );
+      stat('Volume').should('have.text', '850 ml');
+      noStat('Length');
+    });
+  });
+
+  it('falls back to the estimated amount when a print records no actual usage', () => {
+    createMaterial('Estimated Only Spool').then((id) => {
+      logPrint('Usage Calc Estimated', [
+        {
+          filamentId: id,
+          estimatedAmountMg: 40000,
+          estimatedSource: WEIGHT,
+        },
+      ]);
+
+      openMaterial(id);
+
+      cy.get('app-filament-remaining-card').should('contain.text', '960 g');
+      stat('Used').should('have.text', '40 g');
+    });
+  });
+
+  it('applies adjustments on top of print usage', () => {
+    // Adjustments are ADDED, so a negative one shortens the spool further.
+    createMaterial('Adjusted Usage Spool').then((id) => {
+      logPrint('Usage Calc Adjusted', [weightRow(id, 100)]);
+
+      request('GET', `/api/Filaments/${id}`).then((response) => {
+        const filament = response.body;
+        return request('PUT', `/api/Filaments/${id}`, {
+          ...filament,
+          filamentAdjustments: [
+            { amountMg: -50000, source: WEIGHT, notes: 'Purge tower' },
+          ],
+        });
+      });
+
+      openMaterial(id);
+
+      // 1000 - 100 used - 50 adjusted.
+      cy.get('app-filament-remaining-card').should('contain.text', '850 g');
+      stat('Used').should('have.text', '100 g');
+    });
+  });
+
+  it('reports the same remaining figure in the materials list and on the detail page', () => {
+    // The list and the detail page are two different projections of the same rule. They drifted
+    // apart once already, and only a spool with usage can tell them apart.
+    createMaterial('List Detail Agreement').then((id) => {
+      logPrint('Usage Calc Agreement A', [weightRow(id, 60)]);
+      logPrint('Usage Calc Agreement B', [lengthRow(id, 10)]);
+
+      const expectedG = Math.round((1000000 - 60000 - mgFromLength(10)) / 1000);
+
+      openMaterial(id);
+      cy.get('app-filament-remaining-card').should(
+        'contain.text',
+        `${expectedG} g`
+      );
+
+      cy.intercept('GET', '/api/Filaments*').as('getFilaments');
+      cy.visit('/filament');
+      cy.wait('@getFilaments');
+      cy.get('#filament-list-search-input')
+        .clear()
+        .type('List Detail Agreement');
+      cy.wait('@getFilaments');
+      cy.get('[data-cy-filament-row]')
+        .first()
+        .within(() => {
+          cy.get('.mat-column-filamentRemaining').should(
+            'contain.text',
+            String(expectedG)
+          );
+        });
+    });
+  });
+
+  it('reports an over-used spool rather than hiding it', () => {
+    // Logging more than the spool held is a data-entry reality, and the card says so instead
+    // of clamping to zero - the number below is what tells the user to check their prints.
+    createMaterial('Over Used Spool').then((id) => {
+      logPrint('Usage Calc Over A', [weightRow(id, 700)]);
+      logPrint('Usage Calc Over B', [weightRow(id, 450)]);
+
+      openMaterial(id);
+
+      cy.get('app-filament-remaining-card').should(
+        'contain.text',
+        '150 g over-used'
+      );
+      stat('Used').should('have.text', '1,150 g');
+    });
+  });
+});

--- a/src/app/core/resolvers/preferred-filament-display-unit-setting-resolver.service.ts
+++ b/src/app/core/resolvers/preferred-filament-display-unit-setting-resolver.service.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import {
-  UserSetting,
   UserSettingService,
   UserSettingType,
 } from 'src/app/core/services/user-setting.service';
@@ -12,18 +11,9 @@ import {
 export class PreferredFilamentDisplayUnitSettingResolverService {
   constructor(private readonly userSettingService: UserSettingService) {}
 
-  // Must never reject: a rejected resolver cancels navigation and bounces to /
-  // (#66), so without this a failed settings fetch would block the material
-  // detail page, which only wants the setting to format a number. Every
-  // consumer already treats the result as nullable.
-  resolve(
-    route: ActivatedRouteSnapshot,
-    state: RouterStateSnapshot
-  ): Promise<UserSetting | null> {
-    return this.userSettingService
-      .getCurrentUsersSettingByType(
-        UserSettingType.Prints_PreferredFilamentDisplayUnit
-      )
-      .catch(() => null);
+  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+    return this.userSettingService.getCurrentUsersSettingByType(
+      UserSettingType.Prints_PreferredFilamentDisplayUnit
+    );
   }
 }

--- a/src/app/core/resolvers/preferred-filament-display-unit-setting-resolver.service.ts
+++ b/src/app/core/resolvers/preferred-filament-display-unit-setting-resolver.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import {
+  UserSetting,
   UserSettingService,
   UserSettingType,
 } from 'src/app/core/services/user-setting.service';
@@ -11,9 +12,18 @@ import {
 export class PreferredFilamentDisplayUnitSettingResolverService {
   constructor(private readonly userSettingService: UserSettingService) {}
 
-  resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
-    return this.userSettingService.getCurrentUsersSettingByType(
-      UserSettingType.Prints_PreferredFilamentDisplayUnit
-    );
+  // Must never reject: a rejected resolver cancels navigation and bounces to /
+  // (#66), so without this a failed settings fetch would block the material
+  // detail page, which only wants the setting to format a number. Every
+  // consumer already treats the result as nullable.
+  resolve(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Promise<UserSetting | null> {
+    return this.userSettingService
+      .getCurrentUsersSettingByType(
+        UserSettingType.Prints_PreferredFilamentDisplayUnit
+      )
+      .catch(() => null);
   }
 }

--- a/src/app/core/services/filament.service.ts
+++ b/src/app/core/services/filament.service.ts
@@ -86,6 +86,27 @@ export interface FilamentDetail {
    * server ignores it on write, so writers may omit it.
    */
   filamentRemaining?: number | null;
+
+  /**
+   * Server-computed remaining length in meters. Null when the spool is untracked,
+   * matching `filamentRemaining`. Read-only: ignored on write.
+   */
+  filamentLengthRemainingInM?: number | null;
+
+  /**
+   * Server-computed remaining volume in milliliters. Null when the spool is
+   * untracked, matching `filamentRemaining`. Read-only: ignored on write.
+   */
+  filamentVolumeRemainingInMl?: number | null;
+
+  /** Distinct prints that used this filament. Read-only: ignored on write. */
+  printCount?: number;
+
+  /**
+   * Total milligrams consumed by prints, actual where recorded and estimated
+   * otherwise. Read-only: ignored on write.
+   */
+  totalUsedMg?: number;
 }
 
 export interface FilamentSummary {

--- a/src/app/documentation/docs/docs-filaments/docs-filaments.component.html
+++ b/src/app/documentation/docs/docs-filaments/docs-filaments.component.html
@@ -82,6 +82,51 @@
     <strong>Adjustments</strong> section below for more information.
   </p>
 
+  <h4 id="remaining-panel">Tracking What's Left on a Material</h4>
+  <p>
+    Open any saved material and you'll see a <strong>Remaining</strong> card
+    beside the form. A bar shows how full the roll is at a glance, with the
+    reading beneath it &mdash; for example <em>412 g of 1,000 g left</em>. Under
+    that, where 3D Print Log has enough information to work them out, you'll
+    also see the remaining <strong>Length</strong> in meters and
+    <strong>Volume</strong> in milliliters, along with how much material has been
+    <strong>Used</strong> in total and how many <strong>Prints</strong> it went
+    into.
+  </p>
+  <p>
+    If the card says <strong>Not tracked</strong>, the material has no Initial
+    Nominal Weight yet, so there is nothing to count down from. Use the
+    <strong>Set nominal weight</strong> button on the card to jump straight to
+    the field, enter the weight of a full roll, and save.
+  </p>
+  <p>
+    If the card shows a warning that the material is <strong>over-used</strong>,
+    more material has been logged against it than the roll was ever supposed to
+    hold. That usually means a print recorded more usage than it really consumed,
+    or the Initial Nominal Weight is too low. Check the prints listed on the card,
+    correct whichever one is wrong, or add an Adjustment to bring the roll back in
+    line with what you actually have.
+  </p>
+  <p>
+    While you're editing, the card previews your unsaved changes. Add an
+    adjustment or change the nominal weight and it shows both figures &mdash; the
+    current amount and what it will become <em>after saving</em>. Nothing is
+    committed until you save. When a change is too complex to preview reliably,
+    such as editing the material's density or diameter, the card simply says the
+    figure updates after saving rather than showing you a number it cannot stand
+    behind.
+  </p>
+
+  <h4 id="remaining-prints">Prints That Used This Material</h4>
+  <p>
+    Below the Remaining card is a list of the most recent prints that used this
+    material, newest first, each showing how much it consumed. Usage marked with
+    an asterisk is an estimate rather than a measured amount. Click any print to
+    open it. If the material has been used more times than the list shows, a
+    <strong>View all</strong> link opens the full print list already filtered to
+    this material.
+  </p>
+
   <hr />
 
   <h3 id="add">Add a new roll of Material</h3>

--- a/src/app/documentation/docs/docs-filaments/docs-filaments.component.html
+++ b/src/app/documentation/docs/docs-filaments/docs-filaments.component.html
@@ -75,6 +75,12 @@
     it'll use the <strong>Estimated Material Used</strong>.
   </p>
   <p>
+    Usage recorded as a length or a volume counts exactly the same. 3D Print Log
+    converts it to a weight using the material's density and diameter, so it
+    does not matter which measurement you enter on a print &mdash; the roll
+    counts down by the same amount either way.
+  </p>
+  <p>
     <strong>Material Adjustments</strong> are entered when Adding/Editing a
     material, and represent non-print usage of material. Useful for documenting
     the wasted materials when changing colors, or adjusting a material's weight
@@ -92,6 +98,12 @@
     <strong>Volume</strong> in milliliters, along with how much material has
     been <strong>Used</strong> in total and how many <strong>Prints</strong> it
     went into.
+  </p>
+  <p>
+    Length and Volume are the remaining weight converted using the material's
+    density and diameter, so all three readings always describe the same roll.
+    Materials measured in a container rather than on a spool &mdash; resins and
+    powders &mdash; have no diameter, so they show a Volume but no Length.
   </p>
   <p>
     If the card says <strong>Not tracked</strong>, the material has no Initial

--- a/src/app/documentation/docs/docs-filaments/docs-filaments.component.html
+++ b/src/app/documentation/docs/docs-filaments/docs-filaments.component.html
@@ -89,9 +89,9 @@
     reading beneath it &mdash; for example <em>412 g of 1,000 g left</em>. Under
     that, where 3D Print Log has enough information to work them out, you'll
     also see the remaining <strong>Length</strong> in meters and
-    <strong>Volume</strong> in milliliters, along with how much material has been
-    <strong>Used</strong> in total and how many <strong>Prints</strong> it went
-    into.
+    <strong>Volume</strong> in milliliters, along with how much material has
+    been <strong>Used</strong> in total and how many <strong>Prints</strong> it
+    went into.
   </p>
   <p>
     If the card says <strong>Not tracked</strong>, the material has no Initial
@@ -102,15 +102,15 @@
   <p>
     If the card shows a warning that the material is <strong>over-used</strong>,
     more material has been logged against it than the roll was ever supposed to
-    hold. That usually means a print recorded more usage than it really consumed,
-    or the Initial Nominal Weight is too low. Check the prints listed on the card,
-    correct whichever one is wrong, or add an Adjustment to bring the roll back in
-    line with what you actually have.
+    hold. That usually means a print recorded more usage than it really
+    consumed, or the Initial Nominal Weight is too low. Check the prints listed
+    on the card, correct whichever one is wrong, or add an Adjustment to bring
+    the roll back in line with what you actually have.
   </p>
   <p>
     While you're editing, the card previews your unsaved changes. Add an
-    adjustment or change the nominal weight and it shows both figures &mdash; the
-    current amount and what it will become <em>after saving</em>. Nothing is
+    adjustment or change the nominal weight and it shows both figures &mdash;
+    the current amount and what it will become <em>after saving</em>. Nothing is
     committed until you save. When a change is too complex to preview reliably,
     such as editing the material's density or diameter, the card simply says the
     figure updates after saving rather than showing you a number it cannot stand

--- a/src/app/filament/filament-detail/filament-detail.component.html
+++ b/src/app/filament/filament-detail/filament-detail.component.html
@@ -1,25 +1,44 @@
 <div class="detail-layout" [class.has-rail]="showUsagePanels()">
-  <!-- The stats card sits before the form in the DOM because that is the order it
-       is read in on a narrow viewport. Grid areas move it to the right-hand rail on
-       wide viewports, but grid reordering does not move keyboard or screen-reader
-       order, so the DOM has to carry the meaningful sequence itself. -->
-  @if (showUsagePanels()) {
-    <div class="rail-stats">
-      <app-filament-remaining-card
-        [remainingMg]="remainingProjection().remainingMg"
-        [projectedMg]="remainingProjection().projectedMg"
-        [isSuppressed]="remainingProjection().isSuppressed"
-        [nominalMg]="loadedFilament?.initialNominalWeightMg ?? null"
-        [lengthRemainingM]="loadedFilament?.filamentLengthRemainingInM ?? null"
-        [volumeRemainingMl]="
-          loadedFilament?.filamentVolumeRemainingInMl ?? null
-        "
-        [totalUsedMg]="loadedFilament?.totalUsedMg ?? null"
-        [printCount]="loadedFilament?.printCount ?? null"
-        (focusNominalWeight)="focusNominalWeight()"
-      ></app-filament-remaining-card>
+  <!-- The rail is one element so that it occupies a single grid area on wide
+       viewports. Splitting it across per-card areas let the tall form stretch the
+       rail rows apart, and it capped each sticky card's travel at its own row.
+       The rail sits before the form in the DOM so the read-only summary is read
+       first; on narrow viewports `order` restores the visual sequence the page
+       has always had (remaining, form, prints, ad). -->
+  <div class="detail-rail">
+    <div class="rail-sticky">
+      @if (showUsagePanels()) {
+        <div class="rail-stats">
+          <app-filament-remaining-card
+            [remainingMg]="remainingProjection().remainingMg"
+            [projectedMg]="remainingProjection().projectedMg"
+            [isSuppressed]="remainingProjection().isSuppressed"
+            [nominalMg]="loadedFilament?.initialNominalWeightMg ?? null"
+            [lengthRemainingM]="
+              loadedFilament?.filamentLengthRemainingInM ?? null
+            "
+            [volumeRemainingMl]="
+              loadedFilament?.filamentVolumeRemainingInMl ?? null
+            "
+            [totalUsedMg]="loadedFilament?.totalUsedMg ?? null"
+            [printCount]="loadedFilament?.printCount ?? null"
+            (focusNominalWeight)="focusNominalWeight()"
+          ></app-filament-remaining-card>
+        </div>
+
+        <div class="rail-prints">
+          <app-filament-prints-panel
+            [filamentId]="loadedFilament.id"
+            [preferredUnit]="preferredFilamentUnit"
+          ></app-filament-prints-panel>
+        </div>
+      }
     </div>
-  }
+
+    <div class="rail-ad">
+      <app-sidebar-ad></app-sidebar-ad>
+    </div>
+  </div>
 
   <mat-card appearance="outlined" class="form-card">
     <form
@@ -1063,17 +1082,4 @@
     </form>
     <app-ad></app-ad>
   </mat-card>
-
-  @if (showUsagePanels()) {
-    <div class="rail-prints">
-      <app-filament-prints-panel
-        [filamentId]="loadedFilament.id"
-        [preferredUnit]="preferredFilamentUnit"
-      ></app-filament-prints-panel>
-    </div>
-  }
-
-  <div class="rail-ad">
-    <app-sidebar-ad></app-sidebar-ad>
-  </div>
 </div>

--- a/src/app/filament/filament-detail/filament-detail.component.html
+++ b/src/app/filament/filament-detail/filament-detail.component.html
@@ -1,5 +1,5 @@
-<div fxLayout="row" fxLayoutAlign="center start" fxLayoutGap="24px">
-  <mat-card appearance="outlined" fxFlex="500px" fxFlex.xs="100%">
+<div class="detail-layout" [class.has-rail]="showUsagePanels()">
+  <mat-card appearance="outlined" class="form-card">
     <form
       [formGroup]="filamentForm"
       (ngSubmit)="onSubmit()"
@@ -1041,7 +1041,31 @@
     </form>
     <app-ad></app-ad>
   </mat-card>
-  <div fxHide fxShow.gt-md fxFlex="300px" class="ad-sidebar">
+
+  @if (showUsagePanels()) {
+    <div class="rail-stats">
+      <app-filament-remaining-card
+        [remainingMg]="remainingProjection().remainingMg"
+        [projectedMg]="remainingProjection().projectedMg"
+        [isSuppressed]="remainingProjection().isSuppressed"
+        [nominalMg]="loadedFilament?.initialNominalWeightMg ?? null"
+        [lengthRemainingM]="loadedFilament?.filamentLengthRemainingInM ?? null"
+        [volumeRemainingMl]="loadedFilament?.filamentVolumeRemainingInMl ?? null"
+        [totalUsedMg]="loadedFilament?.totalUsedMg ?? null"
+        [printCount]="loadedFilament?.printCount ?? null"
+        (focusNominalWeight)="focusNominalWeight()"
+      ></app-filament-remaining-card>
+    </div>
+
+    <div class="rail-prints">
+      <app-filament-prints-panel
+        [filamentId]="loadedFilament.id"
+        [preferredUnit]="preferredFilamentUnit"
+      ></app-filament-prints-panel>
+    </div>
+  }
+
+  <div class="rail-ad">
     <app-sidebar-ad></app-sidebar-ad>
   </div>
 </div>

--- a/src/app/filament/filament-detail/filament-detail.component.html
+++ b/src/app/filament/filament-detail/filament-detail.component.html
@@ -1,4 +1,26 @@
 <div class="detail-layout" [class.has-rail]="showUsagePanels()">
+  <!-- The stats card sits before the form in the DOM because that is the order it
+       is read in on a narrow viewport. Grid areas move it to the right-hand rail on
+       wide viewports, but grid reordering does not move keyboard or screen-reader
+       order, so the DOM has to carry the meaningful sequence itself. -->
+  @if (showUsagePanels()) {
+    <div class="rail-stats">
+      <app-filament-remaining-card
+        [remainingMg]="remainingProjection().remainingMg"
+        [projectedMg]="remainingProjection().projectedMg"
+        [isSuppressed]="remainingProjection().isSuppressed"
+        [nominalMg]="loadedFilament?.initialNominalWeightMg ?? null"
+        [lengthRemainingM]="loadedFilament?.filamentLengthRemainingInM ?? null"
+        [volumeRemainingMl]="
+          loadedFilament?.filamentVolumeRemainingInMl ?? null
+        "
+        [totalUsedMg]="loadedFilament?.totalUsedMg ?? null"
+        [printCount]="loadedFilament?.printCount ?? null"
+        (focusNominalWeight)="focusNominalWeight()"
+      ></app-filament-remaining-card>
+    </div>
+  }
+
   <mat-card appearance="outlined" class="form-card">
     <form
       [formGroup]="filamentForm"
@@ -1043,22 +1065,6 @@
   </mat-card>
 
   @if (showUsagePanels()) {
-    <div class="rail-stats">
-      <app-filament-remaining-card
-        [remainingMg]="remainingProjection().remainingMg"
-        [projectedMg]="remainingProjection().projectedMg"
-        [isSuppressed]="remainingProjection().isSuppressed"
-        [nominalMg]="loadedFilament?.initialNominalWeightMg ?? null"
-        [lengthRemainingM]="loadedFilament?.filamentLengthRemainingInM ?? null"
-        [volumeRemainingMl]="
-          loadedFilament?.filamentVolumeRemainingInMl ?? null
-        "
-        [totalUsedMg]="loadedFilament?.totalUsedMg ?? null"
-        [printCount]="loadedFilament?.printCount ?? null"
-        (focusNominalWeight)="focusNominalWeight()"
-      ></app-filament-remaining-card>
-    </div>
-
     <div class="rail-prints">
       <app-filament-prints-panel
         [filamentId]="loadedFilament.id"

--- a/src/app/filament/filament-detail/filament-detail.component.html
+++ b/src/app/filament/filament-detail/filament-detail.component.html
@@ -1050,7 +1050,9 @@
         [isSuppressed]="remainingProjection().isSuppressed"
         [nominalMg]="loadedFilament?.initialNominalWeightMg ?? null"
         [lengthRemainingM]="loadedFilament?.filamentLengthRemainingInM ?? null"
-        [volumeRemainingMl]="loadedFilament?.filamentVolumeRemainingInMl ?? null"
+        [volumeRemainingMl]="
+          loadedFilament?.filamentVolumeRemainingInMl ?? null
+        "
         [totalUsedMg]="loadedFilament?.totalUsedMg ?? null"
         [printCount]="loadedFilament?.printCount ?? null"
         (focusNominalWeight)="focusNominalWeight()"

--- a/src/app/filament/filament-detail/filament-detail.component.scss
+++ b/src/app/filament/filament-detail/filament-detail.component.scss
@@ -45,35 +45,18 @@ mat-card-title {
   }
 }
 
-// The page is a single DOM order (form, then rail cards) reordered by grid
-// areas, so the mobile reading order puts the remaining figure first without
-// duplicating any markup.
+// One column on narrow viewports, laid out in DOM order: stats, form, prints, ad.
+// No named areas here on purpose — declaring the four rows explicitly would keep
+// their 24px gaps even in add and copy mode, where the stats and prints elements
+// do not exist and the ad is hidden, leaving stray space around the form.
 .detail-layout {
   display: grid;
   gap: 24px;
   justify-content: center;
   grid-template-columns: minmax(0, 560px);
-  grid-template-areas:
-    'stats'
-    'form'
-    'prints'
-    'ad';
-}
-
-.form-card {
-  grid-area: form;
-}
-
-.rail-stats {
-  grid-area: stats;
-}
-
-.rail-prints {
-  grid-area: prints;
 }
 
 .rail-ad {
-  grid-area: ad;
   // Matches the `fxHide fxShow.gt-md` this element replaces: ngx-layout's
   // `gt-md` is `min-width: 1280px`, the same threshold used below.
   display: none;
@@ -81,7 +64,9 @@ mat-card-title {
 
 @media (min-width: 1280px) {
   // With the rail: stats, prints and the ad share one 340px column, so the page
-  // absorbs the old ad sidebar rather than becoming three columns.
+  // absorbs the ad sidebar that already lived there rather than becoming three
+  // columns. Named areas exist only at this width, and every child is assigned
+  // one here so no item is auto-placed into an implicit track.
   .detail-layout.has-rail {
     grid-template-columns: minmax(0, 560px) 340px;
     grid-template-areas:
@@ -89,21 +74,42 @@ mat-card-title {
       'form prints'
       'form ad';
     align-items: start;
+
+    .form-card {
+      grid-area: form;
+    }
+
+    .rail-stats {
+      grid-area: stats;
+      // Keeps the number on screen while the user scrolls the long form down to
+      // the Weights section, which is exactly when it matters.
+      position: sticky;
+      top: 16px;
+    }
+
+    .rail-prints {
+      grid-area: prints;
+    }
+
+    .rail-ad {
+      grid-area: ad;
+    }
   }
 
-  // Add and copy modes have no rail content, but the ad keeps the side
-  // placement it has today rather than dropping below the form.
+  // Add and copy modes have no rail content, but the ad keeps the side placement
+  // it has today rather than dropping below the form.
   .detail-layout:not(.has-rail) {
     grid-template-columns: minmax(0, 560px) 300px;
     grid-template-areas: 'form ad';
     align-items: start;
-  }
 
-  .detail-layout.has-rail .rail-stats {
-    // Keeps the number on screen while the user scrolls the long form down to
-    // the Weights section, which is exactly when it matters.
-    position: sticky;
-    top: 16px;
+    .form-card {
+      grid-area: form;
+    }
+
+    .rail-ad {
+      grid-area: ad;
+    }
   }
 
   .rail-ad {

--- a/src/app/filament/filament-detail/filament-detail.component.scss
+++ b/src/app/filament/filament-detail/filament-detail.component.scss
@@ -44,3 +44,69 @@ mat-card-title {
     pointer-events: none;
   }
 }
+
+// The page is a single DOM order (form, then rail cards) reordered by grid
+// areas, so the mobile reading order puts the remaining figure first without
+// duplicating any markup.
+.detail-layout {
+  display: grid;
+  gap: 24px;
+  justify-content: center;
+  grid-template-columns: minmax(0, 560px);
+  grid-template-areas:
+    'stats'
+    'form'
+    'prints'
+    'ad';
+}
+
+.form-card {
+  grid-area: form;
+}
+
+.rail-stats {
+  grid-area: stats;
+}
+
+.rail-prints {
+  grid-area: prints;
+}
+
+.rail-ad {
+  grid-area: ad;
+  // Matches the `fxHide fxShow.gt-md` this element replaces: ngx-layout's
+  // `gt-md` is `min-width: 1280px`, the same threshold used below.
+  display: none;
+}
+
+@media (min-width: 1280px) {
+  // With the rail: stats, prints and the ad share one 340px column, so the page
+  // absorbs the old ad sidebar rather than becoming three columns.
+  .detail-layout.has-rail {
+    grid-template-columns: minmax(0, 560px) 340px;
+    grid-template-areas:
+      'form stats'
+      'form prints'
+      'form ad';
+    align-items: start;
+  }
+
+  // Add and copy modes have no rail content, but the ad keeps the side
+  // placement it has today rather than dropping below the form.
+  .detail-layout:not(.has-rail) {
+    grid-template-columns: minmax(0, 560px) 300px;
+    grid-template-areas: 'form ad';
+    align-items: start;
+  }
+
+  .detail-layout.has-rail .rail-stats {
+    // Keeps the number on screen while the user scrolls the long form down to
+    // the Weights section, which is exactly when it matters.
+    position: sticky;
+    top: 16px;
+  }
+
+  .rail-ad {
+    display: block;
+  }
+}

--- a/src/app/filament/filament-detail/filament-detail.component.scss
+++ b/src/app/filament/filament-detail/filament-detail.component.scss
@@ -45,15 +45,28 @@ mat-card-title {
   }
 }
 
-// One column on narrow viewports, laid out in DOM order: stats, form, prints, ad.
-// No named areas here on purpose — declaring the four rows explicitly would keep
-// their 24px gaps even in add and copy mode, where the stats and prints elements
-// do not exist and the ad is hidden, leaving stray space around the form.
+// One column on narrow viewports, laid out in the order the page has always used:
+// stats, form, prints, ad. The rail wrappers collapse with `display: contents` so
+// their children are grid items here, and `order` on the form puts it back between
+// the remaining card and the prints panel. No named areas at this width on purpose
+// — declaring rows explicitly would keep their 24px gaps in add and copy mode,
+// where the stats and prints elements do not exist and the ad is hidden, leaving
+// stray space around the form.
 .detail-layout {
   display: grid;
   gap: 24px;
   justify-content: center;
   grid-template-columns: minmax(0, 560px);
+}
+
+.detail-rail,
+.rail-sticky {
+  display: contents;
+}
+
+.rail-prints,
+.rail-ad {
+  order: 1;
 }
 
 .rail-ad {
@@ -63,52 +76,70 @@ mat-card-title {
 }
 
 @media (min-width: 1280px) {
-  // With the rail: stats, prints and the ad share one 340px column, so the page
-  // absorbs the ad sidebar that already lived there rather than becoming three
-  // columns. Named areas exist only at this width, and every child is assigned
-  // one here so no item is auto-placed into an implicit track.
+  // With the rail: the remaining card, the prints panel and the ad share one
+  // 340px column, so the page absorbs the ad sidebar that already lived there
+  // rather than becoming three columns. The rail is a single grid area — giving
+  // each card its own row made the tall form stretch the rows apart and stranded
+  // the prints panel in the vertical middle of the page.
   .detail-layout.has-rail {
     grid-template-columns: minmax(0, 560px) 340px;
-    grid-template-areas:
-      'form stats'
-      'form prints'
-      'form ad';
-    align-items: start;
+    grid-template-areas: 'form rail';
 
     .form-card {
       grid-area: form;
     }
 
-    .rail-stats {
-      grid-area: stats;
-      // Keeps the number on screen while the user scrolls the long form down to
-      // the Weights section, which is exactly when it matters.
+    .detail-rail {
+      grid-area: rail;
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+      // Stretch to the form's height. A sticky child can only travel inside its
+      // containing block, so a content-height rail would unstick almost at once.
+      align-self: stretch;
+    }
+
+    .rail-sticky {
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
       position: sticky;
-      top: 16px;
+      // Clears the 64px fixed navbar, matching `.ad-sidebar` in styles.scss.
+      // Keeps the remaining number and the recent prints on screen while the
+      // user scrolls the long form down to the Weights section, which is
+      // exactly when they matter.
+      top: 80px;
+      // Backstop for short viewports: the group scrolls within itself rather
+      // than pushing its lower half off screen.
+      max-height: calc(100vh - 96px);
+      overflow-y: auto;
+      overscroll-behavior: contain;
     }
 
-    .rail-prints {
-      grid-area: prints;
-    }
-
+    .rail-prints,
     .rail-ad {
-      grid-area: ad;
+      order: 0;
     }
   }
 
-  // Add and copy modes have no rail content, but the ad keeps the side placement
-  // it has today rather than dropping below the form.
+  // Add and copy modes have no rail content, so the rail carries only the ad and
+  // keeps the side placement it has today rather than dropping below the form.
   .detail-layout:not(.has-rail) {
     grid-template-columns: minmax(0, 560px) 300px;
-    grid-template-areas: 'form ad';
+    grid-template-areas: 'form rail';
     align-items: start;
 
     .form-card {
       grid-area: form;
     }
 
+    .detail-rail {
+      grid-area: rail;
+      display: block;
+    }
+
     .rail-ad {
-      grid-area: ad;
+      order: 0;
     }
   }
 

--- a/src/app/filament/filament-detail/filament-detail.component.spec.ts
+++ b/src/app/filament/filament-detail/filament-detail.component.spec.ts
@@ -23,7 +23,12 @@ import {
 import { LoggingService } from 'src/app/core/services/logging.service';
 import { UserSettingService } from 'src/app/core/services/user-setting.service';
 
+import { PrintService } from 'src/app/core/services/print.service';
+import { FilamentSourceMeasurement } from 'src/app/core/services/filament.service';
+
 import { FilamentDetailComponent } from './filament-detail.component';
+import { FilamentPrintsPanelComponent } from './filament-prints-panel/filament-prints-panel.component';
+import { FilamentRemainingCardComponent } from './filament-remaining-card/filament-remaining-card.component';
 
 describe('FilamentDetailComponent', () => {
   let component: FilamentDetailComponent;
@@ -97,6 +102,15 @@ describe('FilamentDetailComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('renders neither usage card in add mode', () => {
+    expect(
+      fixture.nativeElement.querySelector('app-filament-remaining-card')
+    ).toBeNull();
+    expect(
+      fixture.nativeElement.querySelector('app-filament-prints-panel')
+    ).toBeNull();
   });
 
   describe('color pattern form', () => {
@@ -526,5 +540,162 @@ describe('FilamentDetailComponent - value serialization', () => {
     expect(adj.length).toBe(1);
     expect(adj[0].amountMg).toBeNull(); // was silently becoming 0 on load
     expect(adj[0].lengthInM).toBe(100);
+  });
+});
+
+describe('FilamentDetailComponent - usage panels', () => {
+  let usageComponent: FilamentDetailComponent;
+  let usageFixture: ComponentFixture<FilamentDetailComponent>;
+
+  const savedFilament = {
+    id: 'filament-1',
+    displayName: 'Test',
+    materialType: 'PLA',
+    materialDensityGramPerCubicCm: 1.24,
+    diameterMm: 1.75,
+    source: FilamentSourceMeasurement.Weight,
+    initialNominalWeightMg: 1000000,
+    filamentRemaining: 412000,
+    filamentLengthRemainingInM: 138.2,
+    filamentVolumeRemainingInMl: 345.1,
+    printCount: 23,
+    totalUsedMg: 588000,
+    filamentAdjustments: [],
+    colors: [],
+  };
+
+  async function setup(filamentOverrides: Record<string, unknown> = {}) {
+    const mockFilamentService = jasmine.createSpyObj<FilamentService>(
+      'FilamentService',
+      {
+        getFilamentBrands: of({ brands: [] }),
+        getFilamentPurchaseLocations: of({ purchaseLocations: [] }),
+        getFilamentStorageLocations: of({ storageLocations: [] }),
+      }
+    );
+    const mockToastr = jasmine.createSpyObj<ToastrService>('ToastrService', [
+      'success',
+    ]);
+    const mockUserSettings = jasmine.createSpyObj<UserSettingService>(
+      'UserSettingService',
+      ['updateUserSetting']
+    );
+    const mockLog = jasmine.createSpyObj<LoggingService>('LoggingService', [
+      'logException',
+      'logEvent',
+    ]);
+    const mockPrintService = jasmine.createSpyObj<PrintService>(
+      'PrintService',
+      ['getPrintSummaries', 'getPrintImage']
+    );
+    mockPrintService.getPrintSummaries.and.returnValue(
+      of({ items: [], paging: { totalCount: 0 } } as never)
+    );
+    mockPrintService.getPrintImage.and.returnValue(of(''));
+
+    await TestBed.configureTestingModule({
+      declarations: [FilamentDetailComponent],
+      imports: [
+        RouterTestingModule,
+        FormsModule,
+        ReactiveFormsModule,
+        MatInputModule,
+        MatSelectModule,
+        MatDatepickerModule,
+        MatCheckboxModule,
+        MatNativeDateModule,
+        MatAutocompleteModule,
+        MatButtonToggleModule,
+        MatChipsModule,
+        MatButtonModule,
+        MatTooltipModule,
+        FilamentRemainingCardComponent,
+        FilamentPrintsPanelComponent,
+      ],
+      providers: [
+        { provide: FilamentService, useValue: mockFilamentService },
+        { provide: ToastrService, useValue: mockToastr },
+        { provide: UserSettingService, useValue: mockUserSettings },
+        { provide: LoggingService, useValue: mockLog },
+        { provide: PrintService, useValue: mockPrintService },
+        { provide: MAT_DATE_LOCALE, useValue: 'en-US' },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            data: of({
+              filament: { ...savedFilament, ...filamentOverrides },
+              materials: [],
+              materialCategories: [],
+            }),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    usageFixture = TestBed.createComponent(FilamentDetailComponent);
+    usageComponent = usageFixture.componentInstance;
+    usageFixture.detectChanges();
+  }
+
+  it('renders both usage cards for a saved filament', async () => {
+    await setup();
+    expect(
+      usageFixture.nativeElement.querySelector('app-filament-remaining-card')
+    ).toBeTruthy();
+    expect(
+      usageFixture.nativeElement.querySelector('app-filament-prints-panel')
+    ).toBeTruthy();
+  });
+
+  it('renders neither card in copy mode', async () => {
+    // CopyFilamentDetailResolverService nulls the id: the clone's remaining and
+    // prints belong to the source spool, not to the copy.
+    await setup({ id: null });
+    expect(
+      usageFixture.nativeElement.querySelector('app-filament-remaining-card')
+    ).toBeNull();
+    expect(
+      usageFixture.nativeElement.querySelector('app-filament-prints-panel')
+    ).toBeNull();
+  });
+
+  it('does not mark the form dirty when the cards render', async () => {
+    await setup();
+    // A false dirty state would trip PendingChangesGuard and block navigation.
+    expect(usageComponent.filamentForm.dirty).toBeFalse();
+  });
+
+  it('projects the server value while the form is untouched', async () => {
+    await setup();
+    expect(usageComponent.remainingProjection().projectedMg).toBe(
+      usageComponent.remainingProjection().remainingMg
+    );
+    expect(usageComponent.remainingProjection().projectedMg).toBe(412000);
+  });
+
+  it('projects a pending adjustment', async () => {
+    await setup();
+    const before = usageComponent.remainingProjection().projectedMg!;
+
+    usageComponent.addAdjustment();
+    usageComponent.filamentAdjustments.at(0).get('amountG')!.setValue(-32);
+    usageFixture.detectChanges();
+
+    expect(usageComponent.remainingProjection().projectedMg).toBeCloseTo(
+      before - 32000,
+      0
+    );
+  });
+
+  it('projects an edited nominal weight', async () => {
+    await setup();
+
+    usageComponent.filamentForm.get('initialNominalWeightG')!.setValue(1200);
+    usageFixture.detectChanges();
+
+    expect(usageComponent.remainingProjection().projectedMg).toBeCloseTo(
+      612000,
+      0
+    );
   });
 });

--- a/src/app/filament/filament-detail/filament-detail.component.ts
+++ b/src/app/filament/filament-detail/filament-detail.component.ts
@@ -5,6 +5,8 @@ import {
   HostListener,
   OnDestroy,
   OnInit,
+  computed,
+  signal,
 } from '@angular/core';
 import {
   UntypedFormArray,
@@ -50,8 +52,63 @@ import {
   SpoolWeightCalculatorDialogResult,
 } from '../spool-weight-calculator-dialog/spool-weight-calculator-dialog.component';
 import { resolveSpoolWeightMg } from '../spool-weight-calculator-dialog/spool-weight-adjustment.util';
+import { PrintFilamentSourceMeasurement } from 'src/app/core/services/print.service';
+import {
+  AdjustmentRow,
+  ProjectionResult,
+  projectRemainingMg,
+} from './remaining-projection';
 
 const EMPTY_GUID = '00000000-0000-0000-0000-000000000000';
+
+function gramsToMg(grams: number | null | undefined): number | null {
+  return grams == null ? null : grams * 1000;
+}
+
+/**
+ * Adjustment rows out of the form. Weight rows are converted from the form's
+ * grams to milligrams; length and volume rows are passed through in their own
+ * units, because `projectRemainingMg` converts them itself from the CURRENT
+ * density and diameter rather than trusting the stale derived milligrams.
+ */
+function toFormAdjustmentRows(
+  value: Record<string, unknown> | null
+): AdjustmentRow[] {
+  const rows = (value?.['filamentAdjustments'] ?? []) as {
+    source?: number;
+    amountG?: number | null;
+    lengthInM?: number | null;
+    volumeMl?: number | null;
+  }[];
+
+  return rows.map((row) => ({
+    source:
+      row.source == null
+        ? PrintFilamentSourceMeasurement.Weight
+        : (row.source as PrintFilamentSourceMeasurement),
+    amountMg: row.amountG == null ? null : row.amountG * 1000,
+    lengthInM: row.lengthInM ?? null,
+    volumeMl: row.volumeMl ?? null,
+  }));
+}
+
+/**
+ * The same rows as last saved. Already in milligrams; no gram conversion.
+ *
+ * `FilamentAdjustmentSourceMeasurement` and `PrintFilamentSourceMeasurement`
+ * both number Weight 1, Length 2, Volume 3, which is what makes this cast safe.
+ * They are separate enums: if a future member diverges, map explicitly.
+ */
+function toServerAdjustmentRows(
+  filament: FilamentDetail | null | undefined
+): AdjustmentRow[] {
+  return (filament?.filamentAdjustments ?? []).map((adjustment) => ({
+    source: adjustment.source as unknown as PrintFilamentSourceMeasurement,
+    amountMg: adjustment.amountMg ?? null,
+    lengthInM: adjustment.lengthInM ?? null,
+    volumeMl: adjustment.volumeMl ?? null,
+  }));
+}
 
 @Component({
   selector: 'app-filament-detail',
@@ -144,6 +201,76 @@ export class FilamentDetailComponent
   normalizedColors: string[] = [];
   private colorsSubscription: Subscription;
 
+  /**
+   * Mirrors the form value so computed signals can react to edits. Reading a
+   * form's value never marks it dirty, so `PendingChangesGuard` is unaffected.
+   */
+  private readonly formValue = signal<Record<string, unknown> | null>(null);
+  private formValueSubscription: Subscription;
+
+  /** False in add mode (no filament) and copy mode (a clone is not the source spool). */
+  protected readonly showUsagePanels = signal(false);
+
+  /** The user's preferred filament unit, resolved on the route. */
+  protected preferredFilamentUnit = PrintFilamentSourceMeasurement.Weight;
+
+  /**
+   * Public rather than protected: the spec asserts on it directly, and
+   * `protected` would not compile from the test file.
+   */
+  public readonly remainingProjection = computed<ProjectionResult>(() => {
+    const form = this.formValue();
+    const filament = this.loadedFilament;
+
+    return projectRemainingMg({
+      serverRemainingMg: filament?.filamentRemaining ?? null,
+      serverNominalMg: filament?.initialNominalWeightMg ?? null,
+      formNominalMg: gramsToMg(
+        form?.['initialNominalWeightG'] as number | null
+      ),
+      serverAdjustments: toServerAdjustmentRows(filament),
+      formAdjustments: toFormAdjustmentRows(form),
+      serverNominalM: filament?.initialNominalLengthM ?? null,
+      formNominalM: (form?.['initialNominalLengthM'] as number | null) ?? null,
+      serverNominalMl: filament?.initialNominalVolumeMl ?? null,
+      formNominalMl:
+        (form?.['initialNominalVolumeMl'] as number | null) ?? null,
+      source:
+        (form?.['source'] as PrintFilamentSourceMeasurement) ??
+        PrintFilamentSourceMeasurement.Weight,
+      filament: {
+        materialDensityGramPerCubicCm: form?.[
+          'materialDensityGramPerCubicCm'
+        ] as number,
+        diameterMm: form?.['diameterMm'] as number,
+      },
+      serverFilament: {
+        materialDensityGramPerCubicCm: filament?.materialDensityGramPerCubicCm,
+        diameterMm: filament?.diameterMm ?? undefined,
+      },
+    });
+  });
+
+  /**
+   * Scrolls to and focuses the nominal field the spool actually shows. A
+   * length- or volume-sourced spool never renders `initialNominalWeightG`, so
+   * targeting it unconditionally would make the button do nothing there.
+   */
+  protected focusNominalWeight(): void {
+    const controlName =
+      {
+        [FilamentSourceMeasurement.Length]: 'initialNominalLengthM',
+        [FilamentSourceMeasurement.Volume]: 'initialNominalVolumeMl',
+      }[this.filamentForm.get('source')?.value as FilamentSourceMeasurement] ??
+      'initialNominalWeightG';
+
+    const input = this.el.nativeElement.querySelector(
+      `[formcontrolname="${controlName}"]`
+    ) as HTMLInputElement | null;
+    input?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    input?.focus();
+  }
+
   ngOnInit() {
     this.titleService.setTitle('Filament Details - 3D Print Log');
 
@@ -162,6 +289,31 @@ export class FilamentDetailComponent
 
       this.filamentForm = this.buildFormFromFilamentDetail(data.filament);
       this.loadedFilament = (data.filament as FilamentDetail) ?? null;
+
+      // `AsRecorded` is 0, so `|| Weight` would silently coerce a valid
+      // preference into the wrong unit. Test for null, not for falsiness.
+      const unitSetting = (
+        data.preferredFilamentDisplayUnitSetting as UserSetting | null
+      )?.value;
+      const parsedUnit = unitSetting == null ? NaN : Number(unitSetting);
+      this.preferredFilamentUnit = Number.isFinite(parsedUnit)
+        ? (parsedUnit as PrintFilamentSourceMeasurement)
+        : PrintFilamentSourceMeasurement.Weight;
+
+      // Copy mode nulls the id (CopyFilamentDetailResolverService), and add
+      // mode has no filament at all, so the id alone rules out both: a clone's
+      // remaining and prints belong to the source spool, not to the copy. This
+      // is the same saved check canShowSpoolCalculator already uses.
+      const filamentId = this.loadedFilament?.id;
+      this.showUsagePanels.set(!!filamentId && filamentId !== EMPTY_GUID);
+
+      this.formValue.set(this.filamentForm.getRawValue());
+      this.formValueSubscription?.unsubscribe();
+      this.formValueSubscription = this.filamentForm.valueChanges.subscribe(
+        () => {
+          this.formValue.set(this.filamentForm.getRawValue());
+        }
+      );
 
       this.normalizedColors = this.computeNormalizedColors();
       this.colorsSubscription = this.colorsFormArray.valueChanges.subscribe(
@@ -321,6 +473,7 @@ export class FilamentDetailComponent
   ngOnDestroy(): void {
     this.materialCategorySubscription?.unsubscribe();
     this.colorsSubscription?.unsubscribe();
+    this.formValueSubscription?.unsubscribe();
   }
 
   private computeNormalizedColors(): string[] {

--- a/src/app/filament/filament-detail/filament-print-row/filament-print-row.component.html
+++ b/src/app/filament/filament-detail/filament-print-row/filament-print-row.component.html
@@ -27,7 +27,12 @@
            usage resolves each row before summing, so the synthetic row it formats
            no longer knows that one of its contributions was an estimate. -->
       @if (isEstimated()) {
-        <span class="estimated-marker" matTooltip="Estimated usage" aria-label="Estimated">*</span>
+        <span
+          class="estimated-marker"
+          matTooltip="Estimated usage"
+          aria-label="Estimated"
+          >*</span
+        >
       }
     </span>
   }

--- a/src/app/filament/filament-detail/filament-print-row/filament-print-row.component.html
+++ b/src/app/filament/filament-detail/filament-print-row/filament-print-row.component.html
@@ -1,0 +1,34 @@
+<a class="print-row" [routerLink]="['/prints', print().id]">
+  <span class="thumb">
+    @if (hasImage()) {
+      <app-print-image
+        [printId]="print().id"
+        [imageId]="print().defaultPrintImageId"
+        [alt]="print().title"
+      ></app-print-image>
+    } @else {
+      <span class="thumb-placeholder" aria-hidden="true">
+        <mat-icon>photo_camera</mat-icon>
+      </span>
+    }
+  </span>
+
+  <span class="details">
+    <span class="title">{{ print().title }}</span>
+    @if (print().startDate) {
+      <span class="date">{{ print().startDate | date: 'mediumDate' }}</span>
+    }
+  </span>
+
+  @if (usageDisplay(); as display) {
+    <span class="usage">
+      {{ display.displayString }}
+      <!-- Read from isEstimated(), not display.isEstimated: a merged multi-row
+           usage resolves each row before summing, so the synthetic row it formats
+           no longer knows that one of its contributions was an estimate. -->
+      @if (isEstimated()) {
+        <span class="estimated-marker" matTooltip="Estimated usage" aria-label="Estimated">*</span>
+      }
+    </span>
+  }
+</a>

--- a/src/app/filament/filament-detail/filament-print-row/filament-print-row.component.scss
+++ b/src/app/filament/filament-detail/filament-print-row/filament-print-row.component.scss
@@ -1,0 +1,54 @@
+.print-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 4px;
+  color: inherit;
+  text-decoration: none;
+  border-radius: 4px;
+
+  &:hover,
+  &:focus-visible {
+    background: rgb(128 128 128 / 12%);
+  }
+}
+
+.thumb,
+.thumb-placeholder {
+  flex: 0 0 56px;
+  width: 56px;
+  height: 56px;
+  border-radius: 4px;
+  overflow: hidden;
+}
+
+.thumb-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgb(128 128 128 / 15%);
+  opacity: 0.6;
+}
+
+.details {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.date {
+  font-size: 0.75rem;
+  opacity: 0.75;
+}
+
+.usage {
+  flex: 0 0 auto;
+  font-variant-numeric: tabular-nums;
+}

--- a/src/app/filament/filament-detail/filament-print-row/filament-print-row.component.spec.ts
+++ b/src/app/filament/filament-detail/filament-print-row/filament-print-row.component.spec.ts
@@ -107,6 +107,48 @@ describe('FilamentPrintRowComponent', () => {
     expect(el.querySelector('.estimated-marker')).toBeFalsy();
   });
 
+  it('sums rows recorded in different units', () => {
+    // 12 g of actual weight plus a 10 m estimated length row. Totalling each
+    // column separately and then formatting with the FIRST row's source unit
+    // would report 12 g and silently drop the 10 m entirely.
+    const lengthRow = {
+      id: 'usage-length',
+      filament: {
+        id: FILAMENT_ID,
+        materialDensityGramPerCubicCm: 1.24,
+        diameterMm: 1.75,
+      },
+      estimatedLengthInM: 10,
+      estimatedSource: PrintFilamentSourceMeasurement.Length,
+      source: PrintFilamentSourceMeasurement.Length,
+    } as never;
+
+    const el = render(printWith([usage(12_000), lengthRow]));
+
+    // 10 m of 1.75mm PLA is ~29.8 g, so the total is ~41.8 g, not 12 g.
+    expect(el.textContent).not.toContain('12.0g');
+    expect(el.textContent).toContain('41.8g');
+  });
+
+  it('sums rows that are all recorded as lengths', () => {
+    const lengthRow = (m: number) =>
+      ({
+        id: 'usage-' + m,
+        filament: {
+          id: FILAMENT_ID,
+          materialDensityGramPerCubicCm: 1.24,
+          diameterMm: 1.75,
+        },
+        lengthInM: m,
+        source: PrintFilamentSourceMeasurement.Length,
+      }) as never;
+
+    const el = render(printWith([lengthRow(4), lengthRow(6)]));
+
+    // Preferred unit is Weight, so a combined 10 m converts to ~29.8 g.
+    expect(el.textContent).toContain('29.8g');
+  });
+
   it('renders a placeholder when the print has no image', () => {
     const el = render(printWith([usage(12_000)], { defaultPrintImageId: 0 }));
     expect(el.querySelector('.thumb-placeholder')).toBeTruthy();

--- a/src/app/filament/filament-detail/filament-print-row/filament-print-row.component.spec.ts
+++ b/src/app/filament/filament-detail/filament-print-row/filament-print-row.component.spec.ts
@@ -1,0 +1,114 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
+import { provideRouter } from '@angular/router';
+import {
+  PrintFilamentSourceMeasurement,
+  PrintService,
+  PrintStatus,
+  PrintSummary,
+} from 'src/app/core/services/print.service';
+import { FilamentPrintRowComponent } from './filament-print-row.component';
+
+const FILAMENT_ID = 'aaaaaaaa-0000-0000-0000-000000000001';
+
+function usage(amountMg: number | undefined, estimatedAmountMg?: number) {
+  return {
+    id: 'usage-' + amountMg + '-' + estimatedAmountMg,
+    filament: {
+      id: FILAMENT_ID,
+      materialDensityGramPerCubicCm: 1.24,
+      diameterMm: 1.75,
+    },
+    amountMg,
+    estimatedAmountMg,
+    source: PrintFilamentSourceMeasurement.Weight,
+    estimatedSource: PrintFilamentSourceMeasurement.Weight,
+  } as never;
+}
+
+function printWith(
+  usages: unknown[],
+  overrides: Partial<PrintSummary> = {}
+): PrintSummary {
+  return {
+    id: 7,
+    title: 'Benchy',
+    startDate: new Date('2026-07-30T10:00:00Z'),
+    status: PrintStatus.Success,
+    defaultPrintImageId: 3,
+    filamentUsage: usages,
+    ...overrides,
+  } as PrintSummary;
+}
+
+describe('FilamentPrintRowComponent', () => {
+  let fixture: ComponentFixture<FilamentPrintRowComponent>;
+
+  beforeEach(async () => {
+    const printService = jasmine.createSpyObj<PrintService>('PrintService', [
+      'getPrintImage',
+    ]);
+    printService.getPrintImage.and.returnValue(of('data:image/png;base64,AAA'));
+
+    await TestBed.configureTestingModule({
+      imports: [FilamentPrintRowComponent],
+      providers: [
+        provideRouter([]),
+        { provide: PrintService, useValue: printService },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FilamentPrintRowComponent);
+  });
+
+  function render(print: PrintSummary): HTMLElement {
+    fixture.componentRef.setInput('print', print);
+    fixture.componentRef.setInput('filamentId', FILAMENT_ID);
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  it('links to the print', () => {
+    const el = render(printWith([usage(12_000)]));
+    expect(el.querySelector('a')?.getAttribute('href')).toContain('/prints/7');
+  });
+
+  it('sums every usage row for this filament, not just the first', () => {
+    const el = render(printWith([usage(12_000), usage(30_000)]));
+    expect(el.textContent).toContain('42');
+    expect(el.textContent).not.toContain('12 g');
+  });
+
+  it('ignores usage rows for other filaments', () => {
+    const other = {
+      ...(usage(99_000) as object),
+      filament: { id: 'other' },
+    } as never;
+    const el = render(printWith([usage(12_000), other]));
+    expect(el.textContent).toContain('12');
+    expect(el.textContent).not.toContain('99');
+  });
+
+  it('marks estimated usage', () => {
+    const el = render(printWith([usage(undefined, 12_000)]));
+    expect(el.querySelector('.estimated-marker')).toBeTruthy();
+  });
+
+  it('sums a mixed actual and estimated pair', () => {
+    // Resolving actual-else-estimated per row gives 12 + 30. Merging the rows'
+    // columns first and preferring actual across the merge would show 12 alone.
+    const el = render(printWith([usage(12_000), usage(undefined, 30_000)]));
+    expect(el.textContent).toContain('42');
+    expect(el.querySelector('.estimated-marker')).toBeTruthy();
+  });
+
+  it('does not mark a purely actual multi-row usage as estimated', () => {
+    const el = render(printWith([usage(12_000), usage(30_000)]));
+    expect(el.querySelector('.estimated-marker')).toBeFalsy();
+  });
+
+  it('renders a placeholder when the print has no image', () => {
+    const el = render(printWith([usage(12_000)], { defaultPrintImageId: 0 }));
+    expect(el.querySelector('.thumb-placeholder')).toBeTruthy();
+  });
+});

--- a/src/app/filament/filament-detail/filament-print-row/filament-print-row.component.ts
+++ b/src/app/filament/filament-detail/filament-print-row/filament-print-row.component.ts
@@ -14,7 +14,10 @@ import {
   PrintSummary,
 } from 'src/app/core/services/print.service';
 import { PrintImageComponent } from 'src/app/shared/print-image/print-image.component';
-import { getFilamentPreferredDisplay } from 'src/app/shared/utils/filament-display.utils';
+import {
+  convertFilamentValue,
+  getFilamentPreferredDisplay,
+} from 'src/app/shared/utils/filament-display.utils';
 
 /** One compact print row in the material detail rail. */
 @Component({
@@ -61,14 +64,21 @@ export class FilamentPrintRowComponent {
   );
 
   /**
-   * Summed across usage rows, resolving actual-else-estimated PER ROW.
+   * Summed across usage rows, resolving actual-else-estimated PER ROW and in each
+   * row's OWN unit before adding anything together.
    *
-   * Merging the rows into one synthetic row first and formatting that once would
-   * be wrong: the helper prefers actual over estimated across the whole row, so a
-   * print with one actual row (12 g) and one estimated row (30 g) would collapse
-   * to the actual column alone and display 12 g — dropping 30 g and contradicting
-   * `totalUsedMg` in the card above. The server's own rule is per row, and this
-   * mirrors it.
+   * Two things have to happen in that order. Resolving per row matters because the
+   * display helper prefers actual over estimated across a whole row, so merging the
+   * columns first would let one row's actual value hide another row's estimate.
+   * Resolving each row's UNIT matters because rows on the same print need not share
+   * one: a 12 g weight row beside a 10 m length row totals ~42 g, and formatting the
+   * merged row with only the first row's source would report 12 g and silently drop
+   * the length entirely.
+   *
+   * Rows already sharing a unit are summed in that unit, so the common case needs no
+   * conversion and cannot fail. Mixed units are converted to milligrams, the same
+   * common denominator the server's own `totalUsedMg` uses. If some row cannot be
+   * converted, this returns null rather than a total that is quietly short.
    */
   protected readonly usageDisplay = computed(() => {
     const usages = this.usages();
@@ -79,27 +89,121 @@ export class FilamentPrintRowComponent {
       return getFilamentPreferredDisplay(usages[0], this.preferredUnit());
     }
 
-    // Resolve each row on its own, then sum the resolved values into a synthetic
-    // row whose actual columns already hold the totals. The estimated columns are
-    // left empty so the helper cannot double count; `isEstimated` is reported
-    // separately from the untouched rows.
-    const totals = { mg: 0, m: 0, ml: 0 };
-    for (const usage of usages) {
-      totals.mg += usage.amountMg ?? usage.estimatedAmountMg ?? 0;
-      totals.m += usage.lengthInM ?? usage.estimatedLengthInM ?? 0;
-      totals.ml += usage.volumeMl ?? usage.estimatedVolumeMl ?? 0;
+    const resolved = usages.map((usage) => resolveRow(usage));
+    if (resolved.some((row) => row === null)) {
+      return null;
+    }
+    const rows = resolved as ResolvedRow[];
+
+    const firstUnit = rows[0].unit;
+    const sharesOneUnit = rows.every((row) => row.unit === firstUnit);
+    const filament = usages[0].filament;
+
+    if (sharesOneUnit) {
+      const total = rows.reduce((sum, row) => sum + row.value, 0);
+      return getFilamentPreferredDisplay(
+        mergedRow(usages[0], firstUnit, total),
+        this.preferredUnit()
+      );
     }
 
-    const merged: PrintFilamentSummaryDto = {
-      ...usages[0],
-      amountMg: totals.mg || undefined,
-      lengthInM: totals.m || undefined,
-      volumeMl: totals.ml || undefined,
-      estimatedAmountMg: undefined,
-      estimatedLengthInM: undefined,
-      estimatedVolumeMl: undefined,
-    };
+    let totalMg = 0;
+    for (const row of rows) {
+      const mg = convertFilamentValue(
+        row.value,
+        row.unit,
+        PrintFilamentSourceMeasurement.Weight,
+        filament
+      );
+      if (mg === null) {
+        return null;
+      }
+      totalMg += mg;
+    }
 
-    return getFilamentPreferredDisplay(merged, this.preferredUnit());
+    return getFilamentPreferredDisplay(
+      mergedRow(usages[0], PrintFilamentSourceMeasurement.Weight, totalMg),
+      this.preferredUnit()
+    );
   });
+}
+
+interface ResolvedRow {
+  unit: PrintFilamentSourceMeasurement;
+  value: number;
+}
+
+/**
+ * One row's contribution: its actual value if it has one, otherwise its estimate,
+ * each read in the unit that row was recorded in. Null when the row records nothing.
+ */
+function resolveRow(usage: PrintFilamentSummaryDto): ResolvedRow | null {
+  const actual = valueInUnit(usage, usage.source, false);
+  if (actual !== null) {
+    return actual;
+  }
+  return valueInUnit(usage, usage.estimatedSource, true);
+}
+
+function valueInUnit(
+  usage: PrintFilamentSummaryDto,
+  unit: PrintFilamentSourceMeasurement | undefined,
+  estimated: boolean
+): ResolvedRow | null {
+  const candidates: [
+    PrintFilamentSourceMeasurement,
+    number | null | undefined,
+  ][] = estimated
+    ? [
+        [PrintFilamentSourceMeasurement.Weight, usage.estimatedAmountMg],
+        [PrintFilamentSourceMeasurement.Length, usage.estimatedLengthInM],
+        [PrintFilamentSourceMeasurement.Volume, usage.estimatedVolumeMl],
+      ]
+    : [
+        [PrintFilamentSourceMeasurement.Weight, usage.amountMg],
+        [PrintFilamentSourceMeasurement.Length, usage.lengthInM],
+        [PrintFilamentSourceMeasurement.Volume, usage.volumeMl],
+      ];
+
+  // Prefer the row's declared source unit, but fall back to whichever column it
+  // actually carries: `source` is optional on the DTO and may be AsRecorded.
+  const ordered =
+    unit == null
+      ? candidates
+      : [
+          ...candidates.filter(([candidate]) => candidate === unit),
+          ...candidates.filter(([candidate]) => candidate !== unit),
+        ];
+
+  for (const [candidateUnit, value] of ordered) {
+    if ((value ?? 0) > 0) {
+      return { unit: candidateUnit, value: value as number };
+    }
+  }
+  return null;
+}
+
+/**
+ * A synthetic row carrying the summed total in one unit. The estimated columns are
+ * cleared so the display helper cannot double count; whether any contribution was an
+ * estimate is reported separately by `isEstimated`.
+ */
+function mergedRow(
+  template: PrintFilamentSummaryDto,
+  unit: PrintFilamentSourceMeasurement,
+  total: number
+): PrintFilamentSummaryDto {
+  return {
+    ...template,
+    source: unit,
+    amountMg:
+      unit === PrintFilamentSourceMeasurement.Weight ? total : undefined,
+    lengthInM:
+      unit === PrintFilamentSourceMeasurement.Length ? total : undefined,
+    volumeMl:
+      unit === PrintFilamentSourceMeasurement.Volume ? total : undefined,
+    estimatedAmountMg: undefined,
+    estimatedLengthInM: undefined,
+    estimatedVolumeMl: undefined,
+  };
 }

--- a/src/app/filament/filament-detail/filament-print-row/filament-print-row.component.ts
+++ b/src/app/filament/filament-detail/filament-print-row/filament-print-row.component.ts
@@ -1,0 +1,105 @@
+import { DatePipe } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from '@angular/core';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { RouterLink } from '@angular/router';
+import {
+  PrintFilamentSourceMeasurement,
+  PrintFilamentSummaryDto,
+  PrintSummary,
+} from 'src/app/core/services/print.service';
+import { PrintImageComponent } from 'src/app/shared/print-image/print-image.component';
+import { getFilamentPreferredDisplay } from 'src/app/shared/utils/filament-display.utils';
+
+/** One compact print row in the material detail rail. */
+@Component({
+  selector: 'app-filament-print-row',
+  templateUrl: './filament-print-row.component.html',
+  styleUrls: ['./filament-print-row.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    DatePipe,
+    RouterLink,
+    MatIconModule,
+    MatTooltipModule,
+    PrintImageComponent,
+  ],
+})
+export class FilamentPrintRowComponent {
+  readonly print = input.required<PrintSummary>();
+  readonly filamentId = input.required<string>();
+  readonly preferredUnit = input<PrintFilamentSourceMeasurement>(
+    PrintFilamentSourceMeasurement.Weight
+  );
+
+  /**
+   * Every usage row for this spool. A print may carry more than one — there is no
+   * unique index on (PrintId, FilamentId) — so taking only the first would show
+   * half the usage and contradict the totals in the card above.
+   */
+  private readonly usages = computed<PrintFilamentSummaryDto[]>(() =>
+    (this.print().filamentUsage ?? []).filter(
+      (u) => u.filament?.id === this.filamentId()
+    )
+  );
+
+  protected readonly hasImage = computed(
+    () => (this.print().defaultPrintImageId ?? 0) > 0
+  );
+
+  protected readonly isEstimated = computed(() =>
+    this.usages().some(
+      (u) =>
+        getFilamentPreferredDisplay(u, this.preferredUnit())?.isEstimated ??
+        false
+    )
+  );
+
+  /**
+   * Summed across usage rows, resolving actual-else-estimated PER ROW.
+   *
+   * Merging the rows into one synthetic row first and formatting that once would
+   * be wrong: the helper prefers actual over estimated across the whole row, so a
+   * print with one actual row (12 g) and one estimated row (30 g) would collapse
+   * to the actual column alone and display 12 g — dropping 30 g and contradicting
+   * `totalUsedMg` in the card above. The server's own rule is per row, and this
+   * mirrors it.
+   */
+  protected readonly usageDisplay = computed(() => {
+    const usages = this.usages();
+    if (usages.length === 0) {
+      return null;
+    }
+    if (usages.length === 1) {
+      return getFilamentPreferredDisplay(usages[0], this.preferredUnit());
+    }
+
+    // Resolve each row on its own, then sum the resolved values into a synthetic
+    // row whose actual columns already hold the totals. The estimated columns are
+    // left empty so the helper cannot double count; `isEstimated` is reported
+    // separately from the untouched rows.
+    const totals = { mg: 0, m: 0, ml: 0 };
+    for (const usage of usages) {
+      totals.mg += usage.amountMg ?? usage.estimatedAmountMg ?? 0;
+      totals.m += usage.lengthInM ?? usage.estimatedLengthInM ?? 0;
+      totals.ml += usage.volumeMl ?? usage.estimatedVolumeMl ?? 0;
+    }
+
+    const merged: PrintFilamentSummaryDto = {
+      ...usages[0],
+      amountMg: totals.mg || undefined,
+      lengthInM: totals.m || undefined,
+      volumeMl: totals.ml || undefined,
+      estimatedAmountMg: undefined,
+      estimatedLengthInM: undefined,
+      estimatedVolumeMl: undefined,
+    };
+
+    return getFilamentPreferredDisplay(merged, this.preferredUnit());
+  });
+}

--- a/src/app/filament/filament-detail/filament-prints-panel/filament-prints-panel.component.html
+++ b/src/app/filament/filament-detail/filament-prints-panel/filament-prints-panel.component.html
@@ -17,7 +17,9 @@
       }
       @case ('error') {
         <p class="error-text">Couldn't load prints.</p>
-        <button mat-stroked-button type="button" (click)="retry()">Retry</button>
+        <button mat-stroked-button type="button" (click)="retry()">
+          Retry
+        </button>
       }
       @case ('ready') {
         @if (prints().length === 0) {
@@ -31,7 +33,11 @@
             ></app-filament-print-row>
           }
           @if (hasMore()) {
-            <a class="view-all" [routerLink]="['/prints']" [queryParams]="viewAllParams()">
+            <a
+              class="view-all"
+              [routerLink]="['/prints']"
+              [queryParams]="viewAllParams()"
+            >
               View all {{ totalCount() }} prints
             </a>
           }

--- a/src/app/filament/filament-detail/filament-prints-panel/filament-prints-panel.component.html
+++ b/src/app/filament/filament-detail/filament-prints-panel/filament-prints-panel.component.html
@@ -1,0 +1,42 @@
+<mat-card appearance="outlined" class="prints-panel">
+  <mat-card-content>
+    <h3 class="panel-title">
+      Prints using this material
+      @if (phase() === 'ready' && totalCount() > 0) {
+        <span class="count">{{ totalCount() }}</span>
+      }
+    </h3>
+
+    @switch (phase()) {
+      @case ('loading') {
+        <div class="skeleton-rows app-skeleton-immediate">
+          @for (row of [1, 2, 3]; track row) {
+            <app-skeleton height="56px"></app-skeleton>
+          }
+        </div>
+      }
+      @case ('error') {
+        <p class="error-text">Couldn't load prints.</p>
+        <button mat-stroked-button type="button" (click)="retry()">Retry</button>
+      }
+      @case ('ready') {
+        @if (prints().length === 0) {
+          <p class="empty-text">No prints have used this material yet.</p>
+        } @else {
+          @for (print of prints(); track print.id) {
+            <app-filament-print-row
+              [print]="print"
+              [filamentId]="filamentId()"
+              [preferredUnit]="preferredUnit()"
+            ></app-filament-print-row>
+          }
+          @if (hasMore()) {
+            <a class="view-all" [routerLink]="['/prints']" [queryParams]="viewAllParams()">
+              View all {{ totalCount() }} prints
+            </a>
+          }
+        }
+      }
+    }
+  </mat-card-content>
+</mat-card>

--- a/src/app/filament/filament-detail/filament-prints-panel/filament-prints-panel.component.scss
+++ b/src/app/filament/filament-detail/filament-prints-panel/filament-prints-panel.component.scss
@@ -1,0 +1,37 @@
+.prints-panel {
+  width: 100%;
+}
+
+.panel-title {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  margin: 0 0 8px;
+  font-size: 1rem;
+  font-weight: 500;
+}
+
+.count {
+  font-size: 0.875rem;
+  opacity: 0.75;
+}
+
+.skeleton-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.empty-text,
+.error-text {
+  margin: 8px 0;
+  font-size: 0.875rem;
+  opacity: 0.75;
+}
+
+.view-all {
+  display: inline-block;
+  margin-top: 8px;
+  font-size: 0.875rem;
+}

--- a/src/app/filament/filament-detail/filament-prints-panel/filament-prints-panel.component.spec.ts
+++ b/src/app/filament/filament-detail/filament-prints-panel/filament-prints-panel.component.spec.ts
@@ -1,0 +1,153 @@
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+} from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { of, throwError } from 'rxjs';
+import {
+  PrintService,
+  PrintStatus,
+  PrintSummary,
+} from 'src/app/core/services/print.service';
+import { FilamentPrintsPanelComponent } from './filament-prints-panel.component';
+
+const FILAMENT_ID = 'aaaaaaaa-0000-0000-0000-000000000001';
+
+function fakePrint(id: number): PrintSummary {
+  return {
+    id,
+    title: 'Print ' + id,
+    startDate: new Date('2026-07-30T10:00:00Z'),
+    status: PrintStatus.Success,
+    defaultPrintImageId: 0,
+    filamentUsage: [],
+  } as unknown as PrintSummary;
+}
+
+describe('FilamentPrintsPanelComponent', () => {
+  let fixture: ComponentFixture<FilamentPrintsPanelComponent>;
+  let printService: jasmine.SpyObj<PrintService>;
+
+  beforeEach(async () => {
+    printService = jasmine.createSpyObj<PrintService>('PrintService', [
+      'getPrintSummaries',
+      'getPrintImage',
+    ]);
+    printService.getPrintImage.and.returnValue(of('data:image/png;base64,AAA'));
+
+    await TestBed.configureTestingModule({
+      imports: [FilamentPrintsPanelComponent],
+      providers: [
+        provideRouter([]),
+        { provide: PrintService, useValue: printService },
+      ],
+    }).compileComponents();
+  });
+
+  function create(): HTMLElement {
+    fixture = TestBed.createComponent(FilamentPrintsPanelComponent);
+    fixture.componentRef.setInput('filamentId', FILAMENT_ID);
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  it('lists the returned prints', fakeAsync(() => {
+    printService.getPrintSummaries.and.returnValue(
+      of({
+        items: [fakePrint(1), fakePrint(2)],
+        paging: { totalCount: 2 },
+      } as never)
+    );
+
+    const el = create();
+    tick(1000);
+    fixture.detectChanges();
+
+    expect(el.querySelectorAll('app-filament-print-row').length).toBe(2);
+  }));
+
+  it('filters by this filament', fakeAsync(() => {
+    printService.getPrintSummaries.and.returnValue(
+      of({ items: [], paging: { totalCount: 0 } } as never)
+    );
+
+    create();
+    tick(1000);
+
+    const filamentIdsArg =
+      printService.getPrintSummaries.calls.mostRecent().args[5];
+    expect(filamentIdsArg).toEqual([FILAMENT_ID]);
+  }));
+
+  it('shows an empty state when nothing used the spool', fakeAsync(() => {
+    printService.getPrintSummaries.and.returnValue(
+      of({ items: [], paging: { totalCount: 0 } } as never)
+    );
+
+    const el = create();
+    tick(1000);
+    fixture.detectChanges();
+
+    expect(el.textContent).toContain('No prints have used this material yet');
+  }));
+
+  it('shows a scoped error without throwing', fakeAsync(() => {
+    printService.getPrintSummaries.and.returnValue(
+      throwError(() => new Error('boom'))
+    );
+
+    const el = create();
+    tick(1000);
+    fixture.detectChanges();
+
+    expect(el.textContent).toContain("Couldn't load prints");
+  }));
+
+  it('refetches when the error state is retried', fakeAsync(() => {
+    printService.getPrintSummaries.and.returnValue(
+      throwError(() => new Error('boom'))
+    );
+
+    const el = create();
+    tick(1000);
+    fixture.detectChanges();
+
+    printService.getPrintSummaries.and.returnValue(
+      of({ items: [fakePrint(1)], paging: { totalCount: 1 } } as never)
+    );
+    el.querySelector('button')!.click();
+    tick(1000);
+    fixture.detectChanges();
+
+    expect(el.querySelectorAll('app-filament-print-row').length).toBe(1);
+  }));
+
+  it('links to the filtered print list', fakeAsync(() => {
+    printService.getPrintSummaries.and.returnValue(
+      of({ items: [fakePrint(1)], paging: { totalCount: 23 } } as never)
+    );
+
+    const el = create();
+    tick(1000);
+    fixture.detectChanges();
+
+    const link = el.querySelector('a.view-all');
+    expect(link?.getAttribute('href')).toContain(
+      'filterByFilamentId=' + FILAMENT_ID
+    );
+  }));
+
+  it('does not offer a view-all link when every print is already listed', fakeAsync(() => {
+    printService.getPrintSummaries.and.returnValue(
+      of({ items: [fakePrint(1)], paging: { totalCount: 1 } } as never)
+    );
+
+    const el = create();
+    tick(1000);
+    fixture.detectChanges();
+
+    expect(el.querySelector('a.view-all')).toBeFalsy();
+  }));
+});

--- a/src/app/filament/filament-detail/filament-prints-panel/filament-prints-panel.component.ts
+++ b/src/app/filament/filament-detail/filament-prints-panel/filament-prints-panel.component.ts
@@ -1,0 +1,129 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { RouterLink } from '@angular/router';
+import { catchError, map, of, switchMap } from 'rxjs';
+import {
+  PrintFilamentSourceMeasurement,
+  PrintService,
+  PrintSummary,
+  PrintSummarySortColumn,
+} from 'src/app/core/services/print.service';
+import { SortDirection } from 'src/app/core/types/sort-request';
+import { withDeferredSkeleton } from 'src/app/shared/skeleton/deferred-skeleton';
+import { SkeletonComponent } from 'src/app/shared/skeleton/skeleton.component';
+import { FilamentPrintRowComponent } from '../filament-print-row/filament-print-row.component';
+
+type PanelPhase = 'idle' | 'loading' | 'ready' | 'error';
+
+interface PanelState {
+  phase: PanelPhase;
+  prints: PrintSummary[];
+  totalCount: number;
+}
+
+const IDLE_STATE: PanelState = { phase: 'idle', prints: [], totalCount: 0 };
+const LOADING_STATE: PanelState = {
+  phase: 'loading',
+  prints: [],
+  totalCount: 0,
+};
+const ERROR_STATE: PanelState = { phase: 'error', prints: [], totalCount: 0 };
+
+const PAGE_SIZE = 10;
+
+/** The recent prints that consumed a given spool, shown beside the material form. */
+@Component({
+  selector: 'app-filament-prints-panel',
+  templateUrl: './filament-prints-panel.component.html',
+  styleUrls: ['./filament-prints-panel.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    RouterLink,
+    MatButtonModule,
+    MatCardModule,
+    MatIconModule,
+    SkeletonComponent,
+    FilamentPrintRowComponent,
+  ],
+})
+export class FilamentPrintsPanelComponent {
+  private readonly printService = inject(PrintService);
+
+  readonly filamentId = input.required<string>();
+  readonly preferredUnit = input<PrintFilamentSourceMeasurement>(
+    PrintFilamentSourceMeasurement.Weight
+  );
+
+  private readonly retryCount = signal(0);
+
+  private readonly request = computed(() => ({
+    id: this.filamentId(),
+    attempt: this.retryCount(),
+  }));
+
+  /**
+   * Fetched here rather than through a resolver on purpose: a rejected resolver
+   * cancels navigation and bounces to '/', so a slow or failing prints query
+   * would block the form the user actually came to edit. The panel owns its own
+   * request and its own failure.
+   */
+  private readonly state = toSignal(
+    toObservable(this.request).pipe(
+      switchMap(({ id }) =>
+        this.printService
+          .getPrintSummaries(
+            1,
+            PAGE_SIZE,
+            '',
+            null,
+            [],
+            [id],
+            SortDirection.Desc,
+            PrintSummarySortColumn.StartDate
+          )
+          .pipe(
+            map(
+              (paged): PanelState => ({
+                phase: 'ready',
+                prints: paged.items ?? [],
+                totalCount: paged.paging?.totalCount ?? 0,
+              })
+            ),
+            catchError(() => of(ERROR_STATE)),
+            // Inside the switchMap so each re-subscription gets fresh timers.
+            withDeferredSkeleton(LOADING_STATE)
+          )
+      )
+    ),
+    { initialValue: IDLE_STATE }
+  );
+
+  protected readonly phase = computed(() => this.state().phase);
+  protected readonly prints = computed(() => this.state().prints);
+  protected readonly totalCount = computed(() => this.state().totalCount);
+  protected readonly hasMore = computed(
+    () => this.totalCount() > this.prints().length
+  );
+
+  /**
+   * The print list reads the SINGULAR `filterByFilamentId` query parameter, not
+   * the plural name the service method uses.
+   */
+  protected readonly viewAllParams = computed(() => ({
+    filterByFilamentId: this.filamentId(),
+  }));
+
+  protected retry(): void {
+    this.retryCount.update((count) => count + 1);
+  }
+}

--- a/src/app/filament/filament-detail/filament-remaining-card/filament-remaining-card.component.html
+++ b/src/app/filament/filament-detail/filament-remaining-card/filament-remaining-card.component.html
@@ -1,0 +1,74 @@
+<mat-card appearance="outlined" class="remaining-card">
+  <mat-card-content>
+    <h3 class="card-title">Remaining</h3>
+
+    @if (isTracked()) {
+      <mat-progress-bar
+        mode="determinate"
+        [value]="percentRemaining()"
+        [color]="isOverUsed() ? 'warn' : 'primary'"
+        aria-label="Filament remaining"
+      ></mat-progress-bar>
+
+      @if (isOverUsed()) {
+        <p class="headline over-used">
+          <mat-icon aria-hidden="true">warning</mat-icon>
+          {{ -(displayMg() ?? 0) / 1000 | number: '1.0-0' }} g over-used
+        </p>
+        <p class="hint">
+          More filament has been logged than this spool held. Check the prints below or add an
+          adjustment.
+        </p>
+      } @else {
+        <p class="headline">
+          {{ (displayMg() ?? 0) / 1000 | number: '1.0-0' }} g
+          @if (nominalMg()) {
+            <span class="of-total">of {{ (nominalMg() ?? 0) / 1000 | number: '1.0-0' }} g left</span>
+          }
+        </p>
+      }
+
+      @if (hasPendingChange()) {
+        <p class="projection">
+          {{ (remainingMg() ?? 0) / 1000 | number: '1.0-0' }} g &rarr;
+          {{ (projectedMg() ?? 0) / 1000 | number: '1.0-0' }} g after saving
+        </p>
+      } @else if (isSuppressed()) {
+        <p class="projection muted">This updates after saving.</p>
+      }
+
+      <dl class="secondary">
+        @if (lengthRemainingM()) {
+          <div>
+            <dt>Length</dt>
+            <dd>{{ lengthRemainingM() | number: '1.0-1' }} m</dd>
+          </div>
+        }
+        @if (volumeRemainingMl()) {
+          <div>
+            <dt>Volume</dt>
+            <dd>{{ volumeRemainingMl() | number: '1.0-1' }} ml</dd>
+          </div>
+        }
+        @if (totalUsedMg()) {
+          <div>
+            <dt>Used</dt>
+            <dd>{{ (totalUsedMg() ?? 0) / 1000 | number: '1.0-0' }} g</dd>
+          </div>
+        }
+        @if (printCount()) {
+          <div>
+            <dt>Prints</dt>
+            <dd>{{ printCount() }}</dd>
+          </div>
+        }
+      </dl>
+    } @else {
+      <p class="headline muted">Not tracked</p>
+      <p class="hint">Set an initial nominal weight to track how much is left.</p>
+      <button mat-stroked-button type="button" (click)="focusNominalWeight.emit()">
+        Set nominal weight
+      </button>
+    }
+  </mat-card-content>
+</mat-card>

--- a/src/app/filament/filament-detail/filament-remaining-card/filament-remaining-card.component.html
+++ b/src/app/filament/filament-detail/filament-remaining-card/filament-remaining-card.component.html
@@ -16,14 +16,16 @@
           {{ -(displayMg() ?? 0) / 1000 | number: '1.0-0' }} g over-used
         </p>
         <p class="hint">
-          More filament has been logged than this spool held. Check the prints below or add an
-          adjustment.
+          More filament has been logged than this spool held. Check the prints
+          below or add an adjustment.
         </p>
       } @else {
         <p class="headline">
           {{ (displayMg() ?? 0) / 1000 | number: '1.0-0' }} g
           @if (nominalMg()) {
-            <span class="of-total">of {{ (nominalMg() ?? 0) / 1000 | number: '1.0-0' }} g left</span>
+            <span class="of-total"
+              >of {{ (nominalMg() ?? 0) / 1000 | number: '1.0-0' }} g left</span
+            >
           }
         </p>
       }
@@ -65,8 +67,14 @@
       </dl>
     } @else {
       <p class="headline muted">Not tracked</p>
-      <p class="hint">Set an initial nominal weight to track how much is left.</p>
-      <button mat-stroked-button type="button" (click)="focusNominalWeight.emit()">
+      <p class="hint">
+        Set an initial nominal weight to track how much is left.
+      </p>
+      <button
+        mat-stroked-button
+        type="button"
+        (click)="focusNominalWeight.emit()"
+      >
         Set nominal weight
       </button>
     }

--- a/src/app/filament/filament-detail/filament-remaining-card/filament-remaining-card.component.scss
+++ b/src/app/filament/filament-detail/filament-remaining-card/filament-remaining-card.component.scss
@@ -1,0 +1,64 @@
+.remaining-card {
+  width: 100%;
+}
+
+.card-title {
+  margin: 0 0 12px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  opacity: 0.75;
+}
+
+.headline {
+  margin: 12px 0 4px;
+  font-size: 1.5rem;
+  font-weight: 500;
+
+  &.over-used {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--mat-sys-error, #b3261e);
+  }
+}
+
+.of-total {
+  font-size: 0.875rem;
+  font-weight: 400;
+  opacity: 0.75;
+}
+
+.projection {
+  margin: 0 0 8px;
+  font-size: 0.875rem;
+}
+
+.hint,
+.muted {
+  opacity: 0.75;
+  font-size: 0.875rem;
+}
+
+.secondary {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px 16px;
+  margin: 12px 0 0;
+
+  div {
+    display: flex;
+    flex-direction: column;
+  }
+
+  dt {
+    font-size: 0.75rem;
+    opacity: 0.75;
+  }
+
+  dd {
+    margin: 0;
+    font-size: 1rem;
+  }
+}

--- a/src/app/filament/filament-detail/filament-remaining-card/filament-remaining-card.component.spec.ts
+++ b/src/app/filament/filament-detail/filament-remaining-card/filament-remaining-card.component.spec.ts
@@ -1,0 +1,118 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { FilamentRemainingCardComponent } from './filament-remaining-card.component';
+
+describe('FilamentRemainingCardComponent', () => {
+  let fixture: ComponentFixture<FilamentRemainingCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [FilamentRemainingCardComponent, NoopAnimationsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(FilamentRemainingCardComponent);
+  });
+
+  function render(inputs: Record<string, unknown>): HTMLElement {
+    Object.entries(inputs).forEach(([key, value]) =>
+      fixture.componentRef.setInput(key, value)
+    );
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  it('shows the remaining grams', () => {
+    const el = render({
+      remainingMg: 412_000,
+      projectedMg: 412_000,
+      nominalMg: 1_000_000,
+    });
+    expect(el.textContent).toContain('412');
+  });
+
+  it('explains an untracked spool instead of showing zero', () => {
+    const el = render({
+      remainingMg: null,
+      projectedMg: null,
+      nominalMg: null,
+    });
+    expect(el.textContent).toContain('Not tracked');
+    expect(el.textContent).not.toContain('0 g');
+  });
+
+  it('warns when more was used than the spool held', () => {
+    const el = render({
+      remainingMg: -38_000,
+      projectedMg: -38_000,
+      nominalMg: 1_000_000,
+    });
+    expect(el.querySelector('.over-used')).toBeTruthy();
+    expect(el.textContent).toContain('38');
+  });
+
+  it('shows the projected value when it differs from the server value', () => {
+    const el = render({
+      remainingMg: 412_000,
+      projectedMg: 380_000,
+      nominalMg: 1_000_000,
+    });
+    expect(el.textContent).toContain('after saving');
+    expect(el.textContent).toContain('380');
+  });
+
+  it('hides the projection arrow when it is suppressed', () => {
+    const el = render({
+      remainingMg: 412_000,
+      projectedMg: 412_000,
+      isSuppressed: true,
+      nominalMg: 1_000_000,
+    });
+    // The suppressed note replaces the "X g -> Y g after saving" arrow entirely.
+    expect(el.querySelector('.projection.muted')).toBeTruthy();
+    expect(el.textContent).toContain('updates after saving');
+    expect(el.textContent).not.toContain('g after saving');
+  });
+
+  it('shows the server value, not a stale projection, while suppressed', () => {
+    const el = render({
+      remainingMg: 412_000,
+      projectedMg: 380_000,
+      isSuppressed: true,
+      nominalMg: 1_000_000,
+    });
+    expect(el.textContent).toContain('412');
+    expect(el.textContent).not.toContain('380');
+  });
+
+  it('renders length, volume and usage totals', () => {
+    const el = render({
+      remainingMg: 412_000,
+      projectedMg: 412_000,
+      nominalMg: 1_000_000,
+      lengthRemainingM: 138.2,
+      volumeRemainingMl: 345.1,
+      totalUsedMg: 588_000,
+      printCount: 23,
+    });
+    expect(el.textContent).toContain('138');
+    expect(el.textContent).toContain('345');
+    expect(el.textContent).toContain('588');
+    expect(el.textContent).toContain('23');
+  });
+
+  it('asks the parent to focus the nominal weight input', () => {
+    const el = render({
+      remainingMg: null,
+      projectedMg: null,
+      nominalMg: null,
+    });
+    let emitted = false;
+    fixture.componentInstance.focusNominalWeight.subscribe(
+      () => (emitted = true)
+    );
+
+    el.querySelector('button')!.click();
+
+    expect(emitted).toBeTrue();
+  });
+});

--- a/src/app/filament/filament-detail/filament-remaining-card/filament-remaining-card.component.ts
+++ b/src/app/filament/filament-detail/filament-remaining-card/filament-remaining-card.component.ts
@@ -1,0 +1,81 @@
+import { DecimalPipe } from '@angular/common';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+  output,
+} from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+/**
+ * Read-only summary of how much filament a spool has left.
+ *
+ * Takes only inputs. It must never reach into the filament form: a false dirty
+ * state would trip `PendingChangesGuard` and block navigation off the page.
+ */
+@Component({
+  selector: 'app-filament-remaining-card',
+  templateUrl: './filament-remaining-card.component.html',
+  styleUrls: ['./filament-remaining-card.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    DecimalPipe,
+    MatButtonModule,
+    MatCardModule,
+    MatIconModule,
+    MatProgressBarModule,
+    MatTooltipModule,
+  ],
+})
+export class FilamentRemainingCardComponent {
+  readonly remainingMg = input<number | null>(null);
+  readonly projectedMg = input<number | null>(null);
+  readonly isSuppressed = input(false);
+  readonly nominalMg = input<number | null>(null);
+  readonly lengthRemainingM = input<number | null>(null);
+  readonly volumeRemainingMl = input<number | null>(null);
+  readonly totalUsedMg = input<number | null>(null);
+  readonly printCount = input<number | null>(null);
+
+  /** Asks the parent to focus the nominal-weight input on an untracked spool. */
+  readonly focusNominalWeight = output<void>();
+
+  protected readonly isTracked = computed(() => this.remainingMg() !== null);
+
+  /** The projection when one applies, otherwise the server's own figure. */
+  protected readonly displayMg = computed(() =>
+    this.isSuppressed()
+      ? this.remainingMg()
+      : (this.projectedMg() ?? this.remainingMg())
+  );
+
+  /**
+   * Remaining can legitimately be negative: the API does not clamp it, because a
+   * negative value means usage was logged past the spool's weight and the user
+   * should see that rather than have it hidden.
+   */
+  protected readonly isOverUsed = computed(() => (this.displayMg() ?? 0) < 0);
+
+  protected readonly hasPendingChange = computed(
+    () =>
+      !this.isSuppressed() &&
+      this.projectedMg() !== null &&
+      this.remainingMg() !== null &&
+      Math.round(this.projectedMg()!) !== Math.round(this.remainingMg()!)
+  );
+
+  /** Clamped for the bar only; the caption still shows the real signed value. */
+  protected readonly percentRemaining = computed(() => {
+    const nominal = this.nominalMg();
+    const remaining = this.displayMg();
+    if (!nominal || nominal <= 0 || remaining === null) {
+      return 0;
+    }
+    return Math.min(100, Math.max(0, (remaining / nominal) * 100));
+  });
+}

--- a/src/app/filament/filament-detail/remaining-projection.spec.ts
+++ b/src/app/filament/filament-detail/remaining-projection.spec.ts
@@ -1,0 +1,208 @@
+import { PrintFilamentSourceMeasurement } from 'src/app/core/services/print.service';
+import {
+  AdjustmentRow,
+  ProjectionInput,
+  projectRemainingMg,
+} from './remaining-projection';
+
+const PLA = { materialDensityGramPerCubicCm: 1.24, diameterMm: 1.75 };
+
+/** Milligrams in ten meters of 1.75mm PLA, via the same geometry the helper uses. */
+const TEN_METERS_MG = 10 * Math.PI * (1.75 / 2 / 10) ** 2 * 100 * 1.24 * 1000;
+
+function baseInput(overrides: Partial<ProjectionInput> = {}): ProjectionInput {
+  return {
+    serverRemainingMg: 412_000,
+    serverNominalMg: 1_000_000,
+    formNominalMg: 1_000_000,
+    serverAdjustments: [],
+    formAdjustments: [],
+    source: PrintFilamentSourceMeasurement.Weight,
+    filament: PLA,
+    serverFilament: PLA,
+    ...overrides,
+  };
+}
+
+function weightAdjustment(amountMg: number): AdjustmentRow {
+  return { source: PrintFilamentSourceMeasurement.Weight, amountMg };
+}
+
+describe('projectRemainingMg', () => {
+  it('returns the server value unchanged when nothing was edited', () => {
+    const result = projectRemainingMg(baseInput());
+    expect(result.projectedMg).toBe(412_000);
+    expect(result.isSuppressed).toBeFalse();
+  });
+
+  it('returns the server value when the stored nominal weight is zero', () => {
+    // The form nulls a nominal weight that is not > 0, but the server still
+    // reports a tracked remaining. An absolute recomputation would yield null here.
+    const result = projectRemainingMg(
+      baseInput({
+        serverNominalMg: 0,
+        formNominalMg: null,
+        serverRemainingMg: -50_000,
+      })
+    );
+    expect(result.projectedMg).toBe(-50_000);
+  });
+
+  it('adds an unsaved adjustment', () => {
+    const result = projectRemainingMg(
+      baseInput({ formAdjustments: [weightAdjustment(-32_000)] })
+    );
+    expect(result.projectedMg).toBe(380_000);
+  });
+
+  it('ignores an adjustment that was already saved', () => {
+    const saved = weightAdjustment(-32_000);
+    const result = projectRemainingMg(
+      baseInput({ serverAdjustments: [saved], formAdjustments: [saved] })
+    );
+    expect(result.projectedMg).toBe(412_000);
+  });
+
+  it('subtracts a removed adjustment', () => {
+    const result = projectRemainingMg(
+      baseInput({
+        serverAdjustments: [weightAdjustment(-32_000)],
+        formAdjustments: [],
+      })
+    );
+    expect(result.projectedMg).toBe(444_000);
+  });
+
+  it('converts a length-sourced adjustment row rather than reading its stale milligrams', () => {
+    const result = projectRemainingMg(
+      baseInput({
+        formAdjustments: [
+          {
+            source: PrintFilamentSourceMeasurement.Length,
+            lengthInM: 10,
+            // Stale: what the server derived for a DIFFERENT length last save.
+            amountMg: 999_999,
+          },
+        ],
+      })
+    );
+    expect(result.projectedMg).toBeCloseTo(412_000 + TEN_METERS_MG, 0);
+    expect(result.projectedMg).not.toBeCloseTo(412_000 + 999_999, 0);
+  });
+
+  it('suppresses the projection when density or diameter were edited', () => {
+    const result = projectRemainingMg(
+      baseInput({
+        source: PrintFilamentSourceMeasurement.Length,
+        serverNominalM: 330,
+        formNominalM: 330,
+        filament: { materialDensityGramPerCubicCm: 1.3, diameterMm: 1.75 },
+        serverFilament: PLA,
+      })
+    );
+    expect(result.isSuppressed).toBeTrue();
+    expect(result.projectedMg).toBe(412_000);
+  });
+
+  it('does not suppress on a density edit when nothing needs converting', () => {
+    const result = projectRemainingMg(
+      baseInput({
+        filament: { materialDensityGramPerCubicCm: 1.3, diameterMm: 1.75 },
+        serverFilament: PLA,
+        formAdjustments: [weightAdjustment(-32_000)],
+      })
+    );
+    expect(result.isSuppressed).toBeFalse();
+    expect(result.projectedMg).toBe(380_000);
+  });
+
+  it('tracks an edited nominal weight', () => {
+    const result = projectRemainingMg(baseInput({ formNominalMg: 1_200_000 }));
+    expect(result.projectedMg).toBe(612_000);
+  });
+
+  it('is null when the server reports an untracked spool', () => {
+    const result = projectRemainingMg(
+      baseInput({
+        serverRemainingMg: null,
+        serverNominalMg: null,
+        formNominalMg: null,
+      })
+    );
+    expect(result.projectedMg).toBeNull();
+    expect(result.remainingMg).toBeNull();
+  });
+
+  it('converts a length-sourced spool edit to milligrams', () => {
+    const result = projectRemainingMg(
+      baseInput({
+        source: PrintFilamentSourceMeasurement.Length,
+        serverNominalM: 330,
+        formNominalM: 340,
+      })
+    );
+    expect(result.projectedMg).toBeCloseTo(412_000 + TEN_METERS_MG, 0);
+  });
+
+  it('suppresses the projection when an edit needs a conversion density cannot support', () => {
+    const noDensity = { diameterMm: 1.75 };
+    const result = projectRemainingMg(
+      baseInput({
+        source: PrintFilamentSourceMeasurement.Length,
+        filament: noDensity,
+        serverFilament: noDensity,
+        serverNominalM: 330,
+        formNominalM: 340,
+      })
+    );
+    expect(result.isSuppressed).toBeTrue();
+    expect(result.projectedMg).toBe(412_000);
+  });
+
+  it('does not suppress an untouched spool whose density is missing', () => {
+    // Nothing was edited, so no conversion is attempted and there is nothing to
+    // warn about. Showing "updates after saving" on a pristine form would be noise.
+    const noDensity = { diameterMm: 1.75 };
+    const result = projectRemainingMg(
+      baseInput({
+        source: PrintFilamentSourceMeasurement.Length,
+        filament: noDensity,
+        serverFilament: noDensity,
+        serverNominalM: 330,
+        formNominalM: 330,
+      })
+    );
+    expect(result.isSuppressed).toBeFalse();
+    expect(result.projectedMg).toBe(412_000);
+  });
+
+  it('suppresses when a volume-sourced adjustment cannot be converted', () => {
+    const noDensity = { diameterMm: 1.75 };
+    const result = projectRemainingMg(
+      baseInput({
+        filament: noDensity,
+        serverFilament: noDensity,
+        formAdjustments: [
+          { source: PrintFilamentSourceMeasurement.Volume, volumeMl: 25 },
+        ],
+      })
+    );
+    expect(result.isSuppressed).toBeTrue();
+    expect(result.projectedMg).toBe(412_000);
+  });
+
+  it('treats an AsRecorded adjustment as a weight row rather than coercing it away', () => {
+    const result = projectRemainingMg(
+      baseInput({
+        formAdjustments: [
+          {
+            source: PrintFilamentSourceMeasurement.AsRecorded,
+            amountMg: -32_000,
+          },
+        ],
+      })
+    );
+    expect(result.isSuppressed).toBeFalse();
+    expect(result.projectedMg).toBe(380_000);
+  });
+});

--- a/src/app/filament/filament-detail/remaining-projection.ts
+++ b/src/app/filament/filament-detail/remaining-projection.ts
@@ -1,0 +1,227 @@
+import { PrintFilamentSourceMeasurement } from 'src/app/core/services/print.service';
+import { convertFilamentValue } from 'src/app/shared/utils/filament-display.utils';
+
+/** The conversion inputs a filament contributes: density and diameter. */
+export type ProjectionFilament = {
+  materialDensityGramPerCubicCm?: number;
+  diameterMm?: number;
+} | null;
+
+/**
+ * One adjustment row, in whichever unit the user entered it. Weight is in
+ * MILLIGRAMS here — the caller converts the form's grams before passing it in.
+ */
+export interface AdjustmentRow {
+  source: PrintFilamentSourceMeasurement;
+  amountMg?: number | null;
+  lengthInM?: number | null;
+  volumeMl?: number | null;
+}
+
+/**
+ * Everything the projection needs, in each unit's native representation:
+ * milligrams for weight, meters for length, milliliters for volume.
+ *
+ * The caller converts the form's grams to milligrams; this module never sees grams.
+ */
+export interface ProjectionInput {
+  /** The server's own remaining figure. Null means the spool is untracked. */
+  serverRemainingMg: number | null;
+  serverNominalMg: number | null;
+  formNominalMg: number | null;
+
+  /**
+   * Adjustment rows as saved and as they currently stand in the form. Compared
+   * as summed milligrams, so an added, edited or removed row all fall out of the
+   * same subtraction.
+   */
+  serverAdjustments: AdjustmentRow[];
+  formAdjustments: AdjustmentRow[];
+
+  /** Native-unit values, required only when `source` is Length or Volume. */
+  serverNominalM?: number | null;
+  formNominalM?: number | null;
+  serverNominalMl?: number | null;
+  formNominalMl?: number | null;
+
+  source: PrintFilamentSourceMeasurement;
+
+  /**
+   * Conversion inputs as currently entered. `serverFilament` is what those
+   * values were when the figures were last derived: when they differ, every
+   * historical derived value would be recomputed on save, which the client does
+   * not attempt to mirror.
+   */
+  filament: ProjectionFilament;
+  serverFilament: ProjectionFilament;
+}
+
+export interface ProjectionResult {
+  /** The server's value, passed through for display. */
+  remainingMg: number | null;
+  /** What remaining will be once the form is saved. Equals `remainingMg` when clean. */
+  projectedMg: number | null;
+  /** True when the edit cannot be converted, so the caller must not show an arrow. */
+  isSuppressed: boolean;
+}
+
+/**
+ * Projects the remaining weight as a DELTA against the server's own number.
+ *
+ * Recomputing the value from scratch would make the client a second source of
+ * truth for a figure the server already sent, and the two formulas disagree in
+ * at least two real cases: a stored nominal weight of 0 (which the form nulls
+ * but the server treats as tracked) and the server's own rounding when it
+ * derives milligrams for length- and volume-sourced spools. Starting from the
+ * server's value and adding only the user's edits makes "clean equals server"
+ * true by construction.
+ */
+export function projectRemainingMg(input: ProjectionInput): ProjectionResult {
+  const remainingMg = input.serverRemainingMg ?? null;
+
+  if (remainingMg === null) {
+    return { remainingMg: null, projectedMg: null, isSuppressed: false };
+  }
+
+  // Editing density or diameter re-derives every stored milligram figure on
+  // save, including historical adjustments. Mirroring that client-side would be
+  // a second implementation of the server's conversion pipeline, so the
+  // projection stands down instead.
+  if (derivationInputsChanged(input)) {
+    return { remainingMg, projectedMg: remainingMg, isSuppressed: true };
+  }
+
+  const nominalDelta = nominalDeltaMg(input);
+  if (nominalDelta === null) {
+    return { remainingMg, projectedMg: remainingMg, isSuppressed: true };
+  }
+
+  const formAdjustmentsMg = sumAdjustmentsMg(
+    input.formAdjustments,
+    input.filament
+  );
+  const serverAdjustmentsMg = sumAdjustmentsMg(
+    input.serverAdjustments,
+    input.filament
+  );
+
+  if (formAdjustmentsMg === null || serverAdjustmentsMg === null) {
+    return { remainingMg, projectedMg: remainingMg, isSuppressed: true };
+  }
+
+  return {
+    remainingMg,
+    projectedMg:
+      remainingMg + nominalDelta + (formAdjustmentsMg - serverAdjustmentsMg),
+    isSuppressed: false,
+  };
+}
+
+/**
+ * True when the values the server derives milligrams from have been edited.
+ * Only meaningful for length/volume adjustments and spools; a pure-weight spool
+ * with no converted rows is unaffected by a density change.
+ */
+function derivationInputsChanged(input: ProjectionInput): boolean {
+  const usesConversion =
+    input.source !== PrintFilamentSourceMeasurement.Weight ||
+    input.formAdjustments.some(
+      (a) => a.source !== PrintFilamentSourceMeasurement.Weight
+    ) ||
+    input.serverAdjustments.some(
+      (a) => a.source !== PrintFilamentSourceMeasurement.Weight
+    );
+
+  if (!usesConversion) {
+    return false;
+  }
+
+  return (
+    input.filament?.materialDensityGramPerCubicCm !==
+      input.serverFilament?.materialDensityGramPerCubicCm ||
+    input.filament?.diameterMm !== input.serverFilament?.diameterMm
+  );
+}
+
+/**
+ * Sums adjustment rows in milligrams, converting each row from ITS OWN source
+ * unit. A length- or volume-sourced row's milligram field is the previous save's
+ * server-derived value and is stale the moment the user edits the row, so it is
+ * never read for those rows.
+ *
+ * Returns null when any row needs a conversion the filament cannot support.
+ */
+function sumAdjustmentsMg(
+  rows: AdjustmentRow[],
+  filament: ProjectionFilament
+): number | null {
+  let total = 0;
+
+  for (const row of rows) {
+    if (row.source === PrintFilamentSourceMeasurement.Length) {
+      const mg = convertFilamentValue(
+        row.lengthInM ?? 0,
+        PrintFilamentSourceMeasurement.Length,
+        PrintFilamentSourceMeasurement.Weight,
+        filament
+      );
+      if (mg === null) return null;
+      total += mg;
+    } else if (row.source === PrintFilamentSourceMeasurement.Volume) {
+      const mg = convertFilamentValue(
+        row.volumeMl ?? 0,
+        PrintFilamentSourceMeasurement.Volume,
+        PrintFilamentSourceMeasurement.Weight,
+        filament
+      );
+      if (mg === null) return null;
+      total += mg;
+    } else {
+      total += row.amountMg ?? 0;
+    }
+  }
+
+  return total;
+}
+
+/** Returns null when the spool's source unit cannot be converted to milligrams. */
+function nominalDeltaMg(input: ProjectionInput): number | null {
+  if (input.source === PrintFilamentSourceMeasurement.Length) {
+    return nativeDeltaMg(
+      input.serverNominalM,
+      input.formNominalM,
+      PrintFilamentSourceMeasurement.Length,
+      input.filament
+    );
+  }
+
+  if (input.source === PrintFilamentSourceMeasurement.Volume) {
+    return nativeDeltaMg(
+      input.serverNominalMl,
+      input.formNominalMl,
+      PrintFilamentSourceMeasurement.Volume,
+      input.filament
+    );
+  }
+
+  return (input.formNominalMg ?? 0) - (input.serverNominalMg ?? 0);
+}
+
+function nativeDeltaMg(
+  serverValue: number | null | undefined,
+  formValue: number | null | undefined,
+  unit: PrintFilamentSourceMeasurement,
+  filament: ProjectionFilament
+): number | null {
+  const delta = (formValue ?? 0) - (serverValue ?? 0);
+  if (delta === 0) {
+    return 0;
+  }
+
+  return convertFilamentValue(
+    delta,
+    unit,
+    PrintFilamentSourceMeasurement.Weight,
+    filament
+  );
+}

--- a/src/app/filament/filament-routing.module.ts
+++ b/src/app/filament/filament-routing.module.ts
@@ -13,6 +13,7 @@ import { FilamentDetailResolverService } from './resolvers/filament-detail-resol
 import { FilamentListResolverService } from './resolvers/filament-list-resolver.service';
 import { MaterialResolverService } from './resolvers/material-resolver.service';
 import { MaterialCategoryResolverService } from '../core/resolvers/material-category-resolver.service';
+import { PreferredFilamentDisplayUnitSettingResolverService } from '../core/resolvers/preferred-filament-display-unit-setting-resolver.service';
 import { FilamentStorageLocationResolverService } from './resolvers/filament-storage-location-resolver.service';
 
 export const filamentRoutes: Routes = [
@@ -42,6 +43,8 @@ export const filamentRoutes: Routes = [
           defaultFilamentPriceSetting:
             DefaultFilamentPriceSettingResolverService,
           materialCategories: MaterialCategoryResolverService,
+          preferredFilamentDisplayUnitSetting:
+            PreferredFilamentDisplayUnitSettingResolverService,
         },
         canDeactivate: [PendingChangesGuard],
       },
@@ -58,6 +61,8 @@ export const filamentRoutes: Routes = [
           defaultFilamentPriceSetting:
             DefaultFilamentPriceSettingResolverService,
           materialCategories: MaterialCategoryResolverService,
+          preferredFilamentDisplayUnitSetting:
+            PreferredFilamentDisplayUnitSettingResolverService,
         },
         canDeactivate: [PendingChangesGuard],
       },

--- a/src/app/filament/filament-routing.module.ts
+++ b/src/app/filament/filament-routing.module.ts
@@ -13,7 +13,7 @@ import { FilamentDetailResolverService } from './resolvers/filament-detail-resol
 import { FilamentListResolverService } from './resolvers/filament-list-resolver.service';
 import { MaterialResolverService } from './resolvers/material-resolver.service';
 import { MaterialCategoryResolverService } from '../core/resolvers/material-category-resolver.service';
-import { PreferredFilamentDisplayUnitSettingResolverService } from '../core/resolvers/preferred-filament-display-unit-setting-resolver.service';
+import { FilamentDisplayUnitResolverService } from './resolvers/filament-display-unit-resolver.service';
 import { FilamentStorageLocationResolverService } from './resolvers/filament-storage-location-resolver.service';
 
 export const filamentRoutes: Routes = [
@@ -44,7 +44,7 @@ export const filamentRoutes: Routes = [
             DefaultFilamentPriceSettingResolverService,
           materialCategories: MaterialCategoryResolverService,
           preferredFilamentDisplayUnitSetting:
-            PreferredFilamentDisplayUnitSettingResolverService,
+            FilamentDisplayUnitResolverService,
         },
         canDeactivate: [PendingChangesGuard],
       },
@@ -62,7 +62,7 @@ export const filamentRoutes: Routes = [
             DefaultFilamentPriceSettingResolverService,
           materialCategories: MaterialCategoryResolverService,
           preferredFilamentDisplayUnitSetting:
-            PreferredFilamentDisplayUnitSettingResolverService,
+            FilamentDisplayUnitResolverService,
         },
         canDeactivate: [PendingChangesGuard],
       },

--- a/src/app/filament/filament.module.ts
+++ b/src/app/filament/filament.module.ts
@@ -11,6 +11,8 @@ import { FilamentDetailResolverService } from './resolvers/filament-detail-resol
 import { FilamentListResolverService } from './resolvers/filament-list-resolver.service';
 import { MaterialResolverService } from './resolvers/material-resolver.service';
 import { EmptyStateComponent } from '../shared/empty-state/empty-state.component';
+import { FilamentPrintsPanelComponent } from './filament-detail/filament-prints-panel/filament-prints-panel.component';
+import { FilamentRemainingCardComponent } from './filament-detail/filament-remaining-card/filament-remaining-card.component';
 
 @NgModule({
   declarations: [FilamentDetailComponent, FilamentListContainerComponent],
@@ -19,6 +21,8 @@ import { EmptyStateComponent } from '../shared/empty-state/empty-state.component
     FilamentRoutingModule,
     AdsenseModule,
     EmptyStateComponent,
+    FilamentRemainingCardComponent,
+    FilamentPrintsPanelComponent,
   ],
   providers: [
     FilamentListResolverService,

--- a/src/app/filament/resolvers/filament-display-unit-resolver.service.ts
+++ b/src/app/filament/resolvers/filament-display-unit-resolver.service.ts
@@ -1,0 +1,37 @@
+import { Injectable, inject } from '@angular/core';
+import { ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import {
+  UserSetting,
+  UserSettingService,
+  UserSettingType,
+} from 'src/app/core/services/user-setting.service';
+
+/**
+ * The preferred filament display unit, for routes that only want it to format a
+ * number and must not fail without it.
+ *
+ * Deliberately separate from PreferredFilamentDisplayUnitSettingResolverService.
+ * That one is used by the settings page, where `null` carries meaning — it is how
+ * the page knows to CREATE the setting rather than update it. Degrading a failed
+ * fetch to `null` there would make the settings page try to add a setting that
+ * already exists. Here `null` only means "fall back to the default unit", so
+ * swallowing the failure is safe, and it keeps a settings outage from cancelling
+ * navigation to a page that has nothing to do with settings (#66).
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class FilamentDisplayUnitResolverService {
+  private readonly userSettingService = inject(UserSettingService);
+
+  resolve(
+    route: ActivatedRouteSnapshot,
+    state: RouterStateSnapshot
+  ): Promise<UserSetting | null> {
+    return this.userSettingService
+      .getCurrentUsersSettingByType(
+        UserSettingType.Prints_PreferredFilamentDisplayUnit
+      )
+      .catch(() => null);
+  }
+}


### PR DESCRIPTION
Closes #89.

Requires [3d-print-log-api#97](https://github.com/HoffmanEngineering/3d-print-log-api/pull/97), which adds the four read-only fields this reads. **Merge the API first** — without it the card falls back to the fields it already had (`filamentRemaining`), and length, volume, used and print count are simply hidden rather than showing zeros.

## What this adds

Opening a saved material now shows a right-hand rail with two cards:

- **Remaining** — a bar, the reading (`975 g of 1,000 g left`), and remaining length, volume, total used and print count.
- **Prints using this material** — the ten most recent prints that consumed it, each with its usage, and a *View all* link into the filtered print list when there are more.

## Design notes worth a reviewer's attention

**The rail absorbs the ad sidebar; the page does not become three columns.** `/filament/:id` already had a 300px `fxHide fxShow.gt-md` ad column. The new 340px rail takes that space and the ad moves into it, below the two cards. The old ngx-layout flex row is now a CSS Grid.

**The remaining figure is projected as a delta, not recomputed.** Edit an adjustment or the nominal weight and the card previews the result (`975 g → 943 g after saving`). It starts from the server's own `filamentRemaining` and adds only what changed, so a pristine form provably equals the server value. Recomputing from scratch would make the client a second source of truth and the two formulas genuinely disagree — a stored nominal weight of `0` (which the form nulls but the server treats as tracked), and the server's own rounding when it derives milligrams for length- and volume-sourced spools. When an edit can't be converted reliably — density or diameter changed, or density is missing — the card says the figure updates after saving rather than showing a number it can't stand behind. All of that arithmetic lives in `remaining-projection.ts` as a pure function with 15 tests.

**The form is never marked dirty by any of this.** `PendingChangesGuard` is on the route, so a false dirty state would block navigation off the page. The new code only ever *reads* the form (`getRawValue()`); a unit test asserts `dirty` is false after the cards render, and I confirmed in the browser that leaving a freshly-loaded material still navigates without a prompt.

**The prints panel fetches outside a resolver, deliberately.** A rejected resolver cancels navigation and bounces to `/` (#66), so a slow or failing prints query would block the form the user came to edit. The panel owns its own loading, empty, and error states, with a retry.

**A print can use the same spool twice.** There's no unique index on `(PrintId, FilamentId)`, so a row sums *every* usage entry for the filament — resolving actual-else-estimated per row, and per *unit* per row, before adding anything together. A 12 g weight row beside a 10 m length row totals ~41.8 g; taking the first row's unit would have reported 12 g and silently dropped the length.

**Add and copy mode show neither card.** The copy resolver nulls the id, so the same saved check `canShowSpoolCalculator` already uses rules out both — a clone's remaining and prints belong to the source spool.

**Accessibility:** the stats card sits *before* the form in the DOM, because that's the order it's read in on a narrow viewport. Grid areas move it to the rail on wide viewports, but grid reordering doesn't move keyboard or screen-reader order, so the DOM carries the meaningful sequence itself.

## Scope note

`/filament/:id` needs the user's preferred filament unit to format usage, but it must not fail without it. Rather than making the existing `PreferredFilamentDisplayUnitSettingResolverService` swallow errors, I left it untouched and added a scoped `FilamentDisplayUnitResolverService`. On the settings page a `null` result carries meaning — it's how that page knows to *create* the setting instead of updating it — so degrading failures to `null` there would have made a settings outage cause a duplicate-create.

## Testing

- 1177 unit tests pass, lint clean, production-shaped build clean.
- 35 Cypress tests pass across `cypress/e2e/filaments/`, including a new spec covering the card, the live projection, add mode, and sticky behavior. The sticky test scrolls twice and asserts the card is pinned at its offset both times — `should('be.visible')` alone passes for a card that merely scrolled along, which is exactly how `position: sticky` fails.
- Manually verified against a running API in the E2ETesting environment: the tracked, untracked, and no-usage states; the card totals agreeing with the prints listed beneath them; the *Set nominal weight* button focusing the right field; no navigation prompt on a clean form; and the grid at both breakpoints in tracked and add mode.

Documentation is updated in the Materials docs page.