### PR TITLE
feat(security): add CSP, Permissions-Policy and framing headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Test
         run: npm run test:ci
 
-      - name: Sitemap unit tests
-        run: npm run test:sitemap
+      - name: Script unit tests (sitemap, security headers)
+        run: npm run test:scripts
 
       - name: Build (dev/base config)
         run: npm run build:dev

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,8 +34,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Sitemap unit tests
-        run: npm run test:sitemap
+      - name: Script unit tests (sitemap, security headers)
+        run: npm run test:scripts
 
       - name: Generate sitemap
         run: node scripts/generate-sitemap.mjs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,8 +88,23 @@ Marketing/SEO routes are prerendered to static HTML at build time via `@angular/
 - **SSR-safety (important):** prerendering executes components in Node, so any browser global (`window`, `document`, `localStorage`, `navigator`) touched during construction/init crashes the build. Guard it with `isPlatformBrowser(inject(PLATFORM_ID))`.
 - **Marketing routes** are defined once in `scripts/marketing-routes.mjs`. To add a prerendered page, add it there AND in `app.routes.server.ts`.
 - **Verification:** `scripts/verify-prerender.mjs` runs in CI and gates prerendered output (unique titles/descriptions, OG/Twitter, canonicals, internal link graph, crawl files).
-- **Sitemap** is generated at deploy time by `scripts/generate-sitemap.mjs` (fetches public print/user IDs, writes a `<sitemapindex>` plus chunked child sitemaps into `dist/`). It is not committed; there is no static `src/sitemap.xml`. Unit tests: `npm run test:sitemap`.
+- **Sitemap** is generated at deploy time by `scripts/generate-sitemap.mjs` (fetches public print/user IDs, writes a `<sitemapindex>` plus chunked child sitemaps into `dist/`). It is not committed; there is no static `src/sitemap.xml`. Unit tests: `npm run test:scripts`.
 - **Deploy** ships the prebuilt `dist` with `skip_app_build: true` (no Oryx rebuild) so the generated sitemap reaches production; `refresh-sitemap.yml` redeploys the latest release tag daily.
+
+### Security Headers & CSP
+
+Response headers are served by Azure Static Web Apps from `src/staticwebapp.config.json` (`globalHeaders`), which ships as a build asset — SWA reads it literally, so it stays hand-edited JSON.
+
+- **SWA injects its own defaults**, whether or not we declare any: HSTS (with `preload`), `Referrer-Policy: same-origin`, `X-Content-Type-Options: nosniff`, `X-XSS-Protection`, and `X-DNS-Prefetch-Control`. `globalHeaders` **overrides them by name**, so redeclaring one with a laxer value is a silent downgrade. `SWA_DEFAULT_HEADERS` in `scripts/security-headers-lib.mjs` records the platform baseline and a test asserts we never fall below it. Verify with `curl -sI https://www.3dprintlog.com/` before changing a value.
+
+- **Validation:** `scripts/security-headers.test.mjs` parses the checked-in config and asserts the headers and CSP directives the app depends on. It runs in CI and at deploy via `npm run test:scripts`. `REQUIRED_CSP_SOURCES` maps each directive to the sources a real feature needs, and a test proves that removing any one of them fails — so adding a third-party origin means updating the CSP _and_ that map.
+- **The CSP is report-only.** It ships as `Content-Security-Policy-Report-Only` so a missed origin degrades to a console warning rather than a broken page.
+- **Two things must be solved before enforcing it**, and neither is done:
+  1. There is no `report-uri`/`report-to`, so violations surface only in each visitor's own console. Collecting them needs an endpoint on the API side.
+  2. **AdSense cannot be made to work by host allowlist.** Google states its ad-serving domains change and officially supports only a nonce-based strict CSP (`'nonce-…'` + `'strict-dynamic'` + `'unsafe-eval'`). The current allowlist is best-effort for the report-only stage; enforcing it as written will eventually blank ad slots.
+- **Never add a nonce or hash to `script-src` while `'unsafe-inline'` is present.** CSP Level 3 makes browsers ignore `'unsafe-inline'` as soon as either appears, which would silently kill the gtag init, the pre-paint theme script, and the font `onload` handlers. `validateSecurityHeaders` fails on that combination.
+- **Adding an external origin** (a new analytics vendor, embed, or API host): add it to the narrowest directive that covers it, not to `default-src`. `frame-ancestors`, `form-action`, and `base-uri` do _not_ fall back to `default-src`, which is why they are spelled out.
+- The production Auth0 tenant lives in the `ENVIRONMENT_PROD_TS` secret and is not knowable from the repo, so `connect-src`/`frame-src` match it with `https://*.auth0.com`.
 
 ## Angular Conventions
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "ng test",
     "test:ci": "ng test --no-watch --code-coverage --browsers ChromeHeadless",
     "test:brief": "bash scripts/test-brief.sh",
-    "test:sitemap": "node --test scripts/*.test.mjs",
+    "test:scripts": "node --test scripts/*.test.mjs",
     "verify:shells": "node scripts/verify-shells.mjs",
     "lint": "ng lint",
     "lint:fix": "ng lint --fix",

