### PR TITLE
ci: publish GitHub Releases from the in-app release notes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,15 +11,25 @@ permissions:
   contents: read
 
 jobs:
-  build-and-deploy:
+  # Everything slow and everything that can fail lives here, deliberately with
+  # no `environment:` so it runs immediately on a tag push. The approval gate is
+  # on `deploy` alone, which means review happens with a green, fully built
+  # artifact in hand rather than blocking the build for hours.
+  #
+  # ENVIRONMENT_PROD_TS is a repository secret rather than a `production`
+  # environment secret for that reason -- an ungated job cannot read an
+  # environment secret. Its contents are client-side config (API URL, Auth0
+  # domain/client id, analytics ids, Stripe price ids) that ship inside the
+  # public JS bundle anyway. The Azure deploy credential is the real secret and
+  # stays scoped to the gated `deploy` job below.
+  build:
     runs-on: ubuntu-latest
-    environment: production
 
     steps:
       - uses: actions/checkout@v4
 
-      # Fails fast, before the ~10 minute build, when a tag was pushed without a
-      # matching section in the release notes component.
+      # Fails in seconds, before the build and before an approval is requested,
+      # when a tag was pushed without a matching release-notes section.
       - name: Verify release notes exist for this tag
         env:
           TAG: ${{ github.ref_name }}
@@ -63,13 +73,37 @@ jobs:
       - name: Verify shells
         run: node scripts/verify-shells.mjs
 
+      # The deploy job gets the exact bytes that were verified here, rather than
+      # rebuilding and hoping for the same output.
+      - name: Upload built site
+        uses: actions/upload-artifact@v4
+        with:
+          name: site
+          path: dist/print-log-ui/browser
+          retention-days: 7
+          if-no-files-found: error
+
+  # The only gated job. `environment: production` carries the required-reviewer
+  # rule, so approving this ships the already-built artifact and nothing else.
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Download built site
+        uses: actions/download-artifact@v4
+        with:
+          name: site
+          path: site
+
       - name: Deploy to Azure Static Web Apps (prebuilt)
         uses: Azure/static-web-apps-deploy@v1
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: upload
-          app_location: dist/print-log-ui/browser
+          app_location: site
           output_location: ''
           skip_app_build: true
           skip_api_build: true
@@ -78,7 +112,7 @@ jobs:
   # after a successful deploy, so the Releases feed never announces a version
   # that is not actually live.
   publish-release:
-    needs: build-and-deploy
+    needs: deploy
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - 'v*'
 
+# Default every job to read-only. Only publish-release widens this, so the
+# third-party deploy action never sees a token that can write to the repo.
+permissions:
+  contents: read
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -12,6 +17,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      # Fails fast, before the ~10 minute build, when a tag was pushed without a
+      # matching section in the release notes component.
+      - name: Verify release notes exist for this tag
+        env:
+          TAG: ${{ github.ref_name }}
+        run: node scripts/extract-release-notes.mjs "$TAG" > /dev/null
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -61,3 +73,30 @@ jobs:
           output_location: ''
           skip_app_build: true
           skip_api_build: true
+
+  # Separate job so `contents: write` is scoped to publishing alone. Runs only
+  # after a successful deploy, so the Releases feed never announces a version
+  # that is not actually live.
+  publish-release:
+    needs: build-and-deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Publish GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          node scripts/extract-release-notes.mjs "$TAG" > release-body.md
+          gh release create "$TAG" \
+            --title "$(node scripts/extract-release-notes.mjs "$TAG" --title)" \
+            --notes-file release-body.md

