### PR TITLE
fix(navbar): left-justify links and give the mobile toolbar a fixed height

### DIFF
--- a/src/app/analytics/filters/analytics-filter-bar.component.scss
+++ b/src/app/analytics/filters/analytics-filter-bar.component.scss
@@ -55,7 +55,10 @@
   }
 }
 
-@media (max-width: 600px) {
+// 599px, not 600px: the navbar drops to 56px at max-width 599px, so at exactly
+// 600px this bar would offset by 56px while the navbar was still 64px tall and
+// tuck 8px of itself underneath it.
+@media (max-width: 599px) {
   .analytics-filter-bar {
     inset-block-start: 56px;
   }

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -11,7 +11,7 @@
   right: 0;
 }
 
-@media (max-width: 600px) {
+@media (max-width: 599px) {
   .main-app {
     top: 56px;
   }

--- a/src/app/shared/navbar/navbar.component.html
+++ b/src/app/shared/navbar/navbar.component.html
@@ -1,6 +1,21 @@
 <mat-toolbar color="primary">
-  <mat-toolbar-row fxLayout="row" fxLayoutAlign="space-between center">
-    <div fxFlex="50px" class="brand-img">
+  <mat-toolbar-row class="nav-row">
+    <!-- Narrow screens collapse the whole link set into this one trigger. The
+    collapsed copy lives inside <mat-menu>, whose content is an ng-template that
+    Material only stamps out on open - so it never reaches the prerendered HTML
+    and cannot duplicate the links the way the old matchMedia split did. Which
+    of the two is reachable is decided purely in CSS, so prerender and client
+    agree. -->
+    <button
+      class="nav-menu-trigger link"
+      mat-icon-button
+      [matMenuTriggerFor]="mobileMenu"
+      aria-label="Open navigation menu"
+    >
+      <mat-icon>menu</mat-icon>
+    </button>
+
+    <div class="brand-img">
       <a [routerLink]="['/']" style="height: 100%; width: 100%">
         <img
           src="/assets/3d_brand_logo_b833b3f20dd.svg"
@@ -9,113 +24,68 @@
         <span class="visually-hidden">Navigate to home page.</span>
       </a>
     </div>
-    <div fxFlex fxFlexFill>
-      <!-- One copy of the links, wrapped onto a second line by CSS on narrow
-      screens. Rendering a separate mobile copy behind a matchMedia check used to
-      duplicate "About": matchMedia is always false while prerendering, so the
-      static HTML shipped the wide-screen links and the client then added the
-      narrow-screen copy on top of them. -->
-      <div class="nav-links">
-        @if (!auth.loggedIn) {
-          <a class="link" mat-button routerLink="/" routerLinkActive="active"
-            >Home</a
-          >
-        }
-        @if (auth.loggedIn) {
-          <a
-            mat-button
-            class="link"
-            routerLink="/prints"
-            routerLinkActive="active"
-            >Prints</a
-          >
-          <button mat-button class="link" [matMenuTriggerFor]="printerMenu">
-            Printers
-          </button>
-          <a
-            mat-button
-            class="link"
-            routerLink="/materials"
-            routerLinkActive="active"
-            >Materials</a
-          >
-          <a
-            mat-button
-            class="link"
-            routerLink="/analytics"
-            routerLinkActive="active"
-            >Analytics</a
-          >
-        }
-        <mat-menu #printerMenu="matMenu">
-          <a
-            class="menu-link"
-            mat-menu-item
-            routerLink="/printers"
-            routerLinkActive="active"
-            >Printers</a
-          >
-          <a
-            class="menu-link"
-            mat-menu-item
-            routerLink="/printer-maintenance"
-            routerLinkActive="active"
-            >Printer Maintenance</a
-          >
-        </mat-menu>
-        <button mat-button class="link" [matMenuTriggerFor]="aboutMenu">
-          About
+
+    <div class="nav-links">
+      @if (!auth.loggedIn) {
+        <a class="link" mat-button routerLink="/" routerLinkActive="active"
+          >Home</a
+        >
+      }
+      @if (auth.loggedIn) {
+        <a
+          mat-button
+          class="link"
+          routerLink="/prints"
+          routerLinkActive="active"
+          >Prints</a
+        >
+        <button mat-button class="link" [matMenuTriggerFor]="printerMenu">
+          Printers
         </button>
-        <mat-menu #aboutMenu="matMenu">
-          <a
-            class="menu-link"
-            mat-menu-item
-            routerLink="/docs"
-            routerLinkActive="active"
-            >Documentation</a
-          >
-          @if (auth.loggedIn) {
-            <a
-              class="menu-link"
-              mat-menu-item
-              routerLink="/feedback"
-              routerLinkActive="active"
-              >Send Feedback</a
-            >
-          }
-          <a
-            class="menu-link"
-            mat-menu-item
-            routerLink="/docs/release-notes"
-            routerLinkActive="active"
-            >Version v{{ versionNumber }}</a
-          >
-        </mat-menu>
-        @if (auth.loggedIn && !isPro()) {
-          <a
-            mat-button
-            class="link upgrade-link"
-            routerLink="/subscription"
-            routerLinkActive="active"
-            matTooltip="Unlock Pro features"
-          >
-            <mat-icon>star</mat-icon>
-            Upgrade to Pro
-          </a>
-        }
-        @if (auth.loggedIn && isPro()) {
-          <span class="pro-badge" matTooltip="You're on the Pro plan">
-            <mat-icon>star</mat-icon> Pro
-          </span>
-        }
-      </div>
+        <a
+          mat-button
+          class="link"
+          routerLink="/materials"
+          routerLinkActive="active"
+          >Materials</a
+        >
+        <a
+          mat-button
+          class="link"
+          routerLink="/analytics"
+          routerLinkActive="active"
+          >Analytics</a
+        >
+      }
+      <button mat-button class="link" [matMenuTriggerFor]="aboutMenu">
+        About
+      </button>
+      @if (auth.loggedIn && !isPro()) {
+        <a
+          mat-button
+          class="link upgrade-link"
+          routerLink="/subscription"
+          routerLinkActive="active"
+          matTooltip="Unlock Pro features"
+        >
+          <mat-icon>star</mat-icon>
+          Upgrade to Pro
+        </a>
+      }
+      @if (auth.loggedIn && isPro()) {
+        <span class="pro-badge" matTooltip="You're on the Pro plan">
+          <mat-icon>star</mat-icon> Pro
+        </span>
+      }
     </div>
+
+    <span class="nav-spacer"></span>
+
     @if (auth.loggedIn) {
-      <div fxFlex="50px" fxLayoutAlign="center center">
-        <app-notification-bell></app-notification-bell>
-      </div>
+      <app-notification-bell></app-notification-bell>
     }
-    <div [fxFlex]="auth.loggedIn ? '50px' : '200px'">
+
+    <div class="nav-account">
       @if (auth.loggedIn) {
         <button class="transparent" [matMenuTriggerFor]="profileMenu">
           @if (profilePictureUrl) {
@@ -134,38 +104,6 @@
           }
         </button>
       }
-      <mat-menu #profileMenu="matMenu">
-        @if (auth.loggedIn && isUserProfileFeatureEnabled) {
-          <a
-            class="menu-link"
-            mat-menu-item
-            [routerLink]="['users', userId]"
-            routerLinkActive="active"
-            >My Profile</a
-          >
-        }
-        @if (auth.loggedIn) {
-          <a
-            class="menu-link"
-            mat-menu-item
-            [routerLink]="['/settings']"
-            routerLinkActive="active"
-            >Settings</a
-          >
-        }
-        @if (auth.loggedIn) {
-          <a
-            class="menu-link"
-            mat-menu-item
-            [routerLink]="['/api-keys']"
-            routerLinkActive="active"
-            >Personal Api Keys</a
-          >
-        }
-        @if (auth.loggedIn) {
-          <button mat-menu-item (click)="auth.logout()">Log Out</button>
-        }
-      </mat-menu>
       @if (!auth.loggedIn) {
         <button
           id="loginButton"
@@ -179,3 +117,127 @@
     </div>
   </mat-toolbar-row>
 </mat-toolbar>
+
+<!-- The narrow-screen copy of the link row. printerMenu and aboutMenu are shared
+with the wide-screen buttons above; only one trigger set is ever visible, so a
+single instance of each submenu is enough. -->
+<mat-menu #mobileMenu="matMenu">
+  @if (!auth.loggedIn) {
+    <a class="menu-link" mat-menu-item routerLink="/" routerLinkActive="active"
+      >Home</a
+    >
+  }
+  @if (auth.loggedIn) {
+    <a
+      class="menu-link"
+      mat-menu-item
+      routerLink="/prints"
+      routerLinkActive="active"
+      >Prints</a
+    >
+    <button mat-menu-item [matMenuTriggerFor]="printerMenu">Printers</button>
+    <a
+      class="menu-link"
+      mat-menu-item
+      routerLink="/materials"
+      routerLinkActive="active"
+      >Materials</a
+    >
+    <a
+      class="menu-link"
+      mat-menu-item
+      routerLink="/analytics"
+      routerLinkActive="active"
+      >Analytics</a
+    >
+  }
+  <button mat-menu-item [matMenuTriggerFor]="aboutMenu">About</button>
+  @if (auth.loggedIn && !isPro()) {
+    <a
+      class="menu-link upgrade-link"
+      mat-menu-item
+      routerLink="/subscription"
+      routerLinkActive="active"
+    >
+      <mat-icon>star</mat-icon>
+      Upgrade to Pro
+    </a>
+  }
+  @if (auth.loggedIn && isPro()) {
+    <span class="pro-badge menu-pro-badge">
+      <mat-icon>star</mat-icon> Pro
+    </span>
+  }
+</mat-menu>
+
+<mat-menu #printerMenu="matMenu">
+  <a
+    class="menu-link"
+    mat-menu-item
+    routerLink="/printers"
+    routerLinkActive="active"
+    >Printers</a
+  >
+  <a
+    class="menu-link"
+    mat-menu-item
+    routerLink="/printer-maintenance"
+    routerLinkActive="active"
+    >Printer Maintenance</a
+  >
+</mat-menu>
+
+<mat-menu #aboutMenu="matMenu">
+  <a
+    class="menu-link"
+    mat-menu-item
+    routerLink="/docs"
+    routerLinkActive="active"
+    >Documentation</a
+  >
+  @if (auth.loggedIn) {
+    <a
+      class="menu-link"
+      mat-menu-item
+      routerLink="/feedback"
+      routerLinkActive="active"
+      >Send Feedback</a
+    >
+  }
+  <a
+    class="menu-link"
+    mat-menu-item
+    routerLink="/docs/release-notes"
+    routerLinkActive="active"
+    >Version v{{ versionNumber }}</a
+  >
+</mat-menu>
+
+<mat-menu #profileMenu="matMenu">
+  @if (auth.loggedIn && isUserProfileFeatureEnabled) {
+    <a
+      class="menu-link"
+      mat-menu-item
+      [routerLink]="['users', userId]"
+      routerLinkActive="active"
+      >My Profile</a
+    >
+  }
+  @if (auth.loggedIn) {
+    <a
+      class="menu-link"
+      mat-menu-item
+      [routerLink]="['/settings']"
+      routerLinkActive="active"
+      >Settings</a
+    >
+    <a
+      class="menu-link"
+      mat-menu-item
+      [routerLink]="['/api-keys']"
+      routerLinkActive="active"
+      >Personal Api Keys</a
+    >
+    <button mat-menu-item (click)="auth.logout()">Log Out</button>
+  }
+</mat-menu>

--- a/src/app/shared/navbar/navbar.component.html
+++ b/src/app/shared/navbar/navbar.component.html
@@ -60,26 +60,34 @@
       <button mat-button class="link" [matMenuTriggerFor]="aboutMenu">
         About
       </button>
-      @if (auth.loggedIn && !isPro()) {
-        <a
-          mat-button
-          class="link upgrade-link"
-          routerLink="/subscription"
-          routerLinkActive="active"
-          matTooltip="Unlock Pro features"
-        >
-          <mat-icon>star</mat-icon>
-          Upgrade to Pro
-        </a>
-      }
-      @if (auth.loggedIn && isPro()) {
-        <span class="pro-badge" matTooltip="You're on the Pro plan">
-          <mat-icon>star</mat-icon> Pro
-        </span>
-      }
     </div>
 
     <span class="nav-spacer"></span>
+
+    <!-- Deliberately outside .nav-links, so it survives the narrow-screen
+    collapse instead of being buried in the menu. The gold reads at ~8:1 on the
+    indigo toolbar but only ~1.5:1 on the menu's light surface, and it is the
+    one item worth keeping one tap away. Below the breakpoint the label is
+    dropped and the star carries it. -->
+    @if (auth.loggedIn && !isPro()) {
+      <a
+        mat-button
+        class="link upgrade-link"
+        routerLink="/subscription"
+        routerLinkActive="active"
+        matTooltip="Unlock Pro features"
+        aria-label="Upgrade to Pro"
+      >
+        <mat-icon>star</mat-icon>
+        <span class="upgrade-label">Upgrade to Pro</span>
+      </a>
+    }
+    @if (auth.loggedIn && isPro()) {
+      <span class="pro-badge" matTooltip="You're on the Pro plan">
+        <mat-icon>star</mat-icon>
+        <span class="upgrade-label">Pro</span>
+      </span>
+    }
 
     @if (auth.loggedIn) {
       <app-notification-bell></app-notification-bell>
@@ -152,22 +160,6 @@ single instance of each submenu is enough. -->
     >
   }
   <button mat-menu-item [matMenuTriggerFor]="aboutMenu">About</button>
-  @if (auth.loggedIn && !isPro()) {
-    <a
-      class="menu-link upgrade-link"
-      mat-menu-item
-      routerLink="/subscription"
-      routerLinkActive="active"
-    >
-      <mat-icon>star</mat-icon>
-      Upgrade to Pro
-    </a>
-  }
-  @if (auth.loggedIn && isPro()) {
-    <span class="pro-badge menu-pro-badge">
-      <mat-icon>star</mat-icon> Pro
-    </span>
-  }
 </mat-menu>
 
 <mat-menu #printerMenu="matMenu">

--- a/src/app/shared/navbar/navbar.component.scss
+++ b/src/app/shared/navbar/navbar.component.scss
@@ -55,14 +55,56 @@
   }
 }
 
-// Links live in a single wrapping row: everything fits one line on a wide
-// screen, and the tail wraps onto a second line once the toolbar gets narrow.
+// The toolbar height is load-bearing: app.component.scss, styles.scss and the
+// analytics filter bar all offset content by a hard-coded 64px / 56px. So the
+// link row must never wrap or grow the row. It stays a single nowrap line, and
+// in the narrow band between the mobile breakpoint and a comfortable desktop
+// width it scrolls sideways rather than pushing the bell and avatar off-screen.
+.nav-row {
+  gap: 4px;
+}
+
 .nav-links {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   height: 100%;
+  min-width: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+
+  .link {
+    flex: 0 0 auto;
+  }
+}
+
+// Pushes the notification bell and avatar to the trailing edge now that the
+// links are left-justified.
+.nav-spacer {
+  flex: 1 1 auto;
+}
+
+.nav-account {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+}
+
+// Hidden above the mobile breakpoint; the wide-screen link row serves instead.
+.nav-menu-trigger {
+  display: none;
+  flex: 0 0 auto;
+  color: white;
+}
+
+.menu-pro-badge {
+  padding: 8px 16px;
 }
 
 a:not([mat-menu-item]) {
@@ -100,31 +142,49 @@ mat-toolbar {
   background-color: var(--brand-toolbar-bg);
 }
 
+// Pin the row to the heights the rest of the app offsets content by. Material
+// already defaults to these, but spelling them out stops a tall child (the 50px
+// avatar, a wrapped label) from stretching the row.
+mat-toolbar,
+mat-toolbar-row {
+  height: 64px;
+  min-height: 64px;
+  max-height: 64px;
+}
+
 @media (max-width: 959px) {
   mat-toolbar {
     border-radius: 0px;
   }
 }
 
-@media (max-width: 450px) {
-  .link {
-    height: 28px;
-    // Tighter than Material's default so the whole set still fits two rows.
-    padding: 0 6px;
-    min-width: 0;
-  }
-
-  // Let the row grow with the wrapped links instead of clipping them.
+@media (max-width: 599px) {
+  mat-toolbar,
   mat-toolbar-row {
-    height: auto;
+    height: 56px;
     min-height: 56px;
-    padding-top: 4px;
-    padding-bottom: 4px;
+    max-height: 56px;
   }
 
-  .pro-badge {
-    font-size: 13px;
-    padding: 0 4px;
+  // Swap the inline link row for the single menu trigger.
+  .nav-links {
+    display: none;
+  }
+
+  .nav-menu-trigger {
+    display: inline-flex;
+  }
+
+  // 50px of chrome on each side is a lot of a 56px row; trim to 40px so the
+  // brand and avatar sit comfortably inside it.
+  .brand-img {
+    height: 40px;
+    width: 40px;
+  }
+
+  .profile-picture {
+    width: 40px;
+    height: 40px;
   }
 }
 

--- a/src/app/shared/navbar/navbar.component.scss
+++ b/src/app/shared/navbar/navbar.component.scss
@@ -3,6 +3,13 @@
   height: 50px;
   width: 50px;
   border-radius: 50%;
+  // Must not shrink. The ring is a box-shadow on this box while the image
+  // inside is height: auto, so any narrowing pulls the ring into an oval that
+  // no longer traces the logo. fxFlex="50px" used to pin this via min/max-width;
+  // as a plain flex child it would inherit flex-shrink: 1 and squash in the
+  // band between the mobile breakpoint and a comfortable desktop width.
+  flex: 0 0 50px;
+  box-sizing: border-box;
 
   box-shadow: 0 0 0 1px #292f77;
 
@@ -17,7 +24,7 @@
 
   img {
     width: 100%;
-    height: auto;
+    height: 100%;
   }
 
   img:hover {
@@ -90,6 +97,10 @@
   flex: 1 1 auto;
 }
 
+app-notification-bell {
+  flex: 0 0 auto;
+}
+
 .nav-account {
   display: flex;
   align-items: center;
@@ -101,10 +112,6 @@
   display: none;
   flex: 0 0 auto;
   color: white;
-}
-
-.menu-pro-badge {
-  padding: 8px 16px;
 }
 
 a:not([mat-menu-item]) {
@@ -180,12 +187,34 @@ mat-toolbar-row {
   .brand-img {
     height: 40px;
     width: 40px;
+    flex-basis: 40px;
   }
 
   .profile-picture {
     width: 40px;
     height: 40px;
   }
+
+  // The CTA stays in the toolbar at every width, but a 56px row has no space
+  // for its label - the star plus the tooltip/aria-label carry it instead.
+  .upgrade-label {
+    display: none;
+  }
+
+  .upgrade-link,
+  .pro-badge {
+    min-width: 0;
+    padding: 0 8px;
+
+    mat-icon {
+      margin-right: 0;
+    }
+  }
+}
+
+.upgrade-link,
+.pro-badge {
+  flex: 0 0 auto;
 }
 
 .upgrade-link {

--- a/src/app/shared/navbar/navbar.component.spec.ts
+++ b/src/app/shared/navbar/navbar.component.spec.ts
@@ -55,4 +55,27 @@ describe('NavbarComponent', () => {
 
     expect(aboutButtons.length).toBe(1);
   });
+
+  // The narrow-screen link set lives inside <mat-menu>, whose content Material
+  // only stamps out when the menu opens. So the collapsed copy costs nothing in
+  // the prerendered HTML and cannot re-introduce the duplicate-links bug above.
+  it('renders the collapsed-nav trigger without stamping its menu content', () => {
+    const host = fixture.nativeElement as HTMLElement;
+
+    expect(host.querySelectorAll('.nav-menu-trigger').length).toBe(1);
+    expect(host.textContent).not.toContain('Documentation');
+  });
+
+  // app.component.scss, styles.scss and the analytics filter bar all offset
+  // content by a hard-coded toolbar height, so the row must never wrap or grow.
+  it('keeps the link row on a single line', () => {
+    const navLinks = (fixture.nativeElement as HTMLElement).querySelector(
+      '.nav-links'
+    ) as HTMLElement;
+
+    const styles = getComputedStyle(navLinks);
+
+    expect(styles.flexWrap).toBe('nowrap');
+    expect(styles.justifyContent).toBe('flex-start');
+  });
 });

--- a/src/app/shared/navbar/navbar.component.ts
+++ b/src/app/shared/navbar/navbar.component.ts
@@ -6,7 +6,6 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
-import { FlexLayoutModule } from '@ngbracket/ngx-layout';
 import { AuthService } from 'src/app/core/services/auth.service';
 import { SubscriptionService } from 'src/app/core/services/subscription.service';
 import { environment } from 'src/environments/environment';
@@ -23,7 +22,6 @@ import { NotificationBellComponent } from '../notification-bell/notification-bel
     MatMenuModule,
     MatIconModule,
     MatTooltipModule,
-    FlexLayoutModule,
     NotificationBellComponent,
   ],
 })


### PR DESCRIPTION
## Problem

The navbar links drifted to the center, and on mobile the row wrapped and pushed content around.

Both came from e104460 (PR #123), which replaced the flex-layout markup with a single `.nav-links` container:

- It carries `justify-content: center`. The old markup nested `fxLayoutAlign="center center"` inside a column with `align-items: start`, so the row was content-sized and the centering was inert. `.nav-links` is a full-width flex row, so it started to actually bite.
- It let the links wrap and set `mat-toolbar-row { height: auto }` below 450px. But the toolbar height is load-bearing — `app.component.scss:8`, `styles.scss:226`/`241`, and `analytics-filter-bar.component.scss:6` all offset content by a hard-coded 64px / 56px — so the wrapped second row slid underneath the content.

## Changes

**Justification.** `.nav-links` is `flex-start`, with a `.nav-spacer` pushing the bell and avatar to the trailing edge.

**Fixed height.** `mat-toolbar-row` is pinned (`height`/`min-height`/`max-height`) at 64px, and 56px below the breakpoint, so a tall child can't stretch it again. `.nav-links` is `nowrap`.

**Mobile nav.** Below 599px the link set collapses into a single menu trigger left of the logo. The collapsed copy lives inside `<mat-menu>`, whose content Material only stamps out on open — so it never reaches the prerendered HTML and can't reintroduce the duplicate-`About` bug #123 was fixing. Which set is reachable is decided purely in CSS, so prerender and client agree. `printerMenu`/`aboutMenu` are shared between both trigger sets as nested submenus.

**Pro CTA stays visible.** "Upgrade to Pro" first went into the collapsed menu, reusing `.upgrade-link` — whose gold (`#ffd740`, `!important`) was written for the dark indigo toolbar and lands at roughly **1.5:1** on the menu's light surface, well under the 4.5:1 minimum. It now lives outside `.nav-links` beside the avatar, so it survives the collapse rather than being buried a tap deep. Below the breakpoint the label drops and the star carries it, with the tooltip plus a new `aria-label`.

**Brand mark.** `fxFlex="50px"` used to pin it via min/max-width. As a plain flex child it inherited `flex-shrink: 1`, so between the breakpoint and a comfortable desktop width the box narrowed while its height stayed — and since the ring is a `box-shadow` on that box and the image was `height: auto`, the ring went oval around a smaller logo. Pinned to `flex: 0 0 50px`. The bell is pinned the same way, leaving `.nav-links` as the only element that absorbs overflow, which is what its scroller is for.

**Breakpoints.** Standardized on 599px, matching Material and `styles.scss`. `app.component.scss` said 600px and `analytics-filter-bar.component.scss` said 600px — at exactly 600px the filter bar offset by 56px while the navbar was still 64px, tucking 8px of itself underneath.

Also drops `FlexLayoutModule` from the navbar; no `fx` directives survive.

## Note on the 600–730px band

Logged in with the CTA showing, the links total roughly 565px; add the brand, bell, and avatar and you need ~730px. Since the collapse is at 599px, that band would clip, so `.nav-links` gets `overflow-x: auto` with hidden scrollbars as a safety valve. Moving the collapse to 959px would remove the band entirely if that's preferred.

## Testing

- `npm run lint:brief` clean; `npm run test:brief` 1290 passing.
- New specs assert computed `flex-wrap: nowrap` / `justify-content: flex-start`, and that the collapsed menu content stays out of the DOM until opened.
- **No e2e changes needed** — see below.
- Manually verified in the browser by @HoffmanEngineering.

### E2E impact: none

No Cypress spec touches the navbar. All navigation is `cy.visit()`; the `.mat-mdc-tab` selectors in the analytics specs are the analytics tab bar, not the navbar, and the only `#loginButton` reference is inside a commented-out block in `prints/prints.cy.ts`.

Two specs run at viewports that cross the new behavior and were checked specifically:

- `filaments/filament-appearance.cy.ts` uses `cy.viewport(599, 900)` — exactly the new collapse point, so the navbar there is now the hamburger. The spec asserts only on filament cards and never on navbar contents.
- `filaments/filament-remaining.cy.ts` asserts a sticky offset of `STICKY_TOP = 80` against the 64px navbar, but at `cy.viewport(1440, 900)` — desktop, unchanged.

Mobile specs (`print-list-mobile-selection.cy.ts` at 390px, the analytics specs at 375px) can only be helped: the toolbar is now exactly the 56px their content offsets assume, instead of an overgrown wrapped row.
