### PR TITLE
fix(filament): don't prompt or navigate mid-upload on create, and pin the list's fixed columns

### DIFF
--- a/src/app/filament/filament-detail/filament-detail.component.spec.ts
+++ b/src/app/filament/filament-detail/filament-detail.component.spec.ts
@@ -11,7 +11,7 @@ import { MatSelectModule } from '@angular/material/select';
 import { ActivatedRoute, Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ToastrService } from 'ngx-toastr';
-import { of } from 'rxjs';
+import { Subject, of } from 'rxjs';
 import { MatButtonModule } from '@angular/material/button';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
@@ -197,6 +197,50 @@ describe('FilamentDetailComponent', () => {
       expect(component.saving).toBeFalse();
       expect(router.navigateByUrl).not.toHaveBeenCalled();
       expect(toastr.warning).toHaveBeenCalled();
+    });
+
+    // The URL used to be rewritten the instant the create returned, while the
+    // photos were still uploading. That navigation ran PendingChangesGuard,
+    // which asks the panel whether anything is staged - and mid-upload the
+    // answer is yes, so saving a new material prompted "You have unsaved
+    // changes" about the very photos it was uploading.
+    it('does not navigate while the staged photos are still uploading', () => {
+      setUpNewFilamentForm();
+      stagedImages(true);
+      // Never emits: the upload is still in flight for the whole test.
+      imagesPanelStub.uploadStagedImages.and.returnValue(new Subject());
+
+      component.onSubmit();
+
+      expect(router.navigate).not.toHaveBeenCalled();
+      expect(router.navigateByUrl).not.toHaveBeenCalled();
+    });
+
+    it('leaves the guard alone for its own post-save URL rewrite', async () => {
+      setUpNewFilamentForm();
+      stagedImages(true);
+      imagesPanelStub.uploadStagedImages.and.returnValue(
+        of({ failed: [new File(['x'], 'spool.png')] })
+      );
+
+      let guardAnswer: boolean | null = null;
+      (router.navigate as jasmine.Spy).and.callFake(() => {
+        // The guard runs during the navigation, with photos still staged for
+        // the retry. It must not prompt for a navigation the page started.
+        guardAnswer = component.canDeactivate() as boolean;
+        return Promise.resolve(true);
+      });
+
+      component.onSubmit();
+      await fixture.whenStable();
+
+      expect(router.navigate).toHaveBeenCalledWith(
+        ['/filament', 'new-filament-id'],
+        { replaceUrl: true }
+      );
+      expect(guardAnswer).toBeTrue();
+      // Restored afterwards, or the rest of the page's life skips the check.
+      expect(component.canDeactivate()).toBeFalse();
     });
   });
 

--- a/src/app/filament/filament-detail/filament-detail.component.ts
+++ b/src/app/filament/filament-detail/filament-detail.component.ts
@@ -126,6 +126,8 @@ export class FilamentDetailComponent
 
   protected readonly imagesPanel = viewChild(FilamentImagesPanelComponent);
   public saving = false;
+  /** See `canDeactivate`: suppresses the guard for app-initiated navigation. */
+  private isSelfNavigating = false;
 
   public materials: Material[] = [];
   public filteredMaterials: Observable<Material[]> = null;
@@ -190,9 +192,29 @@ export class FilamentDetailComponent
 
   @HostListener('window:beforeunload')
   canDeactivate(): boolean | Observable<boolean> {
+    // A navigation this component started itself is never the user abandoning
+    // work, so it must not be second-guessed. Without this, rewriting the URL
+    // after a create prompts "You have unsaved changes" about the very photos
+    // the save is in the middle of uploading.
+    if (this.isSelfNavigating) return true;
+
     // The form is blind to staged photos, so without the panel a user who has
     // only picked images would navigate away and silently lose them.
     return !this.filamentForm.dirty && !this.imagesPanel()?.hasStagedImages();
+  }
+
+  /**
+   * Points the URL at the saved material without prompting. Used only after a
+   * create whose photos failed, where the page stays put for the retry - the
+   * success path leaves for the list instead.
+   */
+  private replaceUrlWithSaved(filamentId: string): void {
+    this.isSelfNavigating = true;
+    this.router
+      .navigate(['/filament', filamentId], { replaceUrl: true })
+      // Restore the guard however the navigation ends, or the rest of this
+      // component's life would silently skip the unsaved-changes check.
+      .finally(() => (this.isSelfNavigating = false));
   }
 
   get filamentAdjustments() {
@@ -849,13 +871,9 @@ export class FilamentDetailComponent
         this.filamentForm.markAsPristine();
 
         // The record is no longer new. Write the ID back BEFORE any upload, so a
-        // retry is an update and never a second POST, and replace the URL so a
-        // reload lands on the saved material.
+        // retry is an update and never a second POST.
         if (wasNew && filament.id) {
           this.filamentForm.get('id')?.setValue(filament.id);
-          this.router.navigate(['/filament', filament.id], {
-            replaceUrl: true,
-          });
         }
 
         const panel = this.imagesPanel();
@@ -864,7 +882,9 @@ export class FilamentDetailComponent
           return;
         }
 
