### PR TITLE
fix(parsers): estimate Nylon filament usage

### DIFF
--- a/src/app/core/services/file-parsers/anycubic/anycubic-file-parser.service.spec.ts
+++ b/src/app/core/services/file-parsers/anycubic/anycubic-file-parser.service.spec.ts
@@ -64,4 +64,13 @@ describe('AnycubicFileParserService filament estimates', () => {
       expect(service.estimateFilamentUsageInMg(gcode)).toBeUndefined();
     });
   });
+
+  it('should estimate Nylon using its configured density', () => {
+    const testGcode = `; total filament used [g] = 0.0
+; filament_type = Nylon
+; filament_diameter = 1.75
+; filament used [mm] = 1000`;
+
+    expect(service.estimateFilamentUsageInMg(testGcode)).toBe(2549);
+  });
 });

--- a/src/app/core/services/file-parsers/anycubic/anycubic-file-parser.service.ts
+++ b/src/app/core/services/file-parsers/anycubic/anycubic-file-parser.service.ts
@@ -133,11 +133,15 @@ export class AnycubicFileParserService implements GcodeNewPrintParser {
         filamentUsageLengthInMM,
         filamentDiameter
       );
+    } else if (filamentType.includes('Nylon')) {
+      return this.calculateWeightInMg(
+        MaterialDensities.materials.Nylon,
+        filamentUsageLengthInMM,
+        filamentDiameter
+      );
     }
 
-    // Only PLA, ABS and PETG are handled above, so anything else is unknown
-    // rather than zero. Note MaterialDensities also declares Nylon, which this
-    // chain never reaches -- see #100.
+    // Unknown materials are not estimated rather than being reported as zero.
     return undefined;
   }
 

--- a/src/app/core/services/file-parsers/creality-print/creality-print-file-parser.service.spec.ts
+++ b/src/app/core/services/file-parsers/creality-print/creality-print-file-parser.service.spec.ts
@@ -59,6 +59,15 @@ Adaptive Layers:0`);
   });
 
   describe('estimateFilamentUsageInMg', () => {
+    it('should estimate Nylon using its configured density', () => {
+      const testGcode = `;Filament used: 0.0
+; filament_type: Nylon
+; filament_diameter: 1.75
+; filament used [mm]: 1000`;
+
+      expect(service.estimateFilamentUsageInMg(testGcode)).toBe(2549);
+    });
+
     it('should return undefined when diameter or length is missing or zero', () => {
       const invalidInputs = [
         `; filament_type = PLA

--- a/src/app/core/services/file-parsers/creality-print/creality-print-file-parser.service.ts
+++ b/src/app/core/services/file-parsers/creality-print/creality-print-file-parser.service.ts
@@ -133,11 +133,15 @@ export class CrealityPrintFileParserService implements GcodeNewPrintParser {
         filamentUsageLengthInMM,
         filamentDiameter
       );
+    } else if (filamentType.includes('Nylon')) {
+      return this.calculateWeightInMg(
+        MaterialDensities.materials.Nylon,
+        filamentUsageLengthInMM,
+        filamentDiameter
+      );
     }
 
-    // Only PLA, ABS and PETG are handled above, so anything else is unknown
-    // rather than zero. Note MaterialDensities also declares Nylon, which this
-    // chain never reaches -- see #100.
+    // Unknown materials are not estimated rather than being reported as zero.
     return undefined;
   }
 