--- a/scripts/extract-release-notes.mjs
+++ b/scripts/extract-release-notes.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+// Print the GitHub Release body for a version, taken from the in-app release
+// notes component. Thin I/O wrapper -- all parsing lives in release-notes-lib.mjs.
+//
+//   node scripts/extract-release-notes.mjs v1.47.0
+//   node scripts/extract-release-notes.mjs v1.47.0 --title
+//
+// Exits non-zero when the version has no section, so a deploy fails loudly
+// rather than publishing an empty release.
+
+import { readFileSync } from 'node:fs';
+import { extractReleaseNotes } from './release-notes-lib.mjs';
+
+const NOTES_PATH =
+  'src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html';
+
+const args = process.argv.slice(2);
+const wantTitle = args.includes('--title');
+const version = args.find((a) => !a.startsWith('--'));
+
+if (!version) {
+  console.error(
+    'usage: node scripts/extract-release-notes.mjs <version> [--title]'
+  );
+  process.exit(2);
+}
+
+try {
+  const release = extractReleaseNotes(
+    readFileSync(NOTES_PATH, 'utf8'),
+    version
+  );
+  process.stdout.write(
+    wantTitle ? `${release.title}\n` : `${release.markdown}\n`
+  );
+} catch (error) {
+  console.error(`extract-release-notes: ${error.message}`);
+  process.exit(1);
+}

