### PR TITLE
fix(parsers): reject invalid filament measurements

### DIFF
--- a/src/app/core/services/file-parsers/anycubic/anycubic-file-parser.service.spec.ts
+++ b/src/app/core/services/file-parsers/anycubic/anycubic-file-parser.service.spec.ts
@@ -37,3 +37,31 @@ xdescribe('AnycubicFileParserService', () => {
     expect(actual.estimatedPrintTimeInSeconds).toBeUndefined();
   });
 });
+
+describe('AnycubicFileParserService filament estimates', () => {
+  let service: AnycubicFileParserService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(AnycubicFileParserService);
+  });
+
+  it('should return undefined when diameter or length is missing or zero', () => {
+    const invalidInputs = [
+      `; filament_type = PLA
+; filament used [mm] = 1000`,
+      `; filament_type = PLA
+; filament_diameter = 1.75`,
+      `; filament_type = PLA
+; filament_diameter = 0
+; filament used [mm] = 1000`,
+      `; filament_type = PLA
+; filament_diameter = 1.75
+; filament used [mm] = 0`,
+    ];
+
+    invalidInputs.forEach((gcode) => {
+      expect(service.estimateFilamentUsageInMg(gcode)).toBeUndefined();
+    });
+  });
+});

--- a/src/app/core/services/file-parsers/anycubic/anycubic-file-parser.service.ts
+++ b/src/app/core/services/file-parsers/anycubic/anycubic-file-parser.service.ts
@@ -100,7 +100,7 @@ export class AnycubicFileParserService implements GcodeNewPrintParser {
       gcode,
       '; filament_diameter'
     ).split(',')?.[0];
