### PR TITLE
ci: add Dependabot config and harden workflow tokens

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,71 @@
+version: 2
+
+# Nothing watched package versions before this file existed, which is how 21 open
+# alerts (17 high) accumulated unnoticed. The API repo has had a nuget config for
+# a while; this is the npm/actions equivalent.
+#
+# Grouping is the point. Angular 21 pulls ~22 first-party packages plus a build
+# toolchain, so an ungrouped weekly run opens dozens of PRs and gets ignored --
+# which is the same failure mode as having no config at all.
+#
+# NOT covered here, and easy to assume otherwise:
+#   - Transitive-only advisories. Dependabot bumps what package.json declares; a
+#     vulnerable transitive dep is only fixed when its parent releases.
+#   - The Node version used by CI and the deploy workflow, which is pinned in the
+#     workflow files, not in package.json.
+
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+
+    groups:
+      # Angular packages are versioned in lockstep and must move together -- a
+      # partial bump produces a combination that was never tested upstream, and
+      # @angular/core against a mismatched compiler-cli fails at build time.
+      angular:
+        patterns:
+          - '@angular/*'
+          - '@angular-devkit/*'
+          - '@angular-eslint/*'
+          - '@ngtools/*'
+          - 'ng-packagr'
+          - 'typescript'
+          - 'zone.js'
+
+      # Test tooling only affects CI, so a single combined PR is easy to judge:
+      # either the suite still passes or it does not.
+      test-tooling:
+        patterns:
+          - 'karma*'
+          - 'jasmine*'
+          - '@types/jasmine'
+          - 'cypress'
+          - 'cypress-*'
+
+      lint-and-format:
+        patterns:
+          - 'eslint*'
+          - '@typescript-eslint/*'
+          - 'prettier*'
+          - 'husky'
+          - 'lint-staged'
+
+      # Everything else, split by risk: patch/minor together, majors on their own
+      # so a breaking change is never bundled with routine upgrades.
+      runtime-minor-patch:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,17 @@ on:
   pull_request:
     branches: [main]
 
+# Read-only: CI only builds and tests, it never writes to the repository.
+permissions:
+  contents: read
+
+# A second push to the same PR makes the earlier run redundant. This suite runs
+# lint, unit tests, script tests, strict typecheck and two builds, so cancelling
+# saves a meaningful amount of Actions time.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -23,6 +23,10 @@ concurrency:
 env:
   SA_PASSWORD: 'E2ePassw0rd!Local'
 
+# Read-only: the suite drives a browser, it never writes to the repository.
+permissions:
+  contents: read
+
 jobs:
   e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/refresh-sitemap.yml
+++ b/.github/workflows/refresh-sitemap.yml
@@ -5,6 +5,11 @@ on:
     - cron: '0 6 * * *'
   workflow_dispatch:
 
+# Read-only: this regenerates the sitemap and uploads to Azure. It reads the
+# repository at a release tag and never writes back to it.
+permissions:
+  contents: read
+
 jobs:
   refresh:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Sections 3 and 4 of #105.

## Dependabot (`.github/dependabot.yml`)

Nothing has watched package versions in this repo until now — which is how **21 open alerts (17 high, 4 medium)** accumulated without anyone seeing them.

Covers `npm` and `github-actions`, weekly. **Grouped deliberately:** Angular 21 pulls ~22 first-party packages plus a build toolchain, and an ungrouped weekly run opens dozens of PRs that then get ignored — the same end state as having no config at all. Groups are `angular` (must move in lockstep, since `@angular/core` against a mismatched `compiler-cli` fails at build time), `test-tooling`, `lint-and-format`, and production minor/patch. Majors stay on their own so a breaking change is never bundled with routine upgrades.

Modeled on the API repo's existing nuget config, including documenting what it deliberately does *not* cover.

## Workflow hardening

No workflow in this repo declared `permissions`, so every one ran with the repo default token scope. CI, E2E and the sitemap refresh are all read-only and now say so. (`deploy.yml` was already handled in #106.)

Added a concurrency group to CI: a second push to a PR made the earlier run redundant, and that suite runs lint, unit tests, script tests, strict typecheck and two builds before finishing.

**Deliberately no concurrency group on `deploy.yml` or `refresh-sitemap.yml`** — cancelling a deploy part-way through is worse than letting it finish, and the daily refresh cannot overlap itself. E2E already had one.

## Not in this PR

Enabling the security *features* themselves (secret scanning, push protection, Dependabot security updates, CodeQL) — those are repository settings, not files, and are tracked separately in #105.

There is also a **pre-existing bug this PR does not fix**: every scheduled run of `refresh-sitemap.yml` is stuck in `status=waiting`, because the job carries `environment: production` and that environment requires a reviewer. The daily sitemap refresh has therefore never actually run. Fixing it means deciding how unattended automation should reach the Azure token without going through the human release gate — worth its own issue rather than being folded in here.