--- a/scripts/release-notes-lib.mjs
+++ b/scripts/release-notes-lib.mjs
@@ -1,0 +1,249 @@
+// Pure, side-effect-free helpers for turning the in-app release-notes component
+// into GitHub Release bodies. Safe to import in unit tests.
+//
+// The component at
+//   src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
+// is the single source of truth for release prose -- it is hand-written by the
+// /release skill. This module reads it; nothing here should ever write it.
+
+export const SITE_ORIGIN = 'https://www.3dprintlog.com';
+
+// `lt` and `gt` are deliberately absent. GitHub renders raw HTML inside
+// Markdown, so prose that escaped a tag on purpose ("supports &lt;button&gt;")
+// must stay escaped or the tag vanishes from the release body.
+const NAMED_ENTITIES = {
+  amp: '&',
+  quot: '"',
+  apos: "'",
+  nbsp: ' ',
+};
+
+function decodeEntities(text) {
+  return text.replace(
+    /&(?:#x([0-9a-fA-F]+)|#(\d+)|([a-zA-Z]+));/g,
+    (match, hex, dec, name) => {
+      if (hex || dec) {
+        const code = Number.parseInt(hex ?? dec, hex ? 16 : 10);
+        // Same reasoning as above: a numeric < or > stays escaped.
+        if (!Number.isFinite(code) || code === 0x3c || code === 0x3e) {
+          return match;
+        }
+        return String.fromCodePoint(code);
+      }
+      return NAMED_ENTITIES[name.toLowerCase()] ?? match;
+    }
+  );
+}
+
+function collapse(text) {
+  return text.replace(/\s+/g, ' ').trim();
+}
+
+// A version id may be two-part (the single legacy `v1.6`) or three-part.
+// Normalizing means a `v1.6` tag and a `v1.6.0` tag both find the section.
+function normalizeVersion(raw) {
+  const trimmed = String(raw).trim().replace(/^v/i, '');
+  const parts = trimmed.split('.');
+  while (parts.length < 3) parts.push('0');
+  return parts.join('.');
+}
+
+// Lists nest, so the non-greedy `<li>...</li>` and `<ul>...</ul>` matches that
+// work everywhere else in this file would close on the inner element. These two
+// helpers scan with a depth counter instead.
+
+function extractFirstList(html) {
+  const open = /<ul\b[^>]*>/i.exec(html);
+  if (!open) return null;
+
+  const scan = /<(\/?)ul\b[^>]*>/gi;
+  scan.lastIndex = open.index;
+  let depth = 0;
+  let match;
+
+  while ((match = scan.exec(html)) !== null) {
+    if (match[1] === '') {
+      depth++;
+      continue;
+    }
+    if (--depth === 0) {
+      return {
+        start: open.index,
+        end: scan.lastIndex,
+        inner: html.slice(open.index + open[0].length, match.index),
+      };
+    }
+  }
+
+  // Returning null here would let the block scanner skip the outer list and
+  // render only its nested fragment -- publishing partial notes silently.
+  throw new Error(
+    'unbalanced <ul> in release notes: a list is opened but never closed'
+  );
+}
+
+function splitListItems(html) {
+  const scan = /<(\/?)li\b[^>]*>/gi;
+  const items = [];
+  let depth = 0;
+  let start = -1;
+  let match;
+
+  while ((match = scan.exec(html)) !== null) {
+    if (match[1] === '') {
+      if (depth === 0) start = scan.lastIndex;
+      depth++;
+      continue;
+    }
+    if (--depth === 0 && start >= 0) {
+      items.push(html.slice(start, match.index));
+      start = -1;
+    }
+  }
+  return items;
+}
+
+function renderList(inner, depth) {
+  const pad = '  '.repeat(depth);
+  const lines = [];
+
+  for (const item of splitListItems(inner)) {
+    // An item can hold more than one child list; take them all, or the leftovers
+    // land in the parent's text as raw HTML.
+    const children = [];
+    let rest = item;
+
+    for (
+      let list = extractFirstList(rest);
+      list;
+      list = extractFirstList(rest)
+    ) {
+      children.push(list.inner);
+      rest = rest.slice(0, list.start) + rest.slice(list.end);
+    }
+
+    const text = collapse(rest);
+    if (text) lines.push(`${pad}- ${text}`);
+
+    for (const child of children) {
+      const sub = renderList(child, depth + 1);
+      if (sub) lines.push(sub);
+    }
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Split the component HTML into one entry per release.
+ * Only <h3> headings are releases; the page's <h2> title is not.
+ */
+export function parseSections(html) {
+  const heading =
+    /<h3\b[^>]*\bid="v?([0-9][0-9.]*)"[^>]*>([\s\S]*?)<\/h3\s*>/gi;
+  const found = [];
+  let match;
+
+  while ((match = heading.exec(html)) !== null) {
+    found.push({
+      version: normalizeVersion(match[1]),
+      title: collapse(decodeEntities(match[2].replace(/<[^>]*>/g, ''))),
+      // Where this heading opens, and where its body starts. Keeping both means
+      // the next section's boundary is already known -- searching back for the
+      // literal '<h3' would miss an uppercase <H3> that the matcher accepted.
+      openIndex: match.index,
+      start: heading.lastIndex,
+    });
+  }
+
+  return found.map((section, i) => ({
+    version: section.version,
+    title: section.title,
+    bodyHtml: html.slice(
+      section.start,
+      i + 1 < found.length ? found[i + 1].openIndex : html.length
+    ),
+  }));
+}
+
+/**
+ * Convert a release section's HTML to Markdown suitable for a GitHub Release
+ * body. Handles only the shapes the component actually uses.
+ */
+export function htmlToMarkdown(html) {
+  let s = html;
+
+  // Drop structural and media-only elements. Their inner block content (if any)
+  // is still picked up below, since blocks are matched wherever they appear.
+  s = s.replace(/<\/?(?:div|hr|img|mat-[a-z-]+)\b[^>]*>/gi, '');
+  s = s.replace(/<br\s*\/?>/gi, ' ');
+
+  // Inline formatting, before blocks so it survives into the block text.
+  // Internal links are Angular routerLinks, which are relative and therefore
+  // dead once the body is rendered off-site on github.com.
+  // Two spellings in the history: the plain attribute, and the older
+  // property-binding form `[routerLink]="['/prints']"`.
+  s = s.replace(
+    /<a\b[^>]*\[routerLink\]="\[\s*'([^']*)'\s*\][^>]*>([\s\S]*?)<\/a\s*>/gi,
+    (_, route, text) => `[${collapse(text)}](${SITE_ORIGIN}${route.trim()})`
+  );
+  s = s.replace(
+    /<a\b[^>]*\brouterLink="([^"]*)"[^>]*>([\s\S]*?)<\/a\s*>/gi,
+    (_, route, text) => `[${collapse(text)}](${SITE_ORIGIN}${route.trim()})`
+  );
+  s = s.replace(
+    /<a\b[^>]*\bhref="([^"]*)"[^>]*>([\s\S]*?)<\/a\s*>/gi,
+    (_, href, text) => `[${collapse(text)}](${href.trim()})`
+  );
+  s = s.replace(/<strong\b[^>]*>([\s\S]*?)<\/strong\s*>/gi, '**$1**');
+  s = s.replace(/<em\b[^>]*>([\s\S]*?)<\/em\s*>/gi, '_$1_');
+  s = s.replace(/<code\b[^>]*>([\s\S]*?)<\/code\s*>/gi, '`$1`');
+
+  // Blocks, in document order.
+  const block = /<(p|h4|ul)\b[^>]*>/gi;
+  const out = [];
+  let match;
+
+  while ((match = block.exec(s)) !== null) {
+    const tag = match[1].toLowerCase();
+
+    if (tag === 'ul') {
+      const list = extractFirstList(s.slice(match.index));
+      if (!list) continue;
+      const rendered = renderList(list.inner, 0);
+      if (rendered) out.push(rendered);
+      block.lastIndex = match.index + list.end;
+      continue;
+    }
+
+    const rest = s.slice(block.lastIndex);
+    const close = new RegExp(`</${tag}\\s*>`, 'i').exec(rest);
+    const text = collapse(close ? rest.slice(0, close.index) : rest);
+
+    if (text) out.push(tag === 'h4' ? `### ${text}` : text);
+    if (close) block.lastIndex += close.index + close[0].length;
+  }
+
+  return decodeEntities(out.join('\n\n')).trim();
+}
+
+/**
+ * Look up one release by version (with or without a leading `v`).
+ * Throws when the version has no section -- a silent empty release body is
+ * worse than a failed deploy.
+ */
+export function extractReleaseNotes(html, version) {
+  const wanted = normalizeVersion(version);
+  const section = parseSections(html).find((s) => s.version === wanted);
+
+  if (!section) {
+    throw new Error(
+      `no release notes section for ${wanted}: add an <h3 id="v${wanted}"> entry to the release notes component`
+    );
+  }
+
+  return {
+    version: section.version,
+    title: section.title,
+    markdown: htmlToMarkdown(section.bodyHtml),
+  };
+}