--- a/src/app/core/services/file-parsers/orca/orca-file-parser.service.spec.ts
+++ b/src/app/core/services/file-parsers/orca/orca-file-parser.service.spec.ts
@@ -38,6 +38,15 @@ describe('OrcaFileParserService', () => {
   });
 
   describe('estimateFilamentUsageInMg', () => {
+    it('should estimate Nylon using its configured density', () => {
+      const testGcode = `; total filament used [g] = 0.0
+; filament_type = Nylon
+; filament_diameter = 1.75
+; filament used [mm] = 1000`;
+
+      expect(service.estimateFilamentUsageInMg(testGcode)).toBe(2549);
+    });
+
     it('should return undefined when diameter or length is missing or zero', () => {
       const invalidInputs = [
         `; filament_type = PLA

--- a/src/app/core/services/file-parsers/orca/orca-file-parser.service.ts
+++ b/src/app/core/services/file-parsers/orca/orca-file-parser.service.ts
@@ -89,11 +89,15 @@ export class OrcaFileParserService implements GcodeNewPrintParser {
         filamentUsageLengthInMM,
         filamentDiameter
       );
+    } else if (filamentType.includes('Nylon')) {
+      return this.calculateWeightInMg(
+        MaterialDensities.materials.Nylon,
+        filamentUsageLengthInMM,
+        filamentDiameter
+      );
     }
 
-    // Only PLA, ABS and PETG are handled above, so anything else is unknown
-    // rather than zero. Note MaterialDensities also declares Nylon, which this
-    // chain never reaches -- see #100.
+    // Unknown materials are not estimated rather than being reported as zero.
     return undefined;
   }
 

--- a/src/app/core/services/file-parsers/prusa/prusa-slicer-file-parser.service.spec.ts
+++ b/src/app/core/services/file-parsers/prusa/prusa-slicer-file-parser.service.spec.ts
@@ -61,16 +61,13 @@ describe('PrusaSlicerFileParserService', () => {
       expect(service.estimateFilamentUsageInMg(testGcode)).toBeUndefined();
     });
 
-    // Characterizes existing behavior that is WRONG: a Nylon density is declared
-    // in MaterialDensities but the material chain never branches on it, so a
-    // valid Nylon file loses its estimate. Tracked in #100.
-    it('should currently return undefined for Nylon despite having its density', () => {
+    it('should estimate Nylon using its configured density', () => {
       const testGcode = `; total filament used [g] = 0.0
 ; filament_type = Nylon
 ; filament_diameter = 1.75
 ; filament used [mm] = 1000`;
 
-      expect(service.estimateFilamentUsageInMg(testGcode)).toBeUndefined();
+      expect(service.estimateFilamentUsageInMg(testGcode)).toBe(2549);
     });
 
     it('should return undefined when the diameter is missing', () => {

--- a/src/app/core/services/file-parsers/prusa/prusa-slicer-file-parser.service.ts
+++ b/src/app/core/services/file-parsers/prusa/prusa-slicer-file-parser.service.ts
@@ -89,11 +89,15 @@ export class PrusaSlicerFileParserService implements GcodeNewPrintParser {
         filamentUsageLengthInMM,
         filamentDiameter
       );
+    } else if (filamentType.includes('Nylon')) {
+      return this.calculateWeightInMg(
+        MaterialDensities.materials.Nylon,
+        filamentUsageLengthInMM,
+        filamentDiameter
+      );
     }
 
-    // Only PLA, ABS and PETG are handled above, so anything else is unknown
-    // rather than zero. Note MaterialDensities also declares Nylon, which this
-    // chain never reaches -- see #100.
+    // Unknown materials are not estimated rather than being reported as zero.
     return undefined;
   }
 


### PR DESCRIPTION
## What does this PR do?
Adds the missing Nylon material branch to the PrusaSlicer, OrcaSlicer, Creality Print, and Anycubic filament estimators. Adds regression coverage confirming Nylon uses density 1.06 and unsupported materials remain unestimated.

Closes #100

## How to test
- `CHROME_BIN=/snap/bin/chromium npx ng test --no-watch --browsers ChromeHeadless --include="src/app/core/services/file-parsers/**/*spec.ts"`
- `npm run lint:brief`
- `npm run typecheck:strict`
- `npm run test:scripts`
- `npm run build:dev`

## Checklist
- [x] Tested locally
- [x] Existing tests pass
- [x] Added tests for the change
- [ ] Screenshot not applicable
- [x] No secrets or credentials added