--- a/scripts/security-headers-lib.mjs
+++ b/scripts/security-headers-lib.mjs
@@ -1,0 +1,351 @@
+/**
+ * Helpers for the response headers Azure Static Web Apps serves from
+ * `src/staticwebapp.config.json`.
+ *
+ * The config file is the single source of truth — SWA reads it literally, so it
+ * stays hand-edited JSON. This module exists so `security-headers.test.mjs` can
+ * assert something stronger than "the file has some headers in it": it parses
+ * the policy and checks the directives we actually depend on.
+ */
+
+/**
+ * Parse a Content-Security-Policy value into a `Map` of directive name to
+ * source list. Directive names are lowercased (they are case-insensitive);
+ * sources are left alone, because host sources can be case-sensitive in paths.
+ *
+ * @param {string} value
+ * @returns {Map<string, string[]>}
+ */
+export function parseCsp(value) {
+  const directives = new Map();
+
+  for (const raw of String(value).split(';')) {
+    const parts = raw.trim().split(/\s+/).filter(Boolean);
+    if (parts.length === 0) continue;
+
+    const name = parts[0].toLowerCase();
+    if (directives.has(name)) {
+      throw new Error(`Invalid CSP — duplicate directive: ${name}`);
+    }
+    directives.set(name, parts.slice(1));
+  }
+
+  return directives;
+}
+
+/**
+ * Inverse of {@link parseCsp}. Round-trips a policy so a caller can normalize
+ * one without hand-joining strings.
+ *
+ * @param {Map<string, string[]>} directives
+ * @returns {string}
+ */
+export function serializeCsp(directives) {
+  return [...directives]
+    .map(([name, sources]) =>
+      sources.length ? `${name} ${sources.join(' ')}` : name
+    )
+    .join('; ');
+}
+
+/**
+ * Headers Azure Static Web Apps injects on its own, verified against
+ * https://www.3dprintlog.com. Setting `globalHeaders` *overrides* these by
+ * name, so anything we redeclare must be at least as strict as what the
+ * platform already sends. This constant exists so a test can prove we never
+ * regress one by accident.
+ *
+ * X-XSS-Protection and X-DNS-Prefetch-Control are also injected; we leave both
+ * alone rather than redeclare them (the former is deprecated and superseded by
+ * the CSP).
+ */
+export const SWA_DEFAULT_HEADERS = {
+  'Strict-Transport-Security': 'max-age=10886400; includeSubDomains; preload',
+  'Referrer-Policy': 'same-origin',
+  'X-Content-Type-Options': 'nosniff',
+};
+
+/**
+ * The non-CSP headers every response must carry, with their exact expected
+ * values. Kept as literals rather than matchers so a reviewer can read the
+ * shipped policy straight out of this file.
+ *
+ * HSTS keeps the `preload` token SWA already sends -- dropping it would signal
+ * intent to leave the preload list -- and raises max-age to a year, which is
+ * the minimum the preload list actually requires. The platform default of
+ * 10886400 (126 days) does not qualify.
+ *
+ * Referrer-Policy stays at SWA's `same-origin` rather than the more common
+ * `strict-origin-when-cross-origin`: it sends no referrer at all cross-origin,
+ * which is stricter, and the site already runs on it.
+ */
+export const REQUIRED_GLOBAL_HEADERS = {
+  'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload',
+  'X-Content-Type-Options': 'nosniff',
+  'Referrer-Policy': 'same-origin',
+  'X-Frame-Options': 'DENY',
+  'Cross-Origin-Opener-Policy': 'same-origin-allow-popups',
+  'Permissions-Policy': [
+    'accelerometer=()',
+    'autoplay=(self "https://www.youtube.com" "https://www.youtube-nocookie.com")',
+    'camera=(self)',
+    'display-capture=()',
+    'encrypted-media=(self "https://www.youtube.com" "https://www.youtube-nocookie.com")',
+    'fullscreen=(self "https://www.youtube.com" "https://www.youtube-nocookie.com")',
+    'geolocation=()',
+    'gyroscope=()',
+    'magnetometer=()',
+    'microphone=()',
+    'payment=()',
+    'usb=()',
+  ].join(', '),
+};
+
+/**
+ * Check a parsed `staticwebapp.config.json` for the headers and CSP directives
+ * this app depends on.
+ *
+ * @param {object} config
+ * @returns {string[]} human-readable problems; empty means the config is good.
+ */
+export function validateSecurityHeaders(config) {
+  const problems = [];
+  const headers = config?.globalHeaders;
+
+  if (!headers || typeof headers !== 'object') {
+    problems.push('staticwebapp.config.json has no globalHeaders block');
+    return problems;
+  }
+
+  for (const [name, expected] of Object.entries(REQUIRED_GLOBAL_HEADERS)) {
+    if (!(name in headers)) {
+      problems.push(`missing required header: ${name}`);
+    } else if (headers[name] !== expected) {
+      problems.push(
+        `header ${name} is "${headers[name]}", expected "${expected}"`
+      );
+    }
+  }
+
+  const reportOnly = headers['Content-Security-Policy-Report-Only'];
+  if (!reportOnly) {
+    problems.push(
+      'missing required header: Content-Security-Policy-Report-Only'
+    );
+    return problems;
+  }
+
+  let directives;
+  try {
+    directives = parseCsp(reportOnly);
+  } catch (error) {
+    problems.push(
+      `Content-Security-Policy-Report-Only is malformed: ${error.message}`
+    );
+    return problems;
+  }
+
+  for (const name of REQUIRED_CSP_DIRECTIVES) {
+    if (!directives.has(name)) {
+      problems.push(`CSP is missing the ${name} directive`);
+    }
+  }
+
+  for (const [name, expected] of Object.entries(PINNED_CSP_DIRECTIVES)) {
+    const actual = directives.get(name);
+    if (actual && actual.join(' ') !== expected) {
+      problems.push(
+        `CSP ${name} is "${actual.join(' ')}", expected "${expected}"`
+      );
+    }
+  }
+
+  for (const [name, sources] of Object.entries(REQUIRED_CSP_SOURCES)) {
+    const actual = directives.get(name) ?? [];
+    for (const source of sources) {
+      if (!actual.includes(source)) {
+        problems.push(`CSP ${name} is missing ${source}`);
+      }
+    }
+  }
+
+  // CSP Level 3: a nonce or hash makes browsers ignore 'unsafe-inline' in the
+  // same directive. Mixing them silently disables every inline script that is
+  // not itself hashed -- the gtag init, the pre-paint theme script, and the
+  // font onload handlers.
+  //
+  // Checked across the -elem/-attr variants too, because script-src-elem
+  // *overrides* script-src for script elements: adding a nonce there would slip
+  // past a check that only looked at script-src.
+  for (const name of INLINE_CAPABLE_DIRECTIVES) {
+    const sources = directives.get(name);
+    if (!sources?.includes("'unsafe-inline'")) {
+      continue;
+    }
+    if (sources.some((source) => NONCE_OR_HASH.test(source))) {
+      problems.push(
+        `CSP ${name} mixes 'unsafe-inline' with a nonce/hash; CSP Level 3 ` +
+          "ignores 'unsafe-inline' when either is present"
+      );
+    }
+  }
+
+  // A -elem override that drops 'unsafe-inline' has the same effect as mixing:
+  // the inline scripts the app ships stop running under enforcement.
+  for (const [name, base] of Object.entries(ELEM_OVERRIDES)) {
+    const override = directives.get(name);
+    if (!override) {
+      continue;
+    }
+    if (
+      directives.get(base)?.includes("'unsafe-inline'") &&
+      !override.includes("'unsafe-inline'")
+    ) {
+      problems.push(
+        `CSP ${name} overrides ${base} but drops 'unsafe-inline', which the ` +
+          'inline scripts in index.prod.html depend on'
+      );
+    }
+  }
+
+  return problems;
+}
+
+/**
+ * Directives that must be spelled out rather than inherited from `default-src`.
+ * Fetch directives that do *not* fall back to `default-src` (`frame-ancestors`,
+ * `form-action`, `base-uri`) are the reason this list is explicit.
+ */
+export const REQUIRED_CSP_DIRECTIVES = [
+  'default-src',
+  'script-src',
+  'style-src',
+  'font-src',
+  'img-src',
+  'connect-src',
+  'frame-src',
+  'frame-ancestors',
+  'worker-src',
+  'form-action',
+  'base-uri',
+  'object-src',
+];
+
+/**
+ * Sources each directive must keep, and the feature that breaks without them.
+ *
+ * This is the part of validation with teeth: without it a reviewer can delete
+ * an origin from the policy and every test still passes, because the rest of
+ * the suite only compares the config against constants in this same file.
+ *
+ * Google's hosts were confirmed by capturing the network on
+ * https://www.3dprintlog.com. Note CSP host wildcards require at least one
+ * leading label, so `*.analytics.google.com` does NOT match the bare
+ * `analytics.google.com` that gtag actually beacons to.
+ */
+export const REQUIRED_CSP_SOURCES = {
+  'script-src': [
+    "'self'",
+    // AdSense and the gtag/Google Ads snippets are inline or inject inline.
+    "'unsafe-inline'",
+    'https://www.googletagmanager.com',
+    'https://pagead2.googlesyndication.com',
+    'https://www.googleadservices.com',
+    // Google's CSP guidance lists www.google.com under script-src-elem for the
+    // Conversion Linker and remarketing tags, not just as a beacon target.
+    'https://www.google.com',
+    // documentation.component.ts injects https://www.youtube.com/iframe_api.
+    'https://www.youtube.com',
+  ],
+  'style-src': [
+    "'self'",
+    // Angular Material writes inline styles.
+    "'unsafe-inline'",
+    'https://fonts.googleapis.com',
+  ],
+  'font-src': ["'self'", 'https://fonts.gstatic.com'],
+  // blob: for auth-image.pipe's createObjectURL, data: for generated QR codes,
+  // and bare https: because Auth0 hands back `user.picture` on whatever origin
+  // the identity provider uses (auth.service.ts stores it as profilePicture).
+  'img-src': ["'self'", 'data:', 'blob:', 'https:'],
+  'connect-src': [
+    "'self'",
+    'https://api.3dprintlog.com',
+    // The prod Auth0 tenant lives in the ENVIRONMENT_PROD_TS secret.
+    'https://*.auth0.com',
+    // Print and project images.
+    'https://*.blob.core.windows.net',
+    // Application Insights.
+    'https://dc.services.visualstudio.com',
+    'https://*.in.applicationinsights.azure.com',
+    // GA4 / Google Ads beacons, all observed live.
+    'https://analytics.google.com',
+    'https://www.google.com',
+    'https://www.googletagmanager.com',
+    // Conversion, remarketing and linker traffic.
+    'https://www.googleadservices.com',
+    'https://*.doubleclick.net',
+    'https://*.googlesyndication.com',
+  ],
+  'frame-src': [
+    // <youtube-player> leaves disableCookies at its false default, so the
+    // Angular component passes host: undefined and the IFrame API embeds from
+    // www.youtube.com -- NOT the nocookie host, which is only allowlisted so
+    // setting disableCookies later does not break.
+    'https://www.youtube.com',
+    // GTM injects iframes for some tag types.
+    'https://www.googletagmanager.com',
+    // NOTE: https://*.auth0.com is in the policy but deliberately NOT pinned
+    // here. Auth0 only frames for silent auth when useRefreshTokensFallback is
+    // on, and auth.service.ts leaves it at the SDK default of false, so it is
+    // headroom -- pinning it would contradict that.
+  ],
+  // The G-code viewer spawns a same-origin worker
+  // (src/assets/js/gcode-viewer/ui.js:454), so 'self' is a real dependency.
+  // The blob: in the policy is headroom: html5-qrcode's createObjectURL calls
+  // produce image elements, which img-src blob: covers, not workers.
+  'worker-src': ["'self'"],
+  // Stripe checkout and the billing portal are reached with
+  // `window.location.href = result.url`, a top-level navigation that
+  // form-action does not govern at all. Only 'self' is a real dependency; the
+  // Stripe hosts stay in the policy in case a real form post is ever added.
+  'form-action': ["'self'"],
+};
+
+/** Matches a CSP nonce or hash source expression. */
+const NONCE_OR_HASH = /^'(nonce|sha(256|384|512))-/;
+
+/** Directives where 'unsafe-inline' is meaningful and can be cancelled out. */
+const INLINE_CAPABLE_DIRECTIVES = [
+  'script-src',
+  'script-src-elem',
+  'script-src-attr',
+  'style-src',
+  'style-src-elem',
+  'style-src-attr',
+];
+
+/**
+ * Directives that take precedence over a broader one for their resource kind.
+ *
+ * All four matter for this app, which is why none of them may drop
+ * 'unsafe-inline' while the base directive still carries it:
+ *   -elem  index.prod.html ships two inline <script> elements (the pre-paint
+ *          theme swap and the gtag config), and Angular injects component CSS
+ *          as <style> elements at runtime.
+ *   -attr  the font <link>s carry onload="this.media='all'", and Angular style
+ *          bindings and Material write inline style attributes.
+ */
+const ELEM_OVERRIDES = {
+  'script-src-elem': 'script-src',
+  'script-src-attr': 'script-src',
+  'style-src-elem': 'style-src',
+  'style-src-attr': 'style-src',
+};
+
+/** Directives whose value is a security decision, not a compatibility one. */
+export const PINNED_CSP_DIRECTIVES = {
+  'object-src': "'none'",
+  'frame-ancestors': "'none'",
+  'base-uri': "'self'",
+};

