### PR TITLE
perf(routing): preload the core sections with a network-aware strategy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,15 @@ Routes without `AuthGuard` (e.g. `/prints/:id`, public profiles/materials) must 
 - On a public route, resolvers/services must degrade to a default/`null` for anonymous users, never throw. Fix in the **service** (also protects `ngOnInit` callers), and keep settings consumers null-tolerant (`?.value`, `?? default`). Auth-required endpoints reject with `missing_refresh_token` unless the request sets `allow-anonymous-request` **and** the API marks them `[AllowAnonymous]`.
 - Test logged-out without Auth0: append `?devUserId=anonymous` (dev only; `isDevAnonymous`/`resolveDevUserId` in `core/utils/dev-user.ts`, persisted per-tab in sessionStorage). Regression pattern: `cypress/e2e/prints/public-print-anonymous.cy.ts` (a public-route E2E with no `cy.login()`).
 
+### Route Preloading
+
+Lazy chunks are preloaded **opt-in**, via `SelectivePreloadStrategy` (`core/routing/selective-preload.strategy.ts`) wired into `RouterModule.forRoot`.
+
+- A route preloads only when it carries `data: { preload: true }`. Today that is `prints`, `materials`, and `printers` — the sections a signed-in user reaches first. `preload-route-matrix.spec.ts` pins that list, so widening it is a deliberate, reviewed change.
+- Preloading is skipped entirely when `navigator.connection` reports `saveData` or an effective type of `slow-2g`/`2g`/`3g`, and during prerender (fetching a chunk in Node buys nothing).
+- Do **not** reach for `PreloadAllModules`. It pulls every feature chunk right after first paint, including the documentation site and the d3-backed analytics bundle.
+- `navigator.connection` is read through the `NETWORK_INFORMATION` injection token, which is the one guarded home for that global — see the SSR-safety note above.
+
 ### Environment Configuration
 
 - `src/environments/environment.ts` - Development (localhost:5001 API)

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -1,9 +1,10 @@
 import { NgModule } from '@angular/core';
-import { PreloadAllModules, RouterModule, Routes } from '@angular/router';
+import { RouterModule, Routes } from '@angular/router';
 import { environment } from 'src/environments/environment';
 import { AuthGuard } from './core/guards/auth.guard';
 import { HomepageRedirectGuard } from './core/guards/homepage-redirect.guard';
 import { PendingChangesGuard } from './core/guards/pending-changes.guard';
+import { SelectivePreloadStrategy } from './core/routing/selective-preload.strategy';
 import { HomeComponent } from './home/home.component';
 import { SlicerLandingComponent } from './slicer/slicer-landing.component';
 