-    if (isNaN(filamentDiameter)) {
+    if (!Number.isFinite(filamentDiameter) || filamentDiameter <= 0) {
       return undefined;
     }
     const filamentUsageLengthInMM = +this.parseSettingAsString(
@@ -108,7 +108,10 @@ export class AnycubicFileParserService implements GcodeNewPrintParser {
       '; filament used \\[mm\\]'
     );
 
-    if (isNaN(filamentUsageLengthInMM)) {
+    if (
+      !Number.isFinite(filamentUsageLengthInMM) ||
+      filamentUsageLengthInMM <= 0
+    ) {
       return undefined;
     }
 

--- a/src/app/core/services/file-parsers/creality-print/creality-print-file-parser.service.spec.ts
+++ b/src/app/core/services/file-parsers/creality-print/creality-print-file-parser.service.spec.ts
@@ -57,4 +57,25 @@ Filament used:1.65354m
 Layer Height:0.2
 Adaptive Layers:0`);
   });
+
+  describe('estimateFilamentUsageInMg', () => {
+    it('should return undefined when diameter or length is missing or zero', () => {
+      const invalidInputs = [
+        `; filament_type = PLA
+; filament used [mm] = 1000`,
+        `; filament_type = PLA
+; filament_diameter = 1.75`,
+        `; filament_type = PLA
+; filament_diameter = 0
+; filament used [mm] = 1000`,
+        `; filament_type = PLA
+; filament_diameter = 1.75
+; filament used [mm] = 0`,
+      ];
+
+      invalidInputs.forEach((gcode) => {
+        expect(service.estimateFilamentUsageInMg(gcode)).toBeUndefined();
+      });
+    });
+  });
 });

--- a/src/app/core/services/file-parsers/creality-print/creality-print-file-parser.service.ts
+++ b/src/app/core/services/file-parsers/creality-print/creality-print-file-parser.service.ts
@@ -100,7 +100,7 @@ export class CrealityPrintFileParserService implements GcodeNewPrintParser {
       gcode,
       '; filament_diameter'
     ).split(',')?.[0];
-    if (isNaN(filamentDiameter)) {
+    if (!Number.isFinite(filamentDiameter) || filamentDiameter <= 0) {
       return undefined;
     }
     const filamentUsageLengthInMM = +this.parseSettingAsString(
@@ -108,7 +108,10 @@ export class CrealityPrintFileParserService implements GcodeNewPrintParser {
       '; filament used \\[mm\\]'
     );
 
-    if (isNaN(filamentUsageLengthInMM)) {
+    if (
+      !Number.isFinite(filamentUsageLengthInMM) ||
+      filamentUsageLengthInMM <= 0
+    ) {
       return undefined;
     }
 

--- a/src/app/core/services/file-parsers/orca/orca-file-parser.service.spec.ts
+++ b/src/app/core/services/file-parsers/orca/orca-file-parser.service.spec.ts
@@ -36,4 +36,25 @@ describe('OrcaFileParserService', () => {
 
     expect(actual.estimatedPrintTimeInSeconds).toBeUndefined();
   });
+
+  describe('estimateFilamentUsageInMg', () => {
+    it('should return undefined when diameter or length is missing or zero', () => {
+      const invalidInputs = [
+        `; filament_type = PLA
+; filament used [mm] = 1000`,
+        `; filament_type = PLA
+; filament_diameter = 1.75`,
+        `; filament_type = PLA
+; filament_diameter = 0
+; filament used [mm] = 1000`,
+        `; filament_type = PLA
+; filament_diameter = 1.75
+; filament used [mm] = 0`,
+      ];
+
+      invalidInputs.forEach((gcode) => {
+        expect(service.estimateFilamentUsageInMg(gcode)).toBeUndefined();
+      });
+    });
+  });
 });

--- a/src/app/core/services/file-parsers/orca/orca-file-parser.service.ts
+++ b/src/app/core/services/file-parsers/orca/orca-file-parser.service.ts
@@ -56,7 +56,7 @@ export class OrcaFileParserService implements GcodeNewPrintParser {
       gcode,
       '; filament_diameter'
     ).split(',')?.[0];
-    if (isNaN(filamentDiameter)) {
+    if (!Number.isFinite(filamentDiameter) || filamentDiameter <= 0) {
       return undefined;
     }
     const filamentUsageLengthInMM = +this.parseSettingAsString(
@@ -64,7 +64,10 @@ export class OrcaFileParserService implements GcodeNewPrintParser {
       '; filament used \\[mm\\]'
     );
 
-    if (isNaN(filamentUsageLengthInMM)) {
+    if (
+      !Number.isFinite(filamentUsageLengthInMM) ||
+      filamentUsageLengthInMM <= 0
+    ) {
       return undefined;
     }
 

--- a/src/app/core/services/file-parsers/prusa/prusa-slicer-file-parser.service.spec.ts
+++ b/src/app/core/services/file-parsers/prusa/prusa-slicer-file-parser.service.spec.ts
@@ -73,25 +73,34 @@ describe('PrusaSlicerFileParserService', () => {
       expect(service.estimateFilamentUsageInMg(testGcode)).toBeUndefined();
     });
 
-    // The next two characterize existing behavior that is WRONG, so that the
-    // full surface of the bug is pinned before it is fixed. A missing numeric
-    // setting parses as 0 rather than NaN, so the isNaN guards never fire and
-    // the weight comes out as 0mg instead of "unknown".
-    // Tracked in #99 — flip both to toBeUndefined() when that lands.
-    it('should currently report 0 when the diameter is missing', () => {
+    it('should return undefined when the diameter is missing', () => {
       const testGcode = `; total filament used [g] = 0.0
 ; filament_type = PLA
 ; filament used [mm] = 1000`;
 
-      expect(service.estimateFilamentUsageInMg(testGcode)).toBe(0);
+      expect(service.estimateFilamentUsageInMg(testGcode)).toBeUndefined();
     });
 
-    it('should currently report 0 when the filament length is missing', () => {
+    it('should return undefined when the filament length is missing', () => {
       const testGcode = `; total filament used [g] = 0.0
 ; filament_type = PLA
 ; filament_diameter = 1.75`;
 
-      expect(service.estimateFilamentUsageInMg(testGcode)).toBe(0);
+      expect(service.estimateFilamentUsageInMg(testGcode)).toBeUndefined();
+    });
+
+    it('should return undefined when the diameter or filament length is zero', () => {
+      const zeroDiameter = `; total filament used [g] = 0.0
+; filament_type = PLA
+; filament_diameter = 0
+; filament used [mm] = 1000`;
+      const zeroLength = `; total filament used [g] = 0.0
+; filament_type = PLA
+; filament_diameter = 1.75
+; filament used [mm] = 0`;
+
+      expect(service.estimateFilamentUsageInMg(zeroDiameter)).toBeUndefined();
+      expect(service.estimateFilamentUsageInMg(zeroLength)).toBeUndefined();
     });
   });
 });

--- a/src/app/core/services/file-parsers/prusa/prusa-slicer-file-parser.service.ts
+++ b/src/app/core/services/file-parsers/prusa/prusa-slicer-file-parser.service.ts
@@ -56,7 +56,7 @@ export class PrusaSlicerFileParserService implements GcodeNewPrintParser {
       gcode,
       '; filament_diameter'
     ).split(',')?.[0];
-    if (isNaN(filamentDiameter)) {
+    if (!Number.isFinite(filamentDiameter) || filamentDiameter <= 0) {
       return undefined;
     }
     const filamentUsageLengthInMM = +this.parseSettingAsString(
@@ -64,7 +64,10 @@ export class PrusaSlicerFileParserService implements GcodeNewPrintParser {
       '; filament used \\[mm\\]'
     );
 
-    if (isNaN(filamentUsageLengthInMM)) {
+    if (
+      !Number.isFinite(filamentUsageLengthInMM) ||
+      filamentUsageLengthInMM <= 0
+    ) {
       return undefined;
     }
 

--- a/src/app/print/edit-print-detail/edit-print-detail.component.spec.ts
+++ b/src/app/print/edit-print-detail/edit-print-detail.component.spec.ts
@@ -313,7 +313,6 @@ describe('EditPrintDetailComponent', () => {
         printerId: null,
         startDate: new Date(),
         estimatedPrintTimeInSeconds: null,
-        estimatedFilamentUsageMg: null,
         printTimeInSeconds: null,
         filamentUsageMg: null,
         filamentType: '',
@@ -337,6 +336,7 @@ describe('EditPrintDetailComponent', () => {
       expect(imagesArray.length).toBe(1);
       expect(imagesArray.at(0).value.url).toBe(snapshotUrl);
       expect(imagesArray.at(0).value.url).not.toContain('null');
+      expect(form.get('estimatedFilamentUsageG')?.value).toBeNull();
     });
 
     it('should set isDragOver on drag events', () => {

--- a/src/app/print/edit-print-detail/edit-print-detail.component.ts
+++ b/src/app/print/edit-print-detail/edit-print-detail.component.ts
@@ -850,12 +850,13 @@ export class EditPrintDetailComponent
 
     // Convert the old filamentType/FilamentUsage properties into the new Filament Usage format.
     // Skip when modern filament usage records already exist to avoid duplicate entries.
+    const estimatedFilamentUsageMg = print?.estimatedFilamentUsageMg ?? null;
     if (
       print &&
       printFilamentUsageArray.length === 0 &&
       (!(print.filamentType === null || print.filamentType === '') ||
         print.filamentUsageMg > 0 ||
-        print.estimatedFilamentUsageMg > 0)
+        (estimatedFilamentUsageMg ?? 0) > 0)
     ) {
       const newFormGroup = this.GetNewFilamentUsageForm(
         EMPTY_GUID,
@@ -863,7 +864,9 @@ export class EditPrintDetailComponent
         null,
         null,
         PrintFilamentSourceMeasurement.Weight,
-        print.estimatedFilamentUsageMg / 1000,
+        estimatedFilamentUsageMg !== null
+          ? estimatedFilamentUsageMg / 1000
+          : null,
         null,
         null,
         PrintFilamentSourceMeasurement.Weight,
@@ -905,7 +908,9 @@ export class EditPrintDetailComponent
         print ? this.parseIntoString(print.estimatedPrintTimeInSeconds) : null,
       ],
       estimatedFilamentUsageG: [
-        print ? print.estimatedFilamentUsageMg / 1000 : null,
+        print?.estimatedFilamentUsageMg != null
+          ? print.estimatedFilamentUsageMg / 1000
+          : null,
         [Validators.min(0)],
       ],
       printTimeInSeconds: [


### PR DESCRIPTION
## What does this PR do?

Rejects missing, non-finite, and non-positive filament diameter/length values in the Prusa, Orca, Creality Print, and Anycubic parsers instead of recording a false 0mg estimate. The edit form now maps an absent estimate to `null` rather than `NaN`.

Notes: Fixed filament usage estimates when slicer metadata is missing or invalid.

Closes #99

## How to test

- `CHROME_BIN=/snap/bin/chromium npx ng test --no-watch --browsers ChromeHeadless --include="src/app/core/services/file-parsers/**/*spec.ts" --include="src/app/print/edit-print-detail/edit-print-detail.component.spec.ts"`
- `npm run lint:brief`
- `npm run typecheck:strict`
- `npm run test:scripts`
- `npm run build:dev`

## Checklist

- [x] Manually audited all changes in this PR
- [x] Existing parser and editor tests pass
- [x] New tests cover missing and zero measurements across all four parsers
- [x] No secrets or personal config committed