### PR TITLE
fix(navbar): stop rendering a duplicate "About" on mobile

### DIFF
--- a/src/app/shared/navbar/navbar.component.html
+++ b/src/app/shared/navbar/navbar.component.html
@@ -8,180 +8,105 @@
         />
         <span class="visually-hidden">Navigate to home page.</span>
       </a>
-      <!-- <object
-      viewBox="0 0 100 100"
-      type="image/svg+xml"
-      data="/assets/small_logo.svg"
-      >
-      3D Print Log Logo
-    </object> -->
     </div>
     <div fxFlex fxFlexFill>
-      <div fxLayout="column" fxLayoutAlign="center start" style="height: 100%">
-        <div fxFlex fxLayout="row" fxLayoutAlign="center center">
-          @if (!auth.loggedIn) {
-            <a class="link" mat-button routerLink="/" routerLinkActive="active"
-              >Home</a
-            >
-          }
+      <!-- One copy of the links, wrapped onto a second line by CSS on narrow
+      screens. Rendering a separate mobile copy behind a matchMedia check used to
+      duplicate "About": matchMedia is always false while prerendering, so the
+      static HTML shipped the wide-screen links and the client then added the
+      narrow-screen copy on top of them. -->
+      <div class="nav-links">
+        @if (!auth.loggedIn) {
+          <a class="link" mat-button routerLink="/" routerLinkActive="active"
+            >Home</a
+          >
+        }
+        @if (auth.loggedIn) {
+          <a
+            mat-button
+            class="link"
+            routerLink="/prints"
+            routerLinkActive="active"
+            >Prints</a
+          >
+          <button mat-button class="link" [matMenuTriggerFor]="printerMenu">
+            Printers
+          </button>
+          <a
+            mat-button
+            class="link"
+            routerLink="/materials"
+            routerLinkActive="active"
+            >Materials</a
+          >
+          <a
+            mat-button
+            class="link"
+            routerLink="/analytics"
+            routerLinkActive="active"
+            >Analytics</a
+          >
+        }
+        <mat-menu #printerMenu="matMenu">
+          <a
+            class="menu-link"
+            mat-menu-item
+            routerLink="/printers"
+            routerLinkActive="active"
+            >Printers</a
+          >
+          <a
+            class="menu-link"
+            mat-menu-item
+            routerLink="/printer-maintenance"
+            routerLinkActive="active"
+            >Printer Maintenance</a
+          >
+        </mat-menu>
+        <button mat-button class="link" [matMenuTriggerFor]="aboutMenu">
+          About
+        </button>
+        <mat-menu #aboutMenu="matMenu">
+          <a
+            class="menu-link"
+            mat-menu-item
+            routerLink="/docs"
+            routerLinkActive="active"
+            >Documentation</a
+          >
           @if (auth.loggedIn) {
-            <a
-              mat-button
-              class="link"
-              routerLink="/prints"
-              routerLinkActive="active"
-              >Prints</a
-            >
-          }
-          @if (auth.loggedIn) {
-            <button mat-button class="link" [matMenuTriggerFor]="printerMenu">
-              Printers
-            </button>
-          }
-          <mat-menu #printerMenu="matMenu">
-            <!-- <button mat-menu-item>Fee</button> -->
             <a
               class="menu-link"
               mat-menu-item
-              routerLink="/printers"
+              routerLink="/feedback"
               routerLinkActive="active"
-              >Printers</a
-            >
-            <a
-              class="menu-link"
-              mat-menu-item
-              routerLink="/printer-maintenance"
-              routerLinkActive="active"
-              >Printer Maintenance</a
-            >
-          </mat-menu>
-          @if (auth.loggedIn) {
-            <a
-              mat-button
-              class="link"
-              routerLink="/materials"
-              routerLinkActive="active"
-              >Materials</a
+              >Send Feedback</a
             >
           }