-        panel.uploadStagedImages(filament.id).subscribe(({ failed }) => {
+        const filamentId = filament.id;
+
+        panel.uploadStagedImages(filamentId).subscribe(({ failed }) => {
           // Clear `saving` either way, or the retry button stays disabled
           // forever.
           this.saving = false;
@@ -876,7 +896,10 @@ export class FilamentDetailComponent
 
           // Stay put: the material is saved, and the user needs a surface on
           // which to retry the photos. Navigating away would discard that
-          // chance.
+          // chance. Only now is the URL rewritten, so a reload lands on the
+          // saved material rather than back on `new`.
+          if (wasNew) this.replaceUrlWithSaved(filamentId);
+
           this.toastr.warning(
             `Material saved, but ${failed.length} image(s) failed to upload. You can retry them below.`
           );

--- a/src/app/filament/filament-list-container/filament-list-container.component.scss
+++ b/src/app/filament/filament-list-container/filament-list-container.component.scss
@@ -151,6 +151,15 @@ table {
   padding-right: 0 !important;
 }
 
+// The star is a stock mat-button, so it is 64px wide (min-width beats its 24px
+// icon) and sits left in the cell - every pixel of slack this column takes lands
+// between the star and the thumbnail beside it. 64px of button plus the 5px of
+// right padding every cell in this table carries.
+.mat-column-isFavorite {
+  flex: 0 0 69px !important;
+  width: 69px !important;
+}
+
 // The thumbnail is a fixed 40px box, so this column has nothing to do with the
 // slack `table-layout: auto` hands out - without a width it just grows and
 // leaves the image adrift in a widening cell. 40px of image plus the 5px of

--- a/src/app/filament/filament-list-container/filament-list-container.component.scss
+++ b/src/app/filament/filament-list-container/filament-list-container.component.scss
@@ -151,6 +151,15 @@ table {
   padding-right: 0 !important;
 }
 
+// The thumbnail is a fixed 40px box, so this column has nothing to do with the
+// slack `table-layout: auto` hands out - without a width it just grows and
+// leaves the image adrift in a widening cell. 40px of image plus the 5px of
+// right padding every cell in this table carries.
+.mat-column-image {
+  flex: 0 0 45px !important;
+  width: 45px !important;
+}
+
 .mat-column-colorHex {
   flex: 0 0 70px !important;
   width: 70px !important;


### PR DESCRIPTION
Three fixes in the material images area, found while investigating a report that adding photos to a brand-new material misbehaved.

## 1. The "unsaved changes" prompt on save

`save()` rewrote the URL the instant the create POST returned, while the photos were still uploading:

```ts
this.filamentForm.get('id')?.setValue(filament.id);
this.router.navigate(['/filament', filament.id], { replaceUrl: true });
...
panel.uploadStagedImages(filament.id).subscribe(...)
```

That navigation runs `PendingChangesGuard`, which calls `canDeactivate()` → `imagesPanel()?.hasStagedImages()` (`filament-detail.component.ts:195`). Mid-upload the answer is `true`, so saving a new material prompted *"You have unsaved changes. Do you want to leave this page and discard your changes?"* about the very photos the save was uploading. The app was second-guessing its own navigation.

## 2. A successful upload could be wiped from the panel

The same early navigation re-runs `FilamentDetailResolverService`, which GETs the material and feeds its `images` back into the panel. While uploads are still in flight that list is empty or short, and `syncStoredImages` keeps only items that still carry a `file` — so an image that finished uploading before the resolver responded was dropped from the panel entirely.

Both come from navigating too early, so it no longer does. The ID is still written back before the upload, so a retry is an update and never a second POST, but the URL is only rewritten on the failure path, where the page stays put to offer the retry and a reload should land on the saved material. The success path leaves for the list as before and never needs it.

That one remaining rewrite is still a navigation the page starts itself with photos legitimately staged for retry, so it's exempted from the guard via an `isSelfNavigating` flag, cleared however the navigation settles so the rest of the component's life keeps the unsaved-changes check.

## 3. Material list columns grew with the viewport

`table { width: 100% }` with the default `table-layout: auto` hands slack to any column without a width. `isFavorite` and `image` had none, so they took a share of it. `.filament-thumbnail` is a fixed 40px box and the star is a stock `mat-button` that sits left in its cell, so in both cases the content stayed put and the space opened up beside it.

Both are pinned now, matching the treatment `select`, `colorHex`, and `more` already had. All the leading fixed-size columns are covered; the slack goes to the text columns that should absorb it.

## Testing

- `npm run lint:brief` clean; `npm run test:brief` 1290 passing.
- Two new specs on the save flow, both verified to **fail without the fix**:
  - `does not navigate while the staged photos are still uploading`
  - `leaves the guard alone for its own post-save URL rewrite`
- Column sizing verified manually by @HoffmanEngineering.

## Note: the 404 in the original report was not a code bug

The report also described `POST /api/Filaments/{id}/images` returning 404, with Retry failing too. That turned out to be environmental — a stale local API build — and nothing here addresses it. Recorded because the diagnosis is reusable:

The endpoint 404'd even with **no auth header** (should be 401) and with **no file** (should be 400, since the file is checked before any lookup), while `GET /api/Filaments/{id}` returned 200 and sibling routes on the same controller returned 403/200. A 404 that survives removing the auth header means the route isn't registered, not that the record is missing. The running process's own Swagger confirmed it, advertising no `/api/Filaments/{id}/images` at all — every `/images` route it knew was Prints or Projects. The binary predated the `feat/filament-images-api` merge. Rebuilding the API resolved it.

Worth knowing that this means **the upload path had never once run successfully before this branch** — every upload was 404ing — so fix 2 above describes a race that was real but had never been reachable in practice.