--- a/scripts/security-headers.test.mjs
+++ b/scripts/security-headers.test.mjs
@@ -1,0 +1,422 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import {
+  parseCsp,
+  serializeCsp,
+  REQUIRED_CSP_SOURCES,
+  REQUIRED_GLOBAL_HEADERS,
+  SWA_DEFAULT_HEADERS,
+  validateSecurityHeaders,
+} from './security-headers-lib.mjs';
+
+/** Rebuild the config with one CSP source removed, to prove validation bites. */
+function configWithout(directive, source) {
+  const directives = parseCsp(csp);
+  directives.set(
+    directive,
+    directives.get(directive).filter((s) => s !== source)
+  );
+  return {
+    ...config,
+    globalHeaders: {
+      ...globalHeaders,
+      'Content-Security-Policy-Report-Only': serializeCsp(directives),
+    },
+  };
+}
+
+const config = JSON.parse(
+  readFileSync(
+    new URL('../src/staticwebapp.config.json', import.meta.url),
+    'utf8'
+  )
+);
+
+const globalHeaders = config.globalHeaders ?? {};
+const csp = globalHeaders['Content-Security-Policy-Report-Only'];
+
+/* -------------------------------------------------------------------------- */
+/* parseCsp / serializeCsp                                                     */
+/* -------------------------------------------------------------------------- */
+
+test('parseCsp splits a policy into directives and sources', () => {
+  const directives = parseCsp("default-src 'self'; img-src 'self' data:");
+  assert.deepEqual(directives.get('default-src'), ["'self'"]);
+  assert.deepEqual(directives.get('img-src'), ["'self'", 'data:']);
+});
+
+test('parseCsp tolerates extra whitespace and a trailing semicolon', () => {
+  const directives = parseCsp("  default-src   'self' ;  object-src 'none';  ");
+  assert.equal(directives.size, 2);
+  assert.deepEqual(directives.get('object-src'), ["'none'"]);
+});
+
+test('parseCsp lowercases directive names but preserves source case', () => {
+  const directives = parseCsp('Frame-Src https://www.YouTube.com');
+  assert.deepEqual(directives.get('frame-src'), ['https://www.YouTube.com']);
+});
+
+test('parseCsp keeps valueless directives as an empty source list', () => {
+  const directives = parseCsp("upgrade-insecure-requests; object-src 'none'");
+  assert.deepEqual(directives.get('upgrade-insecure-requests'), []);
+});
+
+test('parseCsp throws on a duplicate directive', () => {
+  assert.throws(
+    () => parseCsp("default-src 'self'; default-src 'none'"),
+    /duplicate directive: default-src/i
+  );
+});
+
+test('serializeCsp round-trips a parsed policy', () => {
+  const policy =
+    "default-src 'self'; img-src 'self' data:; upgrade-insecure-requests";
+  assert.equal(serializeCsp(parseCsp(policy)), policy);
+});
+
+/* -------------------------------------------------------------------------- */
+/* validateSecurityHeaders                                                     */
+/* -------------------------------------------------------------------------- */
+
+test('validateSecurityHeaders reports a missing globalHeaders block', () => {
+  const problems = validateSecurityHeaders({ routes: [] });
+  assert.ok(problems.some((p) => /globalHeaders/.test(p)));
+});
+
+test('validateSecurityHeaders reports each missing required header by name', () => {
+  const problems = validateSecurityHeaders({ globalHeaders: {} });
+  for (const name of Object.keys(REQUIRED_GLOBAL_HEADERS)) {
+    assert.ok(
+      problems.some((p) => p.includes(name)),
+      `expected a problem mentioning ${name}`
+    );
+  }
+});
+
+test('validateSecurityHeaders reports a header whose value is wrong', () => {
+  const problems = validateSecurityHeaders({
+    globalHeaders: {
+      ...REQUIRED_GLOBAL_HEADERS,
+      'X-Content-Type-Options': 'sniff',
+    },
+  });
+  assert.ok(
+    problems.some((p) => /X-Content-Type-Options/.test(p) && /nosniff/.test(p))
+  );
+});
+
+test('validateSecurityHeaders passes the checked-in config', () => {
+  assert.deepEqual(validateSecurityHeaders(config), []);
+});
+
+/* -------------------------------------------------------------------------- */
+/* The checked-in staticwebapp.config.json                                     */
+/* -------------------------------------------------------------------------- */
+
+test('config declares a globalHeaders block', () => {
+  assert.ok(
+    config.globalHeaders,
+    'staticwebapp.config.json has no globalHeaders'
+  );
+});
+
+test('every required non-CSP header is present with the expected value', () => {
+  for (const [name, value] of Object.entries(REQUIRED_GLOBAL_HEADERS)) {
+    assert.equal(globalHeaders[name], value, `header ${name}`);
+  }
+});
+
+test('no header we declare is weaker than the one SWA already sends', () => {
+  // globalHeaders overrides the platform defaults by name. Every value we
+  // redeclare has to be at least as strict as what production sends today,
+  // otherwise shipping this config is a downgrade.
+  for (const [name, platformValue] of Object.entries(SWA_DEFAULT_HEADERS)) {
+    const ours = REQUIRED_GLOBAL_HEADERS[name];
+    if (ours === undefined) continue;
+
+    if (name === 'Strict-Transport-Security') {
+      const age = (value) => Number(/max-age=(\d+)/.exec(value)?.[1] ?? 0);
+      assert.ok(
+        age(ours) >= age(platformValue),
+        `HSTS max-age drops from ${age(platformValue)} to ${age(ours)}`
+      );
+      // Dropping `preload` signals intent to leave the HSTS preload list.
+      if (/preload/.test(platformValue)) {
+        assert.match(ours, /preload/, 'HSTS lost the preload token');
+      }
+      continue;
+    }
+
+    assert.equal(ours, platformValue, `${name} must not be relaxed`);
+  }
+});
+
+test('HSTS commits to at least one year and includes subdomains', () => {
+  const hsts = globalHeaders['Strict-Transport-Security'];
+  const maxAge = Number(/max-age=(\d+)/.exec(hsts)?.[1]);
+  assert.ok(maxAge >= 31536000, `max-age ${maxAge} is under one year`);
+  assert.match(hsts, /includeSubDomains/);
+});
+
+test('Permissions-Policy keeps camera available to self for the QR scanner', () => {
+  // src/app/shared/qr-scanner + html5-qrcode needs getUserMedia on our own origin.
+  assert.match(globalHeaders['Permissions-Policy'], /camera=\(self\)/);
+});
+
+test('Permissions-Policy denies microphone and geolocation outright', () => {
+  const policy = globalHeaders['Permissions-Policy'];
+  assert.match(policy, /microphone=\(\)/);
+  assert.match(policy, /geolocation=\(\)/);
+});
+
+test('the CSP ships in report-only mode for this stage', () => {
+  assert.ok(csp, 'no Content-Security-Policy-Report-Only header');
+  assert.equal(
+    globalHeaders['Content-Security-Policy'],
+    undefined,
+    'CSP must not be enforced yet — see issue for the staged rollout'
+  );
+});
+
+test('the CSP parses and locks down the directives that cost nothing', () => {
+  const directives = parseCsp(csp);
+  assert.deepEqual(directives.get('object-src'), ["'none'"]);
+  assert.deepEqual(directives.get('frame-ancestors'), ["'none'"]);
+  assert.deepEqual(directives.get('base-uri'), ["'self'"]);
+});
+
+test('the CSP declares every directive we rely on rather than falling back to default-src', () => {
+  const directives = parseCsp(csp);
+  for (const name of [
+    'default-src',
+    'script-src',
+    'style-src',
+    'font-src',
+    'img-src',
+    'connect-src',
+    'frame-src',
+    'worker-src',
+    'form-action',
+  ]) {
+    assert.ok(directives.has(name), `CSP is missing ${name}`);
+  }
+});
+
+test('style-src and font-src cover the Google Fonts links in the shipped HTML', () => {
+  const directives = parseCsp(csp);
+  // index.prod.html is the file the production build ships -- index.html is the
+  // dev entry point and does not carry the Google Ads tag.
+  const indexHtml = readFileSync(
+    new URL('../src/index.prod.html', import.meta.url),
+    'utf8'
+  );
+  assert.match(indexHtml, /fonts\.googleapis\.com/);
+  assert.ok(
+    directives.get('style-src').includes('https://fonts.googleapis.com')
+  );
+  assert.ok(directives.get('font-src').includes('https://fonts.gstatic.com'));
+});
+
+test('style-src allows inline styles, which Angular Material requires', () => {
+  assert.ok(parseCsp(csp).get('style-src').includes("'unsafe-inline'"));
+});
+
+test('connect-src reaches the production API and the Auth0 tenant', () => {
+  const connect = parseCsp(csp).get('connect-src');
+  assert.ok(connect.includes('https://api.3dprintlog.com'));
+  // The prod Auth0 domain lives in the ENVIRONMENT_PROD_TS secret and is not
+  // knowable here, so the tenant is matched by wildcard.
+  assert.ok(connect.includes('https://*.auth0.com'));
+});
+
+test('frame-src covers the host the YouTube player actually embeds from', () => {
+  // <youtube-player> leaves disableCookies false, so @angular/youtube-player
+  // passes host: undefined and the IFrame API embeds www.youtube.com. Pinning
+  // only the nocookie host would pass while the real player is blocked.
+  const frameSrc = parseCsp(csp).get('frame-src');
+  assert.ok(frameSrc.includes('https://www.youtube.com'));
+});
+
+test('script-src covers the YouTube IFrame API the docs page injects', () => {
+  const docs = readFileSync(
+    new URL(
+      '../src/app/documentation/documentation.component.ts',
+      import.meta.url
+    ),
+    'utf8'
+  );
+  assert.match(docs, /https:\/\/www\.youtube\.com\/iframe_api/);
+  assert.ok(
+    parseCsp(csp).get('script-src').includes('https://www.youtube.com')
+  );
+});
+
+test('img-src allows the arbitrary origins Auth0 profile pictures come from', () => {
+  // auth.service.ts persists Auth0's user.picture, whose host depends on the
+  // identity provider (Google, Gravatar, ...).
+  assert.ok(parseCsp(csp).get('img-src').includes('https:'));
+});
+
+test('validation catches a nonce smuggled into script-src-elem', () => {
+  // script-src-elem overrides script-src for script elements, so a check that
+  // only inspected script-src would miss this.
+  const directives = parseCsp(csp);
+  directives.set('script-src-elem', [
+    "'self'",
+    "'unsafe-inline'",
+    "'nonce-abc'",
+  ]);
+  const problems = validateSecurityHeaders({
+    ...config,
+    globalHeaders: {
+      ...globalHeaders,
+      'Content-Security-Policy-Report-Only': serializeCsp(directives),
+    },
+  });
+
+  assert.ok(
+    problems.some((p) => p.includes('script-src-elem') && /nonce/.test(p)),
+    'nonce in script-src-elem was not reported'
+  );
+});
+
+test('validation catches an -attr override that drops unsafe-inline', () => {
+  // script-src-attr takes precedence over script-src for inline event
+  // handlers. index.prod.html's font links carry onload="this.media='all'",
+  // so 'none' here would stop the fonts ever being applied.
+  for (const name of ['script-src-attr', 'style-src-attr']) {
+    const directives = parseCsp(csp);
+    directives.set(name, ["'none'"]);
+    const problems = validateSecurityHeaders({
+      ...config,
+      globalHeaders: {
+        ...globalHeaders,
+        'Content-Security-Policy-Report-Only': serializeCsp(directives),
+      },
+    });
+
+    assert.ok(
+      problems.some((p) => p.includes(name) && /unsafe-inline/.test(p)),
+      `${name} dropping unsafe-inline was not reported`
+    );
+  }
+});
+
+test('validation catches a nonce smuggled into any inline-capable directive', () => {
+  for (const name of ['script-src-attr', 'style-src-elem', 'style-src-attr']) {
+    const directives = parseCsp(csp);
+    directives.set(name, ["'self'", "'unsafe-inline'", "'sha512-xyz'"]);
+    const problems = validateSecurityHeaders({
+      ...config,
+      globalHeaders: {
+        ...globalHeaders,
+        'Content-Security-Policy-Report-Only': serializeCsp(directives),
+      },
+    });
+
+    assert.ok(
+      problems.some((p) => p.includes(name) && /nonce\/hash/.test(p)),
+      `hash in ${name} was not reported`
+    );
+  }
+});
+
+test('validation catches a script-src-elem override that drops unsafe-inline', () => {
+  const directives = parseCsp(csp);
+  directives.set('script-src-elem', ["'self'"]);
+  const problems = validateSecurityHeaders({
+    ...config,
+    globalHeaders: {
+      ...globalHeaders,
+      'Content-Security-Policy-Report-Only': serializeCsp(directives),
+    },
+  });
+
+  assert.ok(
+    problems.some(
+      (p) => p.includes('script-src-elem') && /unsafe-inline/.test(p)
+    ),
+    'script-src-elem dropping unsafe-inline was not reported'
+  );
+});
+
+test('the CSP has no report-uri pointing at a host we do not control', () => {
+  const directives = parseCsp(csp);
+  const target = directives.get('report-uri');
+  if (target) {
+    for (const uri of target) {
+      assert.match(uri, /^(\/|https:\/\/([a-z0-9-]+\.)*3dprintlog\.com)/);
+    }
+  }
+});
+
+test('script-src covers the Google Ads tag that only production HTML loads', () => {
+  const indexProd = readFileSync(
+    new URL('../src/index.prod.html', import.meta.url),
+    'utf8'
+  );
+  // Production configures a Google Ads conversion tag; dev does not.
+  assert.match(indexProd, /AW-\d+/);
+  assert.ok(
+    parseCsp(csp).get('script-src').includes('https://www.googletagmanager.com')
+  );
+});
+
+test('every source a feature depends on is actually required by validation', () => {
+  // Removing any one of them must be caught. Without this the rest of the
+  // suite would happily pass a policy with Auth0 or telemetry deleted.
+  for (const [directive, sources] of Object.entries(REQUIRED_CSP_SOURCES)) {
+    for (const source of sources) {
+      const problems = validateSecurityHeaders(
+        configWithout(directive, source)
+      );
+      assert.ok(
+        problems.some((p) => p.includes(directive) && p.includes(source)),
+        `dropping ${source} from ${directive} was not reported`
+      );
+    }
+  }
+});
+
+test('validation rejects mixing a nonce or hash with unsafe-inline', () => {
+  // CSP Level 3 makes browsers ignore 'unsafe-inline' once either is present,
+  // which would silently kill the gtag init and the pre-paint theme script.
+  const directives = parseCsp(csp);
+  directives.set('script-src', [
+    ...directives.get('script-src'),
+    "'sha256-abc123'",
+  ]);
+  const problems = validateSecurityHeaders({
+    ...config,
+    globalHeaders: {
+      ...globalHeaders,
+      'Content-Security-Policy-Report-Only': serializeCsp(directives),
+    },
+  });
+
+  assert.ok(
+    problems.some((p) => /unsafe-inline/.test(p) && /nonce\/hash/.test(p)),
+    'mixing a hash with unsafe-inline was not reported'
+  );
+});
+
+/* -------------------------------------------------------------------------- */
+/* Regressions in the rest of the config                                       */
+/* -------------------------------------------------------------------------- */
+
+test('the app-shell rewrites and navigation fallback are untouched', () => {
+  const routes = Object.fromEntries(
+    config.routes.filter((r) => r.rewrite).map((r) => [r.route, r.rewrite])
+  );
+  assert.equal(routes['/prints'], '/shells/list-skeleton.html');
+  assert.equal(routes['/materials'], '/shells/list-skeleton.html');
+  assert.equal(routes['/filament'], '/shells/list-skeleton.html');
+  assert.equal(routes['/printers'], '/shells/list-skeleton.html');
+  assert.equal(config.navigationFallback.rewrite, '/shells/app-shell.html');
+});
+
+test('the shells route still opts out of caching', () => {
+  const shells = config.routes.find((r) => r.route === '/shells/*');
+  assert.equal(shells.headers['cache-control'], 'no-cache');
+});