-          @if (!this.mobileQuery.matches) {
-            @if (auth.loggedIn) {
-              <a
-                mat-button
-                class="link"
-                routerLink="/analytics"
-                routerLinkActive="active"
-                >Analytics</a
-              >
-            }
-            <button mat-button class="link" [matMenuTriggerFor]="aboutMenu">
-              About
-            </button>
-            <mat-menu #aboutMenu="matMenu">
-              <!-- <button mat-menu-item>Fee</button> -->
-              <a
-                class="menu-link"
-                mat-menu-item
-                routerLink="/docs"
-                routerLinkActive="active"
-                >Documentation</a
-              >
-              @if (auth.loggedIn) {
-                <a
-                  class="menu-link"
-                  mat-menu-item
-                  routerLink="/feedback"
-                  routerLinkActive="active"
-                  >Send Feedback</a
-                >
-              }
-              <a
-                class="menu-link"
-                mat-menu-item
-                routerLink="/docs/release-notes"
-                routerLinkActive="active"
-                >Version v{{ versionNumber }}</a
-              >
-            </mat-menu>
-            @if (auth.loggedIn && !isPro()) {
-              <a
-                mat-button
-                class="link upgrade-link"
-                routerLink="/subscription"
-                routerLinkActive="active"
-                matTooltip="Unlock Pro features"
-              >
-                <mat-icon>star</mat-icon>
-                Upgrade to Pro
-              </a>
-            }
-            @if (auth.loggedIn && isPro()) {
-              <span class="pro-badge" matTooltip="You're on the Pro plan">
-                <mat-icon>star</mat-icon> Pro
-              </span>
-            }
-          }
-        </div>
-        @if (this.mobileQuery.matches) {
-          <div fxFlex fxLayout="row" fxLayoutAlign="center center">
-            <ng-container>
-              @if (auth.loggedIn) {
-                <a
-                  mat-button
-                  class="link"
-                  routerLink="/analytics"
-                  routerLinkActive="active"
-                  >Analytics</a
-                >
-              }
-              <button mat-button class="link" [matMenuTriggerFor]="aboutMenu">
-                About
-              </button>
-              <mat-menu #aboutMenu="matMenu">
-                <!-- <button mat-menu-item>Fee</button> -->
-                <a
-                  class="menu-link"
-                  mat-menu-item
-                  routerLink="/docs"
-                  routerLinkActive="active"
-                  >Documentation</a
-                >
-                @if (auth.loggedIn) {
-                  <a
-                    class="menu-link"
-                    mat-menu-item
-                    routerLink="/feedback"
-                    routerLinkActive="active"
-                    >Send Feedback</a
-                  >
-                }
-                <a
-                  class="menu-link"
-                  mat-menu-item
-                  routerLink="/docs/release-notes"
-                  routerLinkActive="active"
-                  >Version v{{ versionNumber }}</a
-                >
-              </mat-menu>
-              @if (auth.loggedIn && !isPro()) {
-                <a
-                  mat-button
-                  class="link upgrade-link"
-                  routerLink="/subscription"
-                  routerLinkActive="active"
-                  matTooltip="Unlock Pro features"
-                >
-                  <mat-icon>star</mat-icon>
-                  Upgrade to Pro
-                </a>
-              }
-              @if (auth.loggedIn && isPro()) {
-                <span class="pro-badge" matTooltip="You're on the Pro plan">
-                  <mat-icon>star</mat-icon> Pro
-                </span>
-              }
-            </ng-container>
-          </div>
+          <a
+            class="menu-link"
+            mat-menu-item
+            routerLink="/docs/release-notes"
+            routerLinkActive="active"
+            >Version v{{ versionNumber }}</a
+          >
+        </mat-menu>
+        @if (auth.loggedIn && !isPro()) {
+          <a
+            mat-button
+            class="link upgrade-link"
+            routerLink="/subscription"
+            routerLinkActive="active"
+            matTooltip="Unlock Pro features"
+          >
+            <mat-icon>star</mat-icon>
+            Upgrade to Pro
+          </a>
+        }
+        @if (auth.loggedIn && isPro()) {
+          <span class="pro-badge" matTooltip="You're on the Pro plan">
+            <mat-icon>star</mat-icon> Pro
+          </span>
         }
       </div>
     </div>
@@ -254,4 +179,3 @@
     </div>
   </mat-toolbar-row>
 </mat-toolbar>
-<ng-template #links> </ng-template>

--- a/src/app/shared/navbar/navbar.component.scss
+++ b/src/app/shared/navbar/navbar.component.scss
@@ -55,6 +55,16 @@
   }
 }
 