--- a/scripts/release-notes-lib.test.mjs
+++ b/scripts/release-notes-lib.test.mjs
@@ -1,0 +1,273 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+import {
+  parseSections,
+  htmlToMarkdown,
+  extractReleaseNotes,
+} from './release-notes-lib.mjs';
+
+const NOTES_PATH =
+  'src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html';
+
+// Mirrors the real component: a wrapper, an <h2> that is NOT a release, then
+// two releases. The second carries every inline shape the real file uses --
+// including the capitalized <Strong> that appears 10 times in the history.
+const FIXTURE = `<div class="docs-markdown">
+  <h2>Release Notes</h2>
+  <hr />
+
+  <h3 id="v1.47.0">1.47.0 - Material Remaining &amp; More Bulk Actions</h3>
+  <p>
+    Saved materials now tell you what is
+    left on the spool.
+  </p>
+
+  <h3 id="v1.46.0">1.46.0 - The New Print Page</h3>
+  <p>The print page has been <em>rebuilt</em>.</p>
+  <h4>Full List of Changes:</h4>
+  <ul>
+    <li>
+      <strong>Rebuilt print page</strong> - Now an image hero. (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/81"
+        rel="noreferrer noopener"
+        >#81</a
+      >)
+    </li>
+    <li><Strong>Bulk editing</Strong> - Select rows and act on them.</li>
+  </ul>
+</div>`;
+
+test('parseSections returns one entry per release heading', () => {
+  const sections = parseSections(FIXTURE);
+
+  assert.equal(sections.length, 2);
+  assert.equal(sections[0].version, '1.47.0');
+  assert.equal(sections[1].version, '1.46.0');
+});
+
+test('parseSections keeps the heading text as the release title', () => {
+  const [first] = parseSections(FIXTURE);
+
+  assert.equal(first.title, '1.47.0 - Material Remaining & More Bulk Actions');
+});
+
+test('parseSections ignores the page <h2>, taking only <h3> releases', () => {
+  const versions = parseSections(FIXTURE).map((s) => s.version);
+
+  assert.deepEqual(versions, ['1.47.0', '1.46.0']);
+});
+
+test('parseSections stops a section at the next heading', () => {
+  const [first] = parseSections(FIXTURE);
+
+  assert.match(first.bodyHtml, /left on the spool/);
+  assert.doesNotMatch(first.bodyHtml, /print page has been/);
+});
+
+test('parseSections bounds sections correctly with uppercase <H3> tags', () => {
+  // The heading match is case-insensitive, so the boundary lookup must be too,
+  // or the first section swallows the second.
+  const sections = parseSections(
+    '<H3 id="v1.2.0">First</H3><p>A</p><H3 id="v1.1.0">Second</H3><p>B</p>'
+  );
+
+  assert.equal(sections.length, 2);
+  assert.match(sections[0].bodyHtml, /A/);
+  assert.doesNotMatch(sections[0].bodyHtml, /Second/);
+});
+
+test('parseSections normalizes a two-part id like v1.6 to 1.6.0', () => {
+  const sections = parseSections(
+    '<h3 id="v1.6">1.6 - Old release</h3><p>x</p>'
+  );
+
+  assert.equal(sections[0].version, '1.6.0');
+});
+
+test('htmlToMarkdown renders paragraphs as single collapsed lines', () => {
+  const md = htmlToMarkdown(
+    '<p>\n  Saved materials\n  tell you what is left.\n</p>'
+  );
+
+  assert.equal(md, 'Saved materials tell you what is left.');
+});
+
+test('htmlToMarkdown renders list items as dashes', () => {
+  const md = htmlToMarkdown(
+    '<ul><li>First thing</li><li>Second thing</li></ul>'
+  );
+
+  assert.equal(md, '- First thing\n- Second thing');
+});
+
+test('htmlToMarkdown renders <strong> as bold regardless of tag case', () => {
+  const md = htmlToMarkdown(
+    '<p><strong>One</strong> and <Strong>Two</Strong></p>'
+  );
+
+  assert.equal(md, '**One** and **Two**');
+});
+
+test('htmlToMarkdown renders links as markdown links', () => {
+  const md = htmlToMarkdown(
+    '<p>See (<a\n href="https://example.com/pull/81"\n rel="noreferrer"\n >#81</a\n >)</p>'
+  );
+
+  assert.equal(md, 'See ([#81](https://example.com/pull/81))');
+});
+
+test('htmlToMarkdown absolutizes routerLink into a site URL', () => {
+  // A GitHub Release body is read off-site, so an Angular routerLink has to
+  // become a real URL or it renders as a dead relative link on github.com.
+  const md = htmlToMarkdown(
+    '<p>the <a routerLink="/settings">settings page</a></p>'
+  );
+
+  assert.equal(md, 'the [settings page](https://www.3dprintlog.com/settings)');
+});
+
+test('htmlToMarkdown absolutizes the [routerLink]="[\'/x\']" binding form', () => {
+  // Older sections use Angular property-binding syntax rather than a plain
+  // routerLink attribute.
+  const md = htmlToMarkdown(
+    '<p>the <a [routerLink]="[\'/prints\']">print list</a></p>'
+  );
+
+  assert.equal(md, 'the [print list](https://www.3dprintlog.com/prints)');
+});
+
+test('htmlToMarkdown indents a nested list under its parent item', () => {
+  const md = htmlToMarkdown(
+    '<ul><li>Parent<ul><li>Child one</li><li>Child two</li></ul></li><li>Sibling</li></ul>'
+  );
+
+  assert.equal(md, '- Parent\n  - Child one\n  - Child two\n- Sibling');
+});
+
+test('htmlToMarkdown renders <h4> as a markdown heading', () => {
+  const md = htmlToMarkdown('<h4>Full List of Changes:</h4>');
+
+  assert.equal(md, '### Full List of Changes:');
+});
+
+test('htmlToMarkdown decodes named entities', () => {
+  const md = htmlToMarkdown('<p>Remaining &amp; more &quot;stuff&quot;</p>');
+
+  assert.equal(md, 'Remaining & more "stuff"');
+});
+
+test('htmlToMarkdown decodes decimal and hex numeric entities', () => {
+  const md = htmlToMarkdown('<p>It&#8217;s ready &#x1F680;</p>');
+
+  assert.equal(md, 'It’s ready \u{1F680}');
+});
+
+test('htmlToMarkdown keeps &lt; and &gt; escaped so literal markup survives', () => {
+  // Prose that deliberately shows a tag must stay escaped: GitHub renders raw
+  // HTML in Markdown, so decoding these would make the tag disappear.
+  const md = htmlToMarkdown('<p>Use &lt;button&gt; literally</p>');
+
+  assert.equal(md, 'Use &lt;button&gt; literally');
+});
+
+test('htmlToMarkdown renders every sibling list nested under one item', () => {
+  const md = htmlToMarkdown(
+    '<ul><li>Parent<ul><li>A</li></ul><ul><li>B</li></ul></li></ul>'
+  );
+
+  assert.equal(md, '- Parent\n  - A\n  - B');
+});
+
+test('htmlToMarkdown throws on an unclosed list rather than dropping content', () => {
+  // Silently publishing a fragment of the notes is worse than a failed deploy.
+  assert.throws(
+    () =>
+      htmlToMarkdown('<p>Before</p><ul><li>Outer<ul><li>Inner</li></ul></li>'),
+    /unbalanced <ul>/i
+  );
+});
+
+test('htmlToMarkdown renders <em> as italic', () => {
+  assert.equal(
+    htmlToMarkdown('<p>has been <em>rebuilt</em></p>'),
+    'has been _rebuilt_'
+  );
+});
+
+test('extractReleaseNotes returns the title and markdown body for a version', () => {
+  const release = extractReleaseNotes(FIXTURE, '1.46.0');
+
+  assert.equal(release.version, '1.46.0');
+  assert.equal(release.title, '1.46.0 - The New Print Page');
+  assert.match(release.markdown, /^The print page has been _rebuilt_\./);
+  assert.match(
+    release.markdown,
+    /^- \*\*Rebuilt print page\*\* - Now an image hero/m
+  );
+});
+
+test('extractReleaseNotes accepts a leading v on the version', () => {
+  assert.equal(extractReleaseNotes(FIXTURE, 'v1.46.0').version, '1.46.0');
+});
+
+test('extractReleaseNotes throws for a version with no section', () => {
+  assert.throws(
+    () => extractReleaseNotes(FIXTURE, '1.32.1'),
+    /no release notes section for 1\.32\.1/i
+  );
+});
+
+// -- Against the real component, which is the corpus this ships against. --
+
+const REAL_HTML = readFileSync(NOTES_PATH, 'utf8');
+
+test('every release section in the real file yields non-empty markdown', () => {
+  const sections = parseSections(REAL_HTML);
+  assert.ok(
+    sections.length >= 95,
+    `expected >=95 sections, got ${sections.length}`
+  );
+
+  const empty = sections
+    .filter((s) => htmlToMarkdown(s.bodyHtml).trim().length === 0)
+    .map((s) => s.version);
+
+  assert.deepEqual(empty, []);
+});
+
+test('the real file leaves no unrendered HTML tags in its markdown', () => {
+  const leftovers = parseSections(REAL_HTML)
+    .map((s) => ({ v: s.version, md: htmlToMarkdown(s.bodyHtml) }))
+    .filter((s) => /<\/?[a-zA-Z]/.test(s.md))
+    .map((s) => s.v);
+
+  assert.deepEqual(leftovers, []);
+});
+
+test('every git tag except the known-missing v1.32.1 resolves to a section', (t) => {
+  const tags = execFileSync('git', ['tag'], { encoding: 'utf8' })
+    .split('\n')
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+
+  // actions/checkout is shallow by default and fetches no tags, so this
+  // assertion is only meaningful on a clone that has them.
+  if (tags.length === 0) {
+    t.skip('no git tags available (shallow clone)');
+    return;
+  }
+
+  const missing = tags.filter((tag) => {
+    try {
+      extractReleaseNotes(REAL_HTML, tag);
+      return false;
+    } catch {
+      return true;
+    }
+  });
+
+  assert.deepEqual(missing, ['v1.32.1']);
+});