--- a/src/staticwebapp.config.json
+++ b/src/staticwebapp.config.json
@@ -6,5 +6,14 @@
     { "route": "/printers", "rewrite": "/shells/list-skeleton.html" },
     { "route": "/shells/*", "headers": { "cache-control": "no-cache" } }
   ],
-  "navigationFallback": { "rewrite": "/shells/app-shell.html" }
+  "navigationFallback": { "rewrite": "/shells/app-shell.html" },
+  "globalHeaders": {
+    "Strict-Transport-Security": "max-age=31536000; includeSubDomains; preload",
+    "X-Content-Type-Options": "nosniff",
+    "Referrer-Policy": "same-origin",
+    "X-Frame-Options": "DENY",
+    "Cross-Origin-Opener-Policy": "same-origin-allow-popups",
+    "Permissions-Policy": "accelerometer=(), autoplay=(self \"https://www.youtube.com\" \"https://www.youtube-nocookie.com\"), camera=(self), display-capture=(), encrypted-media=(self \"https://www.youtube.com\" \"https://www.youtube-nocookie.com\"), fullscreen=(self \"https://www.youtube.com\" \"https://www.youtube-nocookie.com\"), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()",
+    "Content-Security-Policy-Report-Only": "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.google.com https://www.googleadservices.com https://pagead2.googlesyndication.com https://tpc.googlesyndication.com https://partner.googleadservices.com https://googleads.g.doubleclick.net https://adservice.google.com https://www.googletagmanager.com https://www.google-analytics.com https://www.youtube.com https://www.youtube-nocookie.com https://s.ytimg.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; img-src 'self' data: blob: https:; media-src 'self' blob:; connect-src 'self' https://api.3dprintlog.com https://www.google.com https://www.googletagmanager.com https://www.googleadservices.com https://analytics.google.com https://*.3dprintlog.com https://*.auth0.com https://*.blob.core.windows.net https://dc.services.visualstudio.com https://*.in.applicationinsights.azure.com https://*.google-analytics.com https://*.analytics.google.com https://*.googlesyndication.com https://*.doubleclick.net https://*.adtrafficquality.google; frame-src 'self' https://www.googletagmanager.com https://www.youtube.com https://www.youtube-nocookie.com https://googleads.g.doubleclick.net https://tpc.googlesyndication.com https://*.adtrafficquality.google https://*.auth0.com; worker-src 'self' blob:; form-action 'self' https://checkout.stripe.com https://billing.stripe.com; frame-ancestors 'none'; base-uri 'self'; object-src 'none'; upgrade-insecure-requests"
+  }
 }