+// Links live in a single wrapping row: everything fits one line on a wide
+// screen, and the tail wraps onto a second line once the toolbar gets narrow.
+.nav-links {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+}
+
 a:not([mat-menu-item]) {
   text-decoration: none;
   color: white;
@@ -99,6 +109,22 @@ mat-toolbar {
 @media (max-width: 450px) {
   .link {
     height: 28px;
+    // Tighter than Material's default so the whole set still fits two rows.
+    padding: 0 6px;
+    min-width: 0;
+  }
+
+  // Let the row grow with the wrapped links instead of clipping them.
+  mat-toolbar-row {
+    height: auto;
+    min-height: 56px;
+    padding-top: 4px;
+    padding-bottom: 4px;
+  }
+
+  .pro-badge {
+    font-size: 13px;
+    padding: 0 4px;
   }
 }
 

--- a/src/app/shared/navbar/navbar.component.spec.ts
+++ b/src/app/shared/navbar/navbar.component.spec.ts
@@ -38,4 +38,21 @@ describe('NavbarComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  // The navbar used to render a second copy of the links for narrow screens
+  // behind a matchMedia check. matchMedia is always false while prerendering, so
+  // the static HTML shipped the wide-screen links and the client added the
+  // narrow-screen copy on top, leaving two "About" buttons - the prerendered one
+  // dead to clicks. There is only ever one copy now.
+  it('renders a single About menu trigger', () => {
+    const aboutTriggers = (
+      fixture.nativeElement as HTMLElement
+    ).querySelectorAll('button.mat-mdc-menu-trigger');
+
+    const aboutButtons = Array.from(aboutTriggers).filter((button) =>
+      button.textContent?.trim().startsWith('About')
+    );
+
+    expect(aboutButtons.length).toBe(1);
+  });
 });

--- a/src/app/shared/navbar/navbar.component.ts
+++ b/src/app/shared/navbar/navbar.component.ts
@@ -1,12 +1,4 @@
-import { MediaMatcher } from '@angular/cdk/layout';
-import {
-  ChangeDetectorRef,
-  Component,
-  NgZone,
-  OnDestroy,
-  OnInit,
-  inject,
-} from '@angular/core';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { RouterModule } from '@angular/router';
 import { MatToolbarModule } from '@angular/material/toolbar';
@@ -44,18 +36,10 @@ export class NavbarComponent implements OnInit, OnDestroy {
 
   public isUserProfileFeatureEnabled = environment.features.userProfile;
 
-  mobileQuery: MediaQueryList;
-  private mobileQueryListener: () => void;
-
   private readonly subscriptionService = inject(SubscriptionService);
   readonly isPro = this.subscriptionService.isPro;
 
-  constructor(
-    public auth: AuthService,
-    private media: MediaMatcher,
-    private changeDetectorRef: ChangeDetectorRef,
-    private ngZone: NgZone
-  ) {}
+  constructor(public auth: AuthService) {}
 
   ngOnInit() {
     this.userProfileSubscription = this.auth.userProfile$.subscribe((user) => {
@@ -67,23 +51,9 @@ export class NavbarComponent implements OnInit, OnDestroy {
         this.userId = null;
       }
     });
-
-    this.setupMobileListener();
-  }
-  setupMobileListener() {
-    this.mobileQuery = this.media.matchMedia('(max-width: 450px)');
-
-    this.mobileQueryListener = () => {
-      this.ngZone.run(() => {
-        this.changeDetectorRef.detectChanges();
-      });
-    };
-    this.mobileQuery.addListener(this.mobileQueryListener);
   }
 
   ngOnDestroy(): void {
-    this.mobileQuery.removeListener(this.mobileQueryListener);
-
     if (this.userProfileSubscription) {
       this.userProfileSubscription.unsubscribe();
     }


### PR DESCRIPTION
@
## The bug

At mobile widths the top navbar sometimes shows two **About** entries. The upper one does nothing when clicked; the lower one opens the menu as expected.

## Cause

The navbar kept **two copies of the link list** and picked between them with `mobileQuery.matches` (`MediaMatcher`, `max-width: 450px`):

- `@if (!mobileQuery.matches)` — Analytics / About / Pro on the wide-screen row
- `@if (mobileQuery.matches)` — the same three on a second row

`matchMedia` is always `false` during prerendering, so the static HTML for the marketing routes ships the wide-screen copy. Confirmed in production output:

```
curl -s https://www.3dprintlog.com/ | grep -o app-navbar.*app-navbar
... <span class="mdc-button__label"> About </span> ...
```

On a narrow client, hydration leaves that prerendered button behind while the mobile copy renders alongside it — hence two Abouts, and the prerendered one has no click handler attached.

## Fix

One copy of the links, wrapped onto a second line by CSS on narrow screens:

- Deleted the duplicated markup and the second `#aboutMenu` template ref.
- `.nav-links` is a `flex-wrap: wrap` row: everything sits on one line on a wide screen, the tail wraps below 450px.
- Under 450px the toolbar row is `height: auto; min-height: 56px` so wrapped links grow the row instead of being clipped, and `.link` padding is tightened so the signed-in set still fits two rows.
- Removed the now-unused `MediaMatcher` / `NgZone` / `ChangeDetectorRef` plumbing and the dead `<ng-template #links>`.

Because the layout no longer branches on a browser-only API, the prerendered HTML and the client render agree at every width.

## Verification

- `npm run test:brief` — 1244 SUCCESS, including a new spec pinning a single About trigger.
- `npm run lint:brief` — clean.
- Checked in the browser at a 430px viewport: one row, one About, 58px toolbar, no leftover button.
@