### PR DESCRIPTION
Implements section 1 (this repo's half) of #105.

## Why

31 tags, zero published Releases. There is no changelog to read on GitHub and nothing to subscribe to via *Watch → Releases only*.

The release notes component already holds 95 sections of hand-written per-version prose, maintained by the `/release` skill. GitHub's `generate_release_notes` — a dump of PR titles — would be a downgrade on that. So this **extracts** the existing prose rather than generating anything: the component stays the single source of truth and now feeds both the in-app docs page and the GitHub Releases feed, with no new authoring work per release.

## What changed

- **`scripts/release-notes-lib.mjs`** — pure parsing and HTML→Markdown conversion.
- **`scripts/extract-release-notes.mjs`** — thin CLI over it, matching the existing `sitemap-lib` / `generate-sitemap` split.
- **`scripts/release-notes-lib.test.mjs`** — 26 tests, picked up automatically by `npm run test:scripts`.
- **`.github/workflows/deploy.yml`** — validates the tag before the build, publishes after the deploy.

## Behavior

A tag with no matching section **fails the deploy** rather than publishing an empty release. The check runs immediately after checkout, so it fails in seconds rather than after the ~10 minute build. `v1.32.1` is the one tag in the history with no section.

Publishing happens only after a successful Azure deploy, so the Releases feed never announces a version that is not live.

## Notes for review

Testing against the real 95-section corpus (rather than fixtures alone) is what surfaced the shapes that actually mattered:

- **Internal links are Angular `routerLink`s, in two spellings** — the plain attribute and the older `[routerLink]="['/prints']"` binding form. Both would have rendered as dead relative links on github.com; they are now absolutized to `https://www.3dprintlog.com`.
- **Lists nest.** The obvious non-greedy `<ul>`/`<li>` regex closes on the inner element, so both are scanned with a depth counter instead.
- **`&lt;`/`&gt;` stay escaped.** GitHub renders raw HTML inside Markdown, so decoding them would make prose like `supports &lt;button&gt;` vanish from the release body.

Two tests lock this down against the real file: every section yields non-empty Markdown, and no section leaves unrendered HTML behind.

### Security

Release publishing is a **separate job** scoped to `contents: write`, with the workflow defaulting to `contents: read`. The `Azure/static-web-apps-deploy@v1` action is passed `GITHUB_TOKEN` and pinned only to a mutable major tag, so it should not run with a token that can rewrite repo contents or releases.

`github.ref_name` is passed via `env:` rather than interpolated into `run:`, avoiding the script-injection pattern that CodeQL's `actions` analysis flags (relevant to section 2 of #105).

### CI note

The tag-coverage test skips when `git tag` returns nothing, since `actions/checkout` is shallow and fetches no tags. Without that it would pass locally and fail in CI.

## Not in this PR

- **Backfilling** existing releases (`v1.43.0` forward) — separate follow-up.
- **The API repo's** release step, which uses `generate_release_notes` since it has no prose source.
- Sections 2–8 of #105.