### PR DESCRIPTION
## What

Adds a `globalHeaders` block to `src/staticwebapp.config.json` — **CSP (report-only), Permissions-Policy, X-Frame-Options, and COOP** — plus Node tests that validate the shipped policy.

## Why these four and not "all the security headers"

Azure Static Web Apps already injects five headers on its own, with no config at all. Verified with `curl -sI https://www.3dprintlog.com/`:

```
Strict-Transport-Security: max-age=10886400; includeSubDomains; preload
Referrer-Policy: same-origin
X-Content-Type-Options: nosniff
X-XSS-Protection: 1; mode=block
X-DNS-Prefetch-Control: off
```

So the genuinely missing pieces are the CSP, Permissions-Policy, and framing protection. That matters here because Auth0 runs with `cacheLocation: 'localstorage'` (`auth.service.ts:68`), so access and refresh tokens sit in JS-readable storage.

**`globalHeaders` overrides the platform defaults by name**, which makes it easy to weaken something by accident. The two headers this redeclares are only tightened:

- **HSTS** keeps the `preload` token and raises `max-age` from 126 days to a year. The preload list requires `31536000`, so the platform default did not actually qualify.
- **Referrer-Policy** stays on SWA's `same-origin` rather than the more commonly recommended `strict-origin-when-cross-origin`, which is *weaker* — it leaks the origin cross-origin.

