### PR TITLE
docs: point the README at Discussions and list every sibling repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,15 @@ The `sitemap.xml` is generated at deploy time from the public API (`scripts/gene
 ## Related Repos
 
 - [3d-print-log-api](https://github.com/HoffmanEngineering/3d-print-log-api) — the backend API
+- [3d-print-log-app](https://github.com/HoffmanEngineering/3d-print-log-app) — Cordova Android app shell
 - [3d-print-log-cura-plugin](https://github.com/HoffmanEngineering/3d-print-log-cura-plugin) — Cura integration
+- [Slic3rPostProcessingUploader](https://github.com/HoffmanEngineering/Slic3rPostProcessingUploader) — PrusaSlicer, OrcaSlicer, Bambu Studio and Slic3r integration
+
+## Questions & Discussions
+
+[**Discussions**](https://github.com/HoffmanEngineering/3d-print-log-ui/discussions) is the front door for the whole project, not just this repository. Ask in [Q&A](https://github.com/HoffmanEngineering/3d-print-log-ui/discussions/categories/q-a) if you have a usage question about the web app, the API, or either slicer plugin — one board means you do not have to guess which repository a question belongs to, and answers stay searchable for whoever asks next.
+
+Bug reports and feature requests still belong in [issues](https://github.com/HoffmanEngineering/3d-print-log-ui/issues), on whichever repository they affect.
 
 ## Support Development
 


### PR DESCRIPTION
@
Part of section 8 of #105.

Discussions is now enabled on this repo (Q&A category confirmed answerable) as the **single front door** for the whole project — four half-used boards would be worse than one active one, which is why the other repos will link here rather than enabling their own.

- Adds a **Questions & Discussions** section making clear the board covers the web app, API and both plugins, so nobody has to guess which repo a usage question belongs to.
- Keeps the issues/discussions split explicit: bugs and feature requests still go to issues.
- **Related Repos listed only two of the four siblings** — adds `3d-print-log-app` and `Slic3rPostProcessingUploader`.

Companion PRs adding the same link to the other four READMEs follow separately.
@