@@ -27,6 +28,7 @@ export const appRoutes: Routes = [
     path: 'prints',
     loadChildren: () =>
       import('./print/print.module').then((m) => m.PrintModule),
+    data: { preload: true },
   },
   {
     path: 'projects',
@@ -37,6 +39,7 @@ export const appRoutes: Routes = [
     path: 'printers',
     loadChildren: () =>
       import('./printer/printer.module').then((m) => m.PrinterModule),
+    data: { preload: true },
   },
   {
     path: 'printer-maintenance',
@@ -94,6 +97,7 @@ export const appRoutes: Routes = [
     path: 'materials',
     loadChildren: () =>
       import('./filament/filament.module').then((m) => m.FilamentModule),
+    data: { preload: true },
   },
   {
     path: 'api-keys',
@@ -196,6 +200,7 @@ export const appRoutes: Routes = [
   imports: [
     RouterModule.forRoot(appRoutes, {
       scrollPositionRestoration: 'enabled',
+      preloadingStrategy: SelectivePreloadStrategy,
     }),
   ],
   exports: [RouterModule],

--- a/src/app/core/routing/preload-route-matrix.spec.ts
+++ b/src/app/core/routing/preload-route-matrix.spec.ts
@@ -1,0 +1,43 @@
+import { Routes } from '@angular/router';
+
+import { appRoutes } from '../../app-routing.module';
+
+/**
+ * Preloading is opt-in per route. This spec pins *which* routes opt in, so
+ * adding `data: { preload: true }` to a new feature is a deliberate, reviewed
+ * decision rather than something that quietly accretes until every chunk is
+ * being fetched again.
+ */
+describe('preload route matrix', () => {
+  /** The sections a signed-in user reaches first and most often. */
+  const PRELOADED = ['prints', 'materials', 'printers'];
+
+  function preloads(route: Routes[number] | undefined): boolean {
+    return route?.data?.['preload'] === true;
+  }
+
+  it('flags exactly the core three sections', () => {
+    const flagged = appRoutes
+      .filter((route) => preloads(route))
+      .map((route) => route.path)
+      .sort();
+
+    expect(flagged).toEqual([...PRELOADED].sort());
+  });
+
+  it('only ever flags routes that actually have a chunk to fetch', () => {
+    for (const route of appRoutes.filter((r) => preloads(r))) {
+      expect(!!(route.loadChildren || route.loadComponent))
+        .withContext(`${route.path} is flagged but is not lazily loaded`)
+        .toBe(true);
+    }
+  });
+
+  it('leaves the heavy secondary sections on demand', () => {
+    // docs, analytics and subscription are large and rarely the first stop.
+    for (const path of ['docs', 'analytics', 'subscription', 'feed']) {
+      const route = appRoutes.find((r) => r.path === path);
+      expect(preloads(route)).withContext(path).toBe(false);
+    }
+  });
+});

--- a/src/app/core/routing/selective-preload.strategy.spec.ts
+++ b/src/app/core/routing/selective-preload.strategy.spec.ts
@@ -1,0 +1,216 @@
+import { PLATFORM_ID } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Route } from '@angular/router';
+import { Observable, of, throwError } from 'rxjs';
+
+import {
+  NETWORK_INFORMATION,
+  NetworkInformationLike,
+  SelectivePreloadStrategy,
+} from './selective-preload.strategy';
+
+describe('SelectivePreloadStrategy', () => {
+  const preloadable: Route = { path: 'prints', data: { preload: true } };
+
+  function build(options: {
+    connection?: NetworkInformationLike | null;
+    platformId?: string;
+  }): SelectivePreloadStrategy {
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        SelectivePreloadStrategy,
+        { provide: NETWORK_INFORMATION, useValue: options.connection ?? null },
+        { provide: PLATFORM_ID, useValue: options.platformId ?? 'browser' },
+      ],
+    });
+    return TestBed.inject(SelectivePreloadStrategy);
+  }
+
+  /** A `load` spy that reports whether the chunk fetch was actually started. */
+  function loader(): jasmine.Spy<() => Observable<unknown>> {
+    return jasmine
+      .createSpy('load')
+      .and.returnValue(of('chunk')) as jasmine.Spy<() => Observable<unknown>>;
+  }
+
+  describe('route opt-in', () => {
+    it('preloads a route flagged with data.preload', async () => {
+      const strategy = build({});
+      const load = loader();
+
+      const result = await firstValue(strategy.preload(preloadable, load));
+
+      expect(load).toHaveBeenCalledTimes(1);
+      expect(result).toBe('chunk');
+    });
+
+    it('does not preload a route with no data block', async () => {
+      const strategy = build({});
+      const load = loader();
+
+      const result = await firstValue(strategy.preload({ path: 'docs' }, load));
+
+      expect(load).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+
+    it('does not preload a route that opts out explicitly', async () => {
+      const strategy = build({});
+      const load = loader();
+
+      await firstValue(
+        strategy.preload({ path: 'docs', data: { preload: false } }, load)
+      );
+
+      expect(load).not.toHaveBeenCalled();
+    });
+
+    it('treats a non-boolean data.preload as opted out', async () => {
+      const strategy = build({});
+      const load = loader();
+
+      await firstValue(
+        strategy.preload(
+          { path: 'docs', data: { preload: 'yes' } } as Route,
+          load
+        )
+      );
+
+      expect(load).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('network awareness', () => {
+    it('skips preloading when the user has asked to save data', async () => {
+      const strategy = build({ connection: { saveData: true } });
+      const load = loader();
+
+      await firstValue(strategy.preload(preloadable, load));
+
+      expect(load).not.toHaveBeenCalled();
+    });
+
+    for (const effectiveType of ['slow-2g', '2g', '3g']) {
+      it(`skips preloading on a ${effectiveType} connection`, async () => {
+        const strategy = build({ connection: { effectiveType } });
+        const load = loader();
+
+        await firstValue(strategy.preload(preloadable, load));
+
+        expect(load).not.toHaveBeenCalled();
+      });
+    }
+
+    it('preloads on a 4g connection', async () => {
+      const strategy = build({ connection: { effectiveType: '4g' } });
+      const load = loader();
+
+      await firstValue(strategy.preload(preloadable, load));
+
+      expect(load).toHaveBeenCalledTimes(1);
+    });
+
+    it('preloads when the Network Information API is unavailable', async () => {
+      // Safari and Firefox do not implement navigator.connection. Absence of
+      // the signal must not be read as a constrained connection.
+      const strategy = build({ connection: null });
+      const load = loader();
+
+      await firstValue(strategy.preload(preloadable, load));
+
+      expect(load).toHaveBeenCalledTimes(1);
+    });
+
+    it('preloads when saveData is explicitly false', async () => {
+      const strategy = build({
+        connection: { saveData: false, effectiveType: '4g' },
+      });
+      const load = loader();
+
+      await firstValue(strategy.preload(preloadable, load));
+
+      expect(load).toHaveBeenCalledTimes(1);
+    });
+
+    it('respects connection changes made in place after construction', async () => {
+      // navigator.connection is a stable object whose properties update as the
+      // radio changes. A strategy that snapshotted saveData or effectiveType at
+      // construction would keep preloading after the user turns data saver on
+      // mid-session.
+      const connection: NetworkInformationLike = { effectiveType: '4g' };
+      const strategy = build({ connection });
+
+      const first = loader();
+      await firstValue(strategy.preload(preloadable, first));
+      expect(first).toHaveBeenCalledTimes(1);
+
+      connection.effectiveType = '2g';
+
+      const second = loader();
+      await firstValue(strategy.preload(preloadable, second));
+      expect(second).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resilience', () => {
+    it('recovers when a chunk fails to load', async () => {
+      // RouterPreloader subscribes without an error handler, so an error that
+      // escapes here tears down the subscription and no route preloads again
+      // for the rest of the session. Angular's own PreloadAllModules guards
+      // against this with catchError; so must we.
+      const strategy = build({});
+      const load = jasmine
+        .createSpy('load')
+        .and.returnValue(throwError(() => new Error('chunk 404')));
+
+      const result = await firstValue(strategy.preload(preloadable, load));
+
+      expect(result).toBeNull();
+    });
+
+    it('recovers when the loader throws synchronously', async () => {
+      const strategy = build({});
+      const load = jasmine.createSpy('load').and.throwError('boom');
+
+      const result = await firstValue(strategy.preload(preloadable, load));
+
+      expect(result).toBeNull();
+    });
+
+    it('keeps preloading later routes after one has failed', async () => {
+      const strategy = build({});
+      const failing = jasmine
+        .createSpy('load')
+        .and.returnValue(throwError(() => new Error('chunk 404')));
+      await firstValue(strategy.preload(preloadable, failing));
+
+      const next = loader();
+      const result = await firstValue(strategy.preload(preloadable, next));
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(result).toBe('chunk');
+    });
+  });
+
+  describe('server-side rendering', () => {
+    it('never preloads during prerender, even for a flagged route', async () => {
+      // Prerendering runs the router in Node, where fetching a lazy chunk buys
+      // nothing and `navigator` does not exist.
+      const strategy = build({ platformId: 'server' });
+      const load = loader();
+
+      const result = await firstValue(strategy.preload(preloadable, load));
+
+      expect(load).not.toHaveBeenCalled();
+      expect(result).toBeNull();
+    });
+  });
+});
+
+/** Resolves the first emission of an observable that is expected to complete. */
+function firstValue<T>(source: Observable<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    source.subscribe({ next: resolve, error: reject });
+  });
+}

--- a/src/app/core/routing/selective-preload.strategy.ts
+++ b/src/app/core/routing/selective-preload.strategy.ts
@@ -1,0 +1,101 @@
+import { isPlatformBrowser } from '@angular/common';
+import { inject, Injectable, InjectionToken, PLATFORM_ID } from '@angular/core';
+import { PreloadingStrategy, Route } from '@angular/router';
+import { catchError, defer, Observable, of } from 'rxjs';
+
+/**
+ * The slice of the Network Information API we act on. Typed structurally
+ * because `navigator.connection` is not in the DOM lib and is unimplemented in
+ * Safari and Firefox.
+ *
+ * @see https://developer.mozilla.org/docs/Web/API/NetworkInformation
+ */
+export interface NetworkInformationLike {
+  /** True when the user has switched on data saver. */
+  saveData?: boolean;
+  /** Round-trip estimate bucketed as 'slow-2g' | '2g' | '3g' | '4g'. */
+  effectiveType?: string;
+}
+
+/**
+ * The live `navigator.connection` object, or `null` where it is unavailable.
+ *
+ * Injected rather than read inline so the strategy stays testable and so the
+ * `navigator` access has exactly one guarded home — prerendering runs this code
+ * in Node, where the global does not exist.
+ */
+export const NETWORK_INFORMATION =
+  new InjectionToken<NetworkInformationLike | null>('NETWORK_INFORMATION', {
+    providedIn: 'root',
+    factory: () => {
+      if (!isPlatformBrowser(inject(PLATFORM_ID))) {
+        return null;
+      }
+
+      return (
+        (navigator as Navigator & { connection?: NetworkInformationLike })
+          .connection ?? null
+      );
+    },
+  });
+
+/** Effective connection types where a background chunk fetch is not worth it. */
+const CONSTRAINED_EFFECTIVE_TYPES = new Set(['slow-2g', '2g', '3g']);
+
+/**
+ * Preloads only the lazy routes that opt in with `data: { preload: true }`, and
+ * only when the connection can afford it.
+ *
+ * The alternative, `PreloadAllModules`, pulls every feature chunk — including
+ * the documentation site and the d3-backed analytics bundle — immediately after
+ * first paint. Flagging just the sections a user reaches first keeps the
+ * navigation win without that cost.
+ */
+@Injectable({ providedIn: 'root' })
+export class SelectivePreloadStrategy implements PreloadingStrategy {
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
+  private readonly connection = inject(NETWORK_INFORMATION);
+
+  preload(route: Route, load: () => Observable<unknown>): Observable<unknown> {
+    if (!this.isBrowser) {
+      return of(null);
+    }
+
+    if (route.data?.['preload'] !== true) {
+      return of(null);
+    }
+
+    if (this.isConnectionConstrained()) {
+      return of(null);
+    }
+
+    // `defer` so a loader that throws synchronously becomes an error
+    // notification, and `catchError` so it stops there. RouterPreloader
+    // subscribes to this without an error handler, so anything that escapes
+    // tears down its subscription and nothing preloads again for the rest of
+    // the session. Angular's own PreloadAllModules guards the same way.
+    return defer(() => load()).pipe(catchError(() => of(null)));
+  }
+
+  /**
+   * `navigator.connection` is a single long-lived object whose properties are
+   * updated in place as the radio changes, so holding the reference is fine --
+   * but the *properties* must be read per call. Snapshotting `saveData` or
+   * `effectiveType` at construction would keep preloading after the user turns
+   * on data saver mid-session.
+   */
+  private isConnectionConstrained(): boolean {
+    const connection = this.connection;
+
+    // No signal is not a bad signal — Safari and Firefox never report one.
+    if (!connection) {
+      return false;
+    }
+
+    if (connection.saveData === true) {
+      return true;
+    }
+
+    return CONSTRAINED_EFFECTIVE_TYPES.has(connection.effectiveType ?? '');
+  }
+}


### PR DESCRIPTION
## What

Adds `SelectivePreloadStrategy` and wires it into `RouterModule.forRoot`, so lazy route chunks are preloaded **opt-in** rather than not at all.

## Why

`PreloadAllModules` was imported at `app-routing.module.ts:2` but **never passed to `forRoot`** — the import was dead and the app ran on Angular's default `NoPreloading`. Nothing was ever prefetched, so every first navigation to prints, materials, or printers paid a full chunk fetch.

The fix is not to wire up `PreloadAllModules`. That pulls *every* feature chunk right after first paint, including the documentation site and the d3-backed analytics bundle — well over a megabyte most sessions never touch.

## Behavior

A route preloads only when it declares `data: { preload: true }`. Today that is `prints`, `materials`, and `printers` — the sections a signed-in user reaches first. `docs`, `analytics`, `subscription`, and `feed` stay on demand.

Preloading is skipped when:
- `navigator.connection` reports `saveData`, or an effective type of `slow-2g` / `2g` / `3g`
- the platform is not a browser — prerendering runs the router in Node, where fetching a lazy chunk buys nothing and `navigator` does not exist

`navigator.connection` is read through the `NETWORK_INFORMATION` injection token, which gives that global exactly one guarded home and keeps the strategy testable. The token holds the single long-lived `NetworkInformation` object; its *properties* are read per call, so turning on data saver mid-session takes effect.

## Failure containment

`preload()` returns `defer(() => load()).pipe(catchError(() => of(null)))`.

This is load-bearing, not defensive habit. `RouterPreloader.setUpPreloading()` does:

```js
this.router.events.pipe(filter(e => e instanceof NavigationEnd),
  concatMap(() => this.preload())).subscribe(() => {});   // no error handler
```

An error escaping `preload()` tears down that subscription, and **nothing preloads again for the rest of the session**. Angular's own `PreloadAllModules` wraps with `catchError` for exactly this reason. `defer` additionally converts a synchronous throw from the loader into an error notification rather than letting it escape the call.

## Tests

19 specs across two files.

`preload-route-matrix.spec.ts` pins *which* routes opt in, so the list cannot quietly grow back into preload-everything — and asserts every flagged route is actually lazily loaded.

`selective-preload.strategy.spec.ts` covers the opt-in check, each constrained connection type, the absent-API case (Safari and Firefox do not implement `navigator.connection`, and absence must not read as "constrained"), in-place connection changes, SSR, and the three failure paths above.

## Verification

- `npm run test:brief` — **TOTAL: 1150 SUCCESS**
- `npm run lint:brief` — clean
- `npm run build` (prod + prerender) — exit 0; `verify-prerender` 27 routes, `verify-shells` pass

## Note on measurement

This *adds* background transfer versus today's behavior (which prefetches nothing) in exchange for faster first navigation to the three core sections. It is not a reduction — worth being clear about, since the ~530K burst of `<link rel="modulepreload">` requests visible on a cold load is the Angular CLI hinting the initial chunk graph and is unrelated to this change.