`SWA_DEFAULT_HEADERS` records the platform baseline and a test asserts nothing declared falls below it.

## The CSP is report-only, and stays that way for now

Two things must be solved before it can be enforced, and neither is done in this PR:

1. **No `report-uri`/`report-to`.** Violations surface only in each visitor's own console, not anywhere aggregatable. Collecting them needs an endpoint on the API side.
2. **AdSense cannot be made to work by host allowlist.** Google states its ad-serving domains change and officially supports only a nonce-based strict CSP (`'nonce-…'` + `'strict-dynamic'` + `'unsafe-eval'`). The ad origins here are best-effort for the report-only stage.

Both are recorded in `AGENTS.md` so the enforce step doesn't get flipped naively.

## Origins were traced, not guessed

- gtag beacons to the bare `analytics.google.com` and to `www.google.com`. CSP host wildcards require at least one leading label, so `*.analytics.google.com` does **not** match `analytics.google.com`. Confirmed by capturing the network on production.
- `<youtube-player>` leaves `disableCookies` at its `false` default, so `@angular/youtube-player` passes `host: undefined` and the IFrame API embeds **`www.youtube.com`**, not the nocookie host. The Permissions-Policy `autoplay`/`fullscreen`/`encrypted-media` allowlists were corrected to match — allowlisting only nocookie would have blocked fullscreen on the real iframe.
- `img-src` keeps bare `https:` because Auth0 returns `user.picture` on whatever origin the identity provider uses (`auth.service.ts:133`).
- `worker-src` pins `'self'` because the G-code viewer spawns a same-origin worker (`src/assets/js/gcode-viewer/ui.js:454`). `form-action` pins only `'self'`: Stripe checkout is reached via `window.location.href = result.url`, a top-level navigation that `form-action` does not govern at all.
- Sources that are only **headroom** stay in the policy but are deliberately *not* pinned — the Auth0 `frame-src` entry (needs `useRefreshTokensFallback`, which the SDK defaults to `false`) and the Stripe `form-action` hosts.

