### PR TITLE
feat(types): gate src/app/core on strictNullChecks (stage 2, part 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Script unit tests (sitemap, security headers)
         run: npm run test:scripts
 
+      - name: Strict null checks (gated directories)
+        run: npm run typecheck:strict
+
       - name: Build (dev/base config)
         run: npm run build:dev
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Script unit tests (sitemap, security headers)
         run: npm run test:scripts
 
+      - name: Strict null checks (gated directories)
+        run: npm run typecheck:strict
+
       - name: Generate sitemap
         run: node scripts/generate-sitemap.mjs
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,7 @@ src/environments/environment.staging.ts
 src/environments/environment.auth0-dev.ts
 
 .sitemap-smoke/
+
+# Cypress artifacts from failed runs
+cypress/screenshots/
+cypress/videos/

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:ci": "ng test --no-watch --code-coverage --browsers ChromeHeadless",
     "test:brief": "bash scripts/test-brief.sh",
     "test:scripts": "node --test scripts/*.test.mjs",
+    "typecheck:strict": "node scripts/typecheck-strict.mjs",
     "verify:shells": "node scripts/verify-shells.mjs",
     "lint": "ng lint",
     "lint:fix": "ng lint --fix",

--- a/scripts/typecheck-strict.mjs
+++ b/scripts/typecheck-strict.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+// Incremental `strictNullChecks` gate (issue #98).
+//
+// TypeScript has no per-directory strictness, and a tsconfig that *includes*
+// only one directory still pulls every transitively-imported file into the
+// program and reports errors for it. Measured on this repo: a core/-only
+// include reports 253 errors, of which only 124 are actually in core/.
+//
+// So the gate compiles the whole app with strictNullChecks on and then keeps
+// only the diagnostics under STRICT_DIRECTORIES. Directories graduate onto that
+// list one PR at a time, which makes widening it a deliberate, reviewed change
+// the same way `preload-route-matrix.spec.ts` pins the preload list.
+
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/**
+ * Directories that must be free of strictNullChecks errors. Add one per PR and
+ * fix its fallout in the same change; never add a directory you have not fixed.
+ */
+export const STRICT_DIRECTORIES = ['src/app/core/'];
+
+/** Matches the `path/to/file.ts(12,34): error TS2531: ...` form tsc emits. */
+const DIAGNOSTIC = /^(.+?)\((\d+),(\d+)\): error (TS\d+): (.*)$/;
+
+export function parseDiagnostics(stdout) {
+  const diagnostics = [];
+
+  for (const line of stdout.split(/\r?\n/)) {
+    const match = DIAGNOSTIC.exec(line.trim());
+    if (!match) {
+      continue;
+    }
+
+    const [, file, lineNo, column, code, message] = match;
+    diagnostics.push({
+      file: file.replace(/\\/g, '/'),
+      line: Number(lineNo),
+      column: Number(column),
+      code,
+      message,
+    });
+  }
+
+  return diagnostics;
+}
+
+export function isGated(file, directories = STRICT_DIRECTORIES) {
+  const normalized = file.replace(/\\/g, '/');
+  return directories.some((directory) => normalized.includes(directory));
+}
+
+export function selectGatedDiagnostics(stdout, directories = STRICT_DIRECTORIES) {
+  return parseDiagnostics(stdout).filter((diagnostic) =>
+    isGated(diagnostic.file, directories)
+  );
+}
+
+function runTsc() {
+  try {
+    execFileSync(
+      process.execPath,
+      [
+        path.join(repoRoot, 'node_modules', 'typescript', 'bin', 'tsc'),
+        '-p',
+        path.join(repoRoot, 'tsconfig.strict.json'),
+      ],
+      { cwd: repoRoot, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
+    );
+    return '';
+  } catch (error) {
+    // tsc exits non-zero whenever it reports anything, including errors outside
+    // the gated directories, so a non-zero exit is expected and not itself a
+    // failure. Only the filtered diagnostics decide the outcome.
+    return `${error.stdout ?? ''}${error.stderr ?? ''}`;
+  }
+}
+
+function main() {
+  const output = runTsc();
+  const all = parseDiagnostics(output);
+  const gated = all.filter((diagnostic) => isGated(diagnostic.file));
+
+  if (gated.length === 0) {
+    console.log(
+      `strictNullChecks gate clean for ${STRICT_DIRECTORIES.join(', ')} ` +
+        `(${all.length} error(s) remain outside the gate).`
+    );
+    return;
+  }
+
+  console.error(
+    `strictNullChecks gate failed: ${gated.length} error(s) in ${STRICT_DIRECTORIES.join(', ')}\n`
+  );
+  for (const diagnostic of gated) {
+    console.error(
+      `  ${diagnostic.file}:${diagnostic.line}:${diagnostic.column} ` +
+        `${diagnostic.code}: ${diagnostic.message}`
+    );
+  }
+  console.error(
+    '\nFix these rather than widening the gate. See issue #98 for the staging plan.'
+  );
+  process.exitCode = 1;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main();
+}

--- a/scripts/typecheck-strict.test.mjs
+++ b/scripts/typecheck-strict.test.mjs
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  STRICT_DIRECTORIES,
+  isGated,
+  parseDiagnostics,
+  selectGatedDiagnostics,
+} from './typecheck-strict.mjs';
+
+const SAMPLE = [
+  "src/app/core/services/auth.service.ts(42,11): error TS2531: Object is possibly 'null'.",
+  "src/app/print/print-list/print-list.component.ts(88,3): error TS2322: Type 'string | null' is not assignable to type 'string'.",
+  'src/app/core/stores/new-print-store.service.ts(7,5): error TS18048: Something is possibly undefined.',
+  'Found 3 errors in 3 files.',
+  '',
+].join('\n');
+
+test('parseDiagnostics extracts file, position, code and message', () => {
+  const diagnostics = parseDiagnostics(SAMPLE);
+
+  assert.equal(diagnostics.length, 3);
+  assert.deepEqual(diagnostics[0], {
+    file: 'src/app/core/services/auth.service.ts',
+    line: 42,
+    column: 11,
+    code: 'TS2531',
+    message: "Object is possibly 'null'.",
+  });
+});
+
+test('parseDiagnostics ignores summary and blank lines', () => {
+  assert.deepEqual(parseDiagnostics('Found 3 errors in 3 files.\n\n'), []);
+});
+
+test('parseDiagnostics normalizes Windows path separators', () => {
+  const diagnostics = parseDiagnostics(
+    "src\\app\\core\\services\\auth.service.ts(1,1): error TS2531: Object is possibly 'null'."
+  );
+
+  assert.equal(diagnostics[0].file, 'src/app/core/services/auth.service.ts');
+});
+
+test('selectGatedDiagnostics keeps only errors inside the gated directories', () => {
+  const gated = selectGatedDiagnostics(SAMPLE);
+
+  assert.equal(gated.length, 2);
+  assert.ok(gated.every((diagnostic) => diagnostic.file.includes('src/app/core/')));
+});
+
+test('selectGatedDiagnostics drops errors that bleed in from ungated directories', () => {
+  const gated = selectGatedDiagnostics(SAMPLE);
+
+  assert.ok(
+    !gated.some((diagnostic) => diagnostic.file.includes('src/app/print/')),
+    'print/ is not on the gate yet, so its errors must not fail the build'
+  );
+});
+
+test('isGated matches a directory regardless of path prefix', () => {
+  assert.ok(isGated('src/app/core/services/auth.service.ts'));
+  assert.ok(isGated('D:/repo/src/app/core/services/auth.service.ts'));
+  assert.ok(!isGated('src/app/filament/filament-detail.component.ts'));
+});
+
+test('the gate starts at core/ only', () => {
+  assert.deepEqual(STRICT_DIRECTORIES, ['src/app/core/']);
+});

--- a/src/app/core/resolvers/currencies-resolver.service.ts
+++ b/src/app/core/resolvers/currencies-resolver.service.ts
@@ -25,7 +25,7 @@ export interface Currency {
   minorPlural: string;
   ISOdigits: number;
   decimals: number;
-  numToBasic: number;
+  numToBasic: number | null;
 }
 
 @Injectable({

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -88,10 +88,12 @@ export class AuthService {
   );
 
   // Create subject and public observable of user profile data
-  private userProfileSubject$ = new BehaviorSubject<UserProfileInfo>(null);
+  private userProfileSubject$ = new BehaviorSubject<UserProfileInfo | null>(
+    null
+  );
   userProfile$ = this.userProfileSubject$.asObservable();
   // Create a local property for login status
-  loggedIn: boolean = null;
+  loggedIn: boolean | null = null;
 
   private readonly subscriptionService = inject(SubscriptionService);
   private readonly userSettingService = inject(UserSettingService);
@@ -150,22 +152,34 @@ export class AuthService {
   }
 
   updateCurrentUserCoverPicture(newUrl: string) {
-    this.userProfileSubject$.next({
-      ...this.userProfileSubject$.value,
-      coverPicture: newUrl,
-    });
+    const profile = this.userProfileSubject$.value;
+    if (!profile) {
+      return;
+    }
+
+    this.userProfileSubject$.next({ ...profile, coverPicture: newUrl });
   }
 
   updateCurrentUserDeactivationDate(deactivationDate: Date | null) {
+    const profile = this.userProfileSubject$.value;
+    if (!profile) {
+      return;
+    }
+
     this.userProfileSubject$.next({
-      ...this.userProfileSubject$.value,
+      ...profile,
       deactivationDateTime: deactivationDate,
     });
   }
 
   updateCurrentUserProfilePicture(newUrl: string) {
+    const profile = this.userProfileSubject$.value;
+    if (!profile) {
+      return;
+    }
+
     this.userProfileSubject$.next({
-      ...this.userProfileSubject$.value,
+      ...profile,
       profilePicture: newUrl,
     });
   }

--- a/src/app/core/services/feed.service.ts
+++ b/src/app/core/services/feed.service.ts
@@ -56,7 +56,7 @@ export class FeedService {
       })
       .pipe(
         map((results) => {
-          const mappedResult = [];
+          const mappedResult: PrintFeedSummary[] = [];
           for (const print of results) {
             mappedResult.push({
               ...print,

--- a/src/app/core/services/file-parsers/anycubic/anycubic-file-parser.service.ts
+++ b/src/app/core/services/file-parsers/anycubic/anycubic-file-parser.service.ts
@@ -90,7 +90,7 @@ export class AnycubicFileParserService implements GcodeNewPrintParser {
       gcode,
       '; filament used \\[g\\]'
     );
-    if (filamentUsedInGrams > 0) {
+    if (filamentUsedInGrams !== undefined && filamentUsedInGrams > 0) {
       return filamentUsedInGrams * 1000;
     }
 
@@ -387,6 +387,9 @@ export class AnycubicFileParserService implements GcodeNewPrintParser {
       return null;
     }
     const durationAsMs = parse(input);
+    if (durationAsMs == null) {
+      return null;
+    }
     const durationAsSeconds = durationAsMs / 1000;
     return Math.floor(durationAsSeconds);
   }

--- a/src/app/core/services/file-parsers/creality-print/creality-print-file-parser.service.ts
+++ b/src/app/core/services/file-parsers/creality-print/creality-print-file-parser.service.ts
@@ -90,7 +90,7 @@ export class CrealityPrintFileParserService implements GcodeNewPrintParser {
       gcode,
       ';Filament used:'
     );
-    if (filamentUsedInGrams > 0) {
+    if (filamentUsedInGrams !== undefined && filamentUsedInGrams > 0) {
       return filamentUsedInGrams * 1000;
     }
 

--- a/src/app/core/services/file-parsers/orca/orca-file-parser.service.ts
+++ b/src/app/core/services/file-parsers/orca/orca-file-parser.service.ts
@@ -46,7 +46,7 @@ export class OrcaFileParserService implements GcodeNewPrintParser {
       gcode,
       '; filament used \\[g\\]'
     );
-    if (filamentUsedInGrams > 0) {
+    if (filamentUsedInGrams !== undefined && filamentUsedInGrams > 0) {
       return filamentUsedInGrams * 1000;
     }
 
@@ -314,6 +314,9 @@ export class OrcaFileParserService implements GcodeNewPrintParser {
       return null;
     }
     const durationAsMs = parse(input);
+    if (durationAsMs == null) {
+      return null;
+    }
     const durationAsSeconds = durationAsMs / 1000;
     return Math.floor(durationAsSeconds);
   }

--- a/src/app/core/services/file-parsers/prusa/prusa-slicer-file-parser.service.ts
+++ b/src/app/core/services/file-parsers/prusa/prusa-slicer-file-parser.service.ts
@@ -46,7 +46,7 @@ export class PrusaSlicerFileParserService implements GcodeNewPrintParser {
       gcode,
       '; total filament used \\[g\\]'
     );
-    if (filamentUsedInGrams > 0) {
+    if (filamentUsedInGrams !== undefined && filamentUsedInGrams > 0) {
       return filamentUsedInGrams * 1000;
     }
 
@@ -289,6 +289,9 @@ export class PrusaSlicerFileParserService implements GcodeNewPrintParser {
       return null;
     }
     const durationAsMs = parse(input);
+    if (durationAsMs == null) {
+      return null;
+    }
     const durationAsSeconds = durationAsMs / 1000;
     return Math.floor(durationAsSeconds);
   }

--- a/src/app/core/services/gcode-file-parser.service.ts
+++ b/src/app/core/services/gcode-file-parser.service.ts
@@ -35,7 +35,11 @@ export enum SupportedGcodeParserSlicers {
 @Injectable({
   providedIn: 'root',
 })
-export class GcodeFileParserService implements GcodeNewPrintParser {
+// Deliberately does NOT implement GcodeNewPrintParser. That interface describes
+// a single slicer's parser, which always yields a PrintDetail; this is the
+// dispatcher in front of them, and it returns null for an unsupported slicer or
+// a failed parse.
+export class GcodeFileParserService {
   constructor(
     private readonly loggingService: LoggingService,
     private readonly prusaSlicerParser: PrusaSlicerFileParserService,
@@ -51,7 +55,10 @@ export class GcodeFileParserService implements GcodeNewPrintParser {
     return Object.values(SupportedGcodeParserSlicers);
   }
 
-  public async parse(gcode: string, fileName?: string): Promise<PrintDetail> {
+  public async parse(
+    gcode: string,
+    fileName?: string
+  ): Promise<PrintDetail | null> {
     const slicer: string = this.detectSlicerFromGcode(gcode);
 
     this.loggingService.logEvent('GcodeAnalyzed', {

--- a/src/app/core/services/google-analytics.service.ts
+++ b/src/app/core/services/google-analytics.service.ts
@@ -25,8 +25,8 @@ export class GoogleAnalyticsService {
     eventName: string,
     eventCategory: string,
     eventAction: string,
-    eventLabel: string = null,
-    eventValue: number = null
+    eventLabel: string | null = null,
+    eventValue: number | null = null
   ) {
     this.gtag('event', eventName, {
       eventCategory,

--- a/src/app/core/services/image-resizer.service.ts
+++ b/src/app/core/services/image-resizer.service.ts
@@ -68,7 +68,7 @@ export class ImageResizerService {
 
       canvas.width = width;
       canvas.height = height;
-      canvas.getContext('2d').drawImage(image, 0, 0, width, height);
+      canvas.getContext('2d')?.drawImage(image, 0, 0, width, height);
       const dataUrl = canvas.toDataURL(
         'image/jpeg',
         settings.imageQuality || this.DEFAULT_IMAGE_QUALITY

--- a/src/app/core/services/local-storage.service.ts
+++ b/src/app/core/services/local-storage.service.ts
@@ -13,10 +13,10 @@ export class LocalStorageService implements Storage {
   clear(): void {
     localStorage.clear();
   }
-  getItem(key: string): string {
+  getItem(key: string): string | null {
     return localStorage.getItem(key);
   }
-  key(index: number): string {
+  key(index: number): string | null {
     return localStorage.key(index);
   }
   removeItem(key: string): void {

--- a/src/app/core/services/material-categories.service.ts
+++ b/src/app/core/services/material-categories.service.ts
@@ -24,7 +24,7 @@ export interface MaterialCategory {
 })
 export class MaterialCategoryService {
   private readonly baseApi = environment.printLogApiUrl;
-  private cachedMaterialCategories: MaterialCategory[] = null;
+  private cachedMaterialCategories: MaterialCategory[] | null = null;
 
   constructor(private readonly http: HttpClient) {}
 

--- a/src/app/core/services/material.service.ts
+++ b/src/app/core/services/material.service.ts
@@ -21,7 +21,7 @@ export interface Material {
 })
 export class MaterialService {
   private readonly baseApi = environment.printLogApiUrl;
-  private cachedMaterials: Material[] = null;
+  private cachedMaterials: Material[] | null = null;
 
   constructor(private readonly http: HttpClient) {}
 

--- a/src/app/core/services/print.service.ts
+++ b/src/app/core/services/print.service.ts
@@ -71,7 +71,8 @@ export enum PrintFilamentSourceMeasurement {
 }
 
 export interface PrintImage {
-  id: number;
+  /** Null for an image extracted from gcode that the API has not saved yet. */
+  id: number | null;
   isDefault: boolean;
   displayOrder: number;
 
@@ -83,9 +84,9 @@ export interface PrintImage {
 
 export interface PrintFilamentSummaryDto {
   /**
-   * GUID
+   * GUID. Null for a row parsed from gcode that the API has not saved yet.
    */
-  id: string;
+  id: string | null;
   filament: FilamentSummary;
 
   amountMg?: number;
@@ -104,9 +105,9 @@ export interface PrintFilamentSummaryDto {
 
 export interface PutPrintFilamentSummaryDto {
   /**
-   * GUID
+   * GUID. Null for a row that has not been saved yet.
    */
-  id: string;
+  id: string | null;
   filamentId?: string;
 
   amountMg?: number;
@@ -176,38 +177,50 @@ export interface PrintDetailDTO {
   projectName?: string;
 }
 
+/**
+ * The payload this client sends on update. The nullable fields mirror
+ * `PrintDetail`, which can still be holding an unsaved scaffold -- the API's own
+ * validation is the authority on what it accepts, so this describes what we can
+ * actually send rather than over-claiming.
+ */
 export interface PutPrintDetailDTO {
-  id: number;
+  id: number | null;
   title: string;
-  printerId: number;
-  startDate?: Date;
-  estimatedPrintTimeInSeconds?: number;
-  estimatedFilamentUsageMg?: number;
-  printTimeInSeconds?: number;
+  printerId: number | null;
+  startDate?: Date | null;
+  estimatedPrintTimeInSeconds?: number | null;
+  estimatedFilamentUsageMg?: number | null;
+  printTimeInSeconds?: number | null;
   filamentUsage: PutPrintFilamentSummaryDto[];
-  filamentUsageMg?: number;
+  filamentUsageMg?: number | null;
   filamentType: string;
   notes: string;
   url: string;
   fileName: string;
   status: PrintStatus;
-  viewStatus: PrintViewStatus;
-  allowComments: boolean;
+  viewStatus: PrintViewStatus | null;
+  allowComments: boolean | null;
   allowFileDownloads?: boolean;
   projectId?: string;
   newProjectName?: string;
 }
 
+/**
+ * A print being viewed or edited. Unlike `PrintDetailDTO`, which always
+ * describes a print the API has already saved, this also models an unsaved one:
+ * the slicer parsers and the new-print flow build a `PrintDetail` before an id,
+ * printer or creator exists, so those fields are genuinely nullable here.
+ */
 export interface PrintDetail {
-  id: number;
+  id: number | null;
   title: string;
-  printerId: number;
+  printerId: number | null;
   printer?: PrinterSummary;
-  startDate?: Date;
-  estimatedPrintTimeInSeconds?: number;
-  estimatedFilamentUsageMg?: number;
-  printTimeInSeconds?: number;
-  filamentUsageMg?: number;
+  startDate?: Date | null;
+  estimatedPrintTimeInSeconds?: number | null;
+  estimatedFilamentUsageMg?: number | null;
+  printTimeInSeconds?: number | null;
+  filamentUsageMg?: number | null;
   filamentType: string;
   filamentUsage: PrintFilamentSummaryDto[];
   notes: string;
@@ -215,12 +228,12 @@ export interface PrintDetail {
   fileName: string;
   status: PrintStatus;
 
-  viewStatus: PrintViewStatus;
-  allowComments: boolean;
+  viewStatus: PrintViewStatus | null;
+  allowComments: boolean | null;
   allowFileDownloads?: boolean;
 
   images?: PrintImage[];
-  createdByUserId: number;
+  createdByUserId: number | null;
   comments: Comment[];
   projectId?: string;
   projectName?: string;
@@ -230,14 +243,15 @@ export interface PrintDetail {
 /**
  * DTO to create a new print
  */
+/** The payload this client sends on create. See `PutPrintDetailDTO`. */
 export interface AddPrintDTO {
   title: string;
-  printerId: number;
-  startDate?: Date;
-  estimatedPrintTimeInSeconds?: number;
-  estimatedFilamentUsageMg?: number;
-  printTimeInSeconds?: number;
-  filamentUsageMg?: number;
+  printerId: number | null;
+  startDate?: Date | null;
+  estimatedPrintTimeInSeconds?: number | null;
+  estimatedFilamentUsageMg?: number | null;
+  printTimeInSeconds?: number | null;
+  filamentUsageMg?: number | null;
   filamentType: string;
   filamentUsage: PrintFilamentSummaryDto[];
   notes: string;
@@ -245,8 +259,8 @@ export interface AddPrintDTO {
   fileName: string;
   status: PrintStatus;
 
-  viewStatus: PrintViewStatus;
-  allowComments: boolean;
+  viewStatus: PrintViewStatus | null;
+  allowComments: boolean | null;
   projectId?: string;
   newProjectName?: string;
 }
@@ -664,10 +678,10 @@ export class PrintService {
       // Pinned by print-cost-fixtures.spec.ts against the shared corpus.
       const hasActual =
         fu.source == PrintFilamentSourceMeasurement.Length
-          ? fu.lengthInM > 0
+          ? (fu.lengthInM ?? 0) > 0
           : fu.source == PrintFilamentSourceMeasurement.Volume
-            ? fu.volumeMl > 0
-            : fu.amountMg > 0;
+            ? (fu.volumeMl ?? 0) > 0
+            : (fu.amountMg ?? 0) > 0;
 
       if (hasActual) {
         const price = this.calculatePrintCost({
@@ -675,7 +689,7 @@ export class PrintService {
           filament: fu.filament,
           source: fu.source,
           lengthM: fu.lengthInM,
-          weightG: fu.amountMg > 0 ? fu.amountMg / 1000 : undefined,
+          weightG: fu.amountMg ? fu.amountMg / 1000 : undefined,
           volumeMl: fu.volumeMl,
           defaultFilamentPrice,
         });
@@ -687,8 +701,9 @@ export class PrintService {
           filament: fu.filament,
           source: fu.estimatedSource,
           lengthM: fu.estimatedLengthInM,
-          weightG:
-            fu.estimatedAmountMg > 0 ? fu.estimatedAmountMg / 1000 : undefined,
+          weightG: fu.estimatedAmountMg
+            ? fu.estimatedAmountMg / 1000
+            : undefined,
           volumeMl: fu.estimatedVolumeMl,
           defaultFilamentPrice,
         });
@@ -698,7 +713,7 @@ export class PrintService {
     }
 
     // Once all prices are calculated, sum them up.
-    let totalPrice: currency = undefined;
+    let totalPrice: currency | undefined = undefined;
 
     for (const price of prices) {
       if (price.valid && !isNaN(price.price.value)) {
@@ -712,16 +727,20 @@ export class PrintService {
 
     function getDecimalSeparator() {
       const numberWithDecimalSeparator = 100000.1;
-      return Intl.NumberFormat()
-        .formatToParts(numberWithDecimalSeparator)
-        .find((part) => part.type === 'decimal').value;
+      return (
+        Intl.NumberFormat()
+          .formatToParts(numberWithDecimalSeparator)
+          .find((part) => part.type === 'decimal')?.value ?? '.'
+      );
     }
 
     function getGroupSeparator() {
       const numberWithDecimalSeparator = 100000.1;
-      return Intl.NumberFormat()
-        .formatToParts(numberWithDecimalSeparator)
-        .find((part) => part.type === 'group').value;
+      return (
+        Intl.NumberFormat()
+          .formatToParts(numberWithDecimalSeparator)
+          .find((part) => part.type === 'group')?.value ?? ','
+      );
     }
 
     const currencyFormat = {
@@ -730,7 +749,7 @@ export class PrintService {
       separator: getGroupSeparator(),
     };
 
-    let total: FilamentPrice = undefined;
+    let total: FilamentPrice | undefined = undefined;
     if (totalPrice) {
       total = {
         formattedPrice: totalPrice.format(currencyFormat),
@@ -792,15 +811,19 @@ export class PrintService {
     const cost = currency(kwhUsed * Number(kwhRate));
 
     function getDecimalSeparator() {
-      return Intl.NumberFormat()
-        .formatToParts(100000.1)
-        .find((part) => part.type === 'decimal').value;
+      return (
+        Intl.NumberFormat()
+          .formatToParts(100000.1)
+          .find((part) => part.type === 'decimal')?.value ?? '.'
+      );
     }
 
     function getGroupSeparator() {
-      return Intl.NumberFormat()
-        .formatToParts(100000.1)
-        .find((part) => part.type === 'group').value;
+      return (
+        Intl.NumberFormat()
+          .formatToParts(100000.1)
+          .find((part) => part.type === 'group')?.value ?? ','
+      );
     }
 
     const currencyFormat = {
@@ -866,16 +889,20 @@ export class PrintService {
 
     function getDecimalSeparator() {
       const numberWithDecimalSeparator = 100000.1;
-      return Intl.NumberFormat()
-        .formatToParts(numberWithDecimalSeparator)
-        .find((part) => part.type === 'decimal').value;
+      return (
+        Intl.NumberFormat()
+          .formatToParts(numberWithDecimalSeparator)
+          .find((part) => part.type === 'decimal')?.value ?? '.'
+      );
     }
 
     function getGroupSeparator() {
       const numberWithDecimalSeparator = 100000.1;
-      return Intl.NumberFormat()
-        .formatToParts(numberWithDecimalSeparator)
-        .find((part) => part.type === 'group').value;
+      return (
+        Intl.NumberFormat()
+          .formatToParts(numberWithDecimalSeparator)
+          .find((part) => part.type === 'group')?.value ?? ','
+      );
     }
 
     const currencyFormat = {
@@ -908,6 +935,10 @@ export class PrintService {
       const densityGramPerCubicM =
         filament.materialDensityGramPerCubicCm * 1000000;
 
+      if (lengthM === undefined) {
+        return { message: '(Price not valid)', valid: false };
+      }
+
       const gramsUsed = areaSqM * +lengthM * densityGramPerCubicM;
 
       if (isNaN(currency(pricePerGram * gramsUsed).value)) {
@@ -924,6 +955,10 @@ export class PrintService {
         usesDefaultPrice: isUsingDefaultFilamentPrice,
       };
     } else if (source === PrintFilamentSourceMeasurement.Volume) {
+      if (volumeMl === undefined) {
+        return { message: '(Price not valid)', valid: false };
+      }
+
       const amountMg =
         +volumeMl * filament.materialDensityGramPerCubicCm * 1000;
       const amountG = amountMg / 1000;

--- a/src/app/core/services/printer-categories.service.ts
+++ b/src/app/core/services/printer-categories.service.ts
@@ -26,7 +26,7 @@ export interface PrinterCategory {
 })
 export class PrinterCategoryService {
   private readonly baseApi = environment.printLogApiUrl;
-  private cachedPrinterCategories: PrinterCategory[] = null;
+  private cachedPrinterCategories: PrinterCategory[] | null = null;
 
   constructor(private readonly http: HttpClient) {}
 

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -1833,19 +1833,24 @@ upcoming <strong>Octoprint Integration</strong> (coming soon).</p>
 
   private async displayReleaseNotes(
     newVersion: string,
-    lastDisplayedVersion: string
+    // Null on a first visit, when nothing has been shown yet.
+    lastDisplayedVersion: string | null
   ) {
-    let release = this.releaseNotes[newVersion];
+    const entry = this.releaseNotes[newVersion];
+
+    if (!entry) {
+      return;
+    }
+
+    // Account for redirected release notes
+    const release = this.isRedirect(entry)
+      ? this.getRedirectedReleaseNotes(entry, lastDisplayedVersion)
+      : entry;
+
+    this.setLastLoggedInVersion(newVersion);
 
     if (release) {
-      // Account for redirected release notes
-      if (this.isRedirect(release)) {
-        release = this.getRedirectedReleaseNotes(release, lastDisplayedVersion);
-      }
-      this.setLastLoggedInVersion(newVersion);
-      if (release) {
-        await this.showReleaseNote(release);
-      }
+      await this.showReleaseNote(release);
     }
   }
 
@@ -1854,7 +1859,7 @@ upcoming <strong>Octoprint Integration</strong> (coming soon).</p>
    */
   getRedirectedReleaseNotes(
     release: RedirectRelease | ReleaseNote,
-    lastDisplayedVersionKey: string
+    lastDisplayedVersionKey: string | null
   ): ReleaseNote | null {
     if (this.isReleaseNote(release)) {
       return release;

--- a/src/app/core/stores/new-print-store.service.ts
+++ b/src/app/core/stores/new-print-store.service.ts
@@ -16,7 +16,7 @@ export class NewPrintStoreService {
     return this.newPrint !== null;
   }
 
-  public getNewPrint(): PrintDetail {
+  public getNewPrint(): PrintDetail | null {
     return this.newPrint;
   }
 

--- a/tsconfig.strict.json
+++ b/tsconfig.strict.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.app.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/strict",
+    "noEmit": true,
+    "strictNullChecks": true
+  }
+}


### PR DESCRIPTION
First increment of #98. Adds the incremental `strictNullChecks` gate and brings `src/app/core/` up to it.

## The gate

`tsconfig.strict.json` + `scripts/typecheck-strict.mjs`, exposed as `npm run typecheck:strict` and wired into `ci.yml` and `deploy.yml`. Seven unit tests cover the filtering logic (script tests 52 → 59).

It **cannot rely on `include`**. TypeScript pulls transitively-imported files into the program regardless of the include list, so a `core/`-only tsconfig reports 253 errors of which only 124 are actually in `core/`. The gate instead compiles the whole app with `strictNullChecks` on and keeps only diagnostics under `STRICT_DIRECTORIES`. Directories graduate one PR at a time, which makes widening the list a deliberate, reviewed edit — the same shape as `preload-route-matrix.spec.ts` pinning the preload list.

Current state: **clean for `src/app/core/`, 319 errors remaining outside the gate.** That's the runway for the next directories.

## 85 errors fixed, no suppressions

No `as any`, no `!` assertions. The recurring finding was a model claiming more than the code delivers:

- **`PrintDetail`** describes both a saved print and an unsaved scaffold — the slicer parsers and the new-print flow build one before an id, printer, or creator exists. Making those fields nullable cascaded 21 errors away at once.
- **The outbound `AddPrintDTO` / `PutPrintDetailDTO`** declared `printerId: number` while the store could hold null. That guarantee was already fiction, so they now describe what this client can actually send; the API's own validation remains the authority on what it accepts.
- **`LocalStorageService.getItem`** declared `string` over a browser API that returns `string | null` for a missing key.
- **`GcodeFileParserService`** declared `implements GcodeNewPrintParser`, but it is the dispatcher in front of the parsers and returns null for an unsupported slicer or a failed parse. Nothing consumed the interface polymorphically, so the marker is dropped rather than weakening it for the five real parsers.

## Two latent defects surfaced and fixed

**`AuthService` spread a possibly-null profile.** `updateCurrentUserCoverPicture`, `updateCurrentUserProfilePicture`, and `updateCurrentUserDeactivationDate` all did `{ ...this.userProfileSubject$.value, … }`. Spreading `null` yields `{}`, so calling any of them before the profile loaded would push a `UserProfileInfo` with **no `id`** to every subscriber. They now no-op until a profile exists.

**`calculatePrintCost` let an absent length or volume reach `+undefined`**, producing `NaN` and relying on a downstream `isNaN` to catch it. The guard is now explicit and returns the same `(Price not valid)` result.

## One deliberate behavior change

`parseAsSeconds` now returns `null` instead of `0` for an unparseable duration. All four call sites gate on `if (time)`, so `0` and `null` were already indistinguishable — not observable, but `0 seconds` was a false reading of the same kind as #99.

## Verification

- `npm run build` and `npm run build:dev` — clean
- `npm run test:brief` — 1205 passing
- `npm run test:scripts` — 59 passing
- `npm run lint:brief` — clean
- `npm run typecheck:strict` — clean for `core/`
- Full Cypress suite against a dev server built from this branch: **19 of 22 specs green, 103 tests passing**, including `public-print-anonymous` and `public-print-resolver-failure` — the two guarding the #66 regression, which matters because this touched `auth.service` and the anonymous `getPrintDetail` path.

The 3 failing specs (`filament-remaining`, `filament-usage-calculations`, `print-list-bulk-actions`) fail **identically on `main`** — verified by checking out `b01b11f` and re-running against the same server and API: 1/4, 0/11, 2/8 in both cases. Pre-existing and environmental, not regressions from this change.

## Also

`cypress/screenshots/` and `cypress/videos/` are now gitignored — failed-run artifacts were not ignored and are easy to commit by accident.

## Next

`shared/` is the natural next directory (29 errors), then `users/` 5, `printer-maintenance/` 9, `settings/` 16, `printer/` 29, `filament/` 64, `print/` 203.
