### PR TITLE
feat: bump version to 1.48.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "print-log-ui",
-  "version": "1.47.0",
+  "version": "1.48.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --ssl --host 0.0.0.0 ",

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -28,6 +28,34 @@ export class VersionReleaseNoteDialogService {
   private readonly LOCAL_STORAGE_KEY = 'LastLoggedInVersion';
 
   private releaseNotes: ReleaseNoteHistory = {
+    '1.48.0': {
+      title: '1.48.0 - Spool Photos',
+      body: `<p>
+<strong>Spool photos</strong> are here! Add pictures of the actual spool to any material, reorder them, and star one as the default. That photo then shows as a thumbnail beside the material everywhere it is listed, so you can spot the right roll without reading every name. Try it on <a href="/filament">your materials</a>.
+</p>
+<p>
+This release also stops sliced files with missing or invalid filament measurements from recording a 0mg estimate, and tidies up the navigation bar on phones.
+</p>
+<p>
+  <strong>Support development of 3D Print Log:</strong><br />
+  <a href="/subscription">Subscribe to Pro</a> for an ad-free experience and extra cloud storage,
+  buy me a coffee by <a
+    href="https://paypal.me/hoffmanengineering"
+    rel="noreferrer noopener"
+    target="_blank"
+    >donating via PayPal</a
+  >, or by becoming a
+  <a
+    href="https://www.patreon.com/HoffmanEngineering"
+    rel="noreferrer noopener"
+    target="_blank"
+  >
+    Patron of Hoffman Engineering</a
+  >
+  on Patreon.com
+  </p><p>Share <strong>3D Print Log</strong> with a friend, and Happy Printing!
+</p>`,
+    },
     '1.47.0': {
       title: '1.47.0 - Material Remaining & More Bulk Actions',
       body: `<p>

--- a/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
+++ b/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
@@ -2,6 +2,106 @@
   <h2>Release Notes</h2>
   <hr />
 
+  <h3 id="v1.48.0">1.48.0 - Spool Photos</h3>
+  <p>
+    Materials can now have photos. The new Photos panel lets you add pictures
+    of the actual spool, reorder them, and star one as the default. That default
+    photo then shows as a thumbnail beside the material everywhere it is listed,
+    in the table and in the mobile cards, so you can spot the right roll in a
+    long list without reading every name.
+  </p>
+  <p>
+    The rest of the release is fixes. Slicer files that are missing or have
+    invalid filament measurements no longer record a confident estimate of 0mg;
+    the amount is simply left empty for you to fill in. The navigation bar has
+    been tidied up on phones: the links sit to the left, the toolbar keeps a
+    fixed height instead of growing, the brand no longer shrinks, the Pro button
+    stays in the toolbar, and "About" no longer appears twice.
+  </p>
+  <h4>Full List of Changes:</h4>
+  <ul>
+    <li>
+      <strong>Spool photos</strong> - A Photos panel on the material detail page
+      lets you add, reorder, delete, and set a default picture of the spool.
+      (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/126"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #126</a
+      >)
+    </li>
+    <li>
+      <strong>Photo thumbnails in the material list</strong> - The default photo
+      shows beside each material in both the table and the mobile cards. (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/126"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #126</a
+      >)
+    </li>
+    <li>
+      <strong>No more 0mg filament estimates</strong> - When a sliced file is
+      missing filament diameter or length, or reports an invalid value, the
+      usage estimate is left empty instead of recorded as zero. (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/122"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #122</a
+      >)
+    </li>
+    <li>
+      <strong>Mobile navigation bar layout</strong> - Links are left-justified,
+      the toolbar has a fixed height, the brand no longer shrinks, and the Pro
+      button stays in the toolbar. (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/129"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #129</a
+      >)
+    </li>
+    <li>
+      <strong>Duplicate "About" link</strong> - "About" no longer renders twice
+      in the mobile menu. (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/123"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #123</a
+      >)
+    </li>
+    <li>
+      <strong>Release notes on GitHub</strong> - Each release published on
+      GitHub is now generated from this page, so the notes there match the ones
+      here. (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/106"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #106</a
+      >,
+      <a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/118"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #118</a
+      >)
+    </li>
+    <li>
+      <strong>Project housekeeping</strong> - Dependency updates are now
+      automated, build workflow permissions were tightened, and the README
+      points at GitHub Discussions for questions and ideas. (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/107"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #107</a
+      >,
+      <a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/119"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #119</a
+      >)
+    </li>
+  </ul>
+
   <h3 id="v1.47.0">1.47.0 - Material Remaining &amp; More Bulk Actions</h3>
   <p>
     Saved materials now tell you what is left on the spool. Opening a material


### PR DESCRIPTION
Version bump to 1.48.0, a minor release covering everything merged since `v1.47.0`.

## Changes

- `package.json` — version `1.47.0` → `1.48.0`
- `docs-release-notes.component.html` — new `<h3 id="v1.48.0">` section at the top of the list
- `version-release-note-dialog.service.ts` — new `1.48.0` entry (full note, not a redirect, since this is a minor release)

## Release contents

Headline feature is **spool photos** for materials (#126). The rest is fixes: parser filament measurement validation (#122) and the mobile navbar layout (#129, #123), plus developer-facing work on release-note publishing (#106, #118) and repo housekeeping (#107, #119).

PR #130 is deliberately **not** listed. It fixes the spool photos feature from #126, which has not shipped yet, so from a user's point of view there is nothing there to have been broken.

## Verification

- `npm run test:scripts` — 85/85 passing (this includes the release-notes extraction test that fails on HTML shapes the Markdown converter cannot handle)
- `node scripts/extract-release-notes.mjs v1.48.0` and `--title` — both render correctly; every PR link resolved, no stray tags
- `git diff --stat` confirms the notes HTML gained 100 lines and nothing else was reformatted (the file has pre-existing prettier drift, so a blanket rewrite would have buried the diff)

## Before approving the deploy

PR #126 flagged that `POST /api/Filaments/{id}/images` returns 500 against the local e2etesting API because blob storage is not provisioned there, so no automated test covers a successful upload end-to-end. This release leads with that feature, so it is worth confirming an upload works against production storage at the approval gate.

## After merge

```bash
git checkout main && git pull
git tag v1.48.0
git push origin v1.48.0
```

The tag builds and tests, waits for approval on the `production` environment, then deploys and publishes the GitHub Release from the notes in this PR.