## Tests

`scripts/security-headers.test.mjs` (52 tests, wired into `npm run test:scripts`, which runs in CI and at deploy).

The part that matters: `REQUIRED_CSP_SOURCES` maps each directive to the sources a real feature depends on, and a test **removes each one in turn and asserts it is reported**. Without that the suite would only be comparing the config against constants in the same file. Mutation-tested — gutting `connect-src`, dropping `https:` from `img-src`, removing YouTube from `script-src`, or weakening `Referrer-Policy` each produce failures.

Validation also rejects two ways of silently disabling the inline scripts and styles the app ships:

1. **Mixing a nonce or hash with `'unsafe-inline'`.** CSP Level 3 makes browsers ignore `'unsafe-inline'` entirely once either is present.
2. **An `-elem`/`-attr` directive that overrides its base while dropping `'unsafe-inline'`.**

Both are checked across `script-src`, `style-src`, and all four of their `-elem`/`-attr` variants, since those take precedence over the base directive for their resource kind. Every one is load-bearing here: `index.prod.html` ships two inline `<script>` elements *and* an `onload="this.media='all'"` attribute, and Angular injects component CSS as `<style>` elements at runtime.

## Also

Renames `npm run test:sitemap` → `test:scripts` (updated in `ci.yml`, `deploy.yml`, `AGENTS.md`) now that the runner covers more than sitemap tests.

## Verification

- `npm run test:scripts` — 52 pass
- `npm run build` (prod + prerender) — exit 0; `verify-prerender` 27 routes, `verify-shells` pass
- `npm run lint:brief` — clean

## Risk

Low. Report-only means a missed origin is a console warning, not a broken page. The header changes are additive except for the two tightened values above.

