### PR TITLE
fix(scripts): assert no tag beyond the known gap misses a section

### DIFF
--- a/scripts/release-notes-lib.test.mjs
+++ b/scripts/release-notes-lib.test.mjs
@@ -260,6 +260,11 @@ test('every git tag except the known-missing v1.32.1 resolves to a section', (t)
     return;
   }
 
+  // Which tags are present depends on the checkout: a full clone has all of
+  // them, while a tag-triggered build has only the tag it was pushed for. So
+  // assert that nothing beyond the known gap is unresolved, rather than that
+  // the gap itself is always present to be found.
+
   const missing = tags.filter((tag) => {
     try {
       extractReleaseNotes(REAL_HTML, tag);
@@ -269,5 +274,8 @@ test('every git tag except the known-missing v1.32.1 resolves to a section', (t)
     }
   });
 
-  assert.deepEqual(missing, ['v1.32.1']);
+  assert.deepEqual(
+    missing.filter((tag) => tag !== 'v1.32.1'),
+    [],
+  );
 });


### PR DESCRIPTION
The `v1.48.0` Deploy build failed on `Script unit tests` (84/85) with a correct release-notes file. The test is wrong, not the release.

## What broke

`release-notes-lib.test.mjs` asserted `missing` deep-equals `['v1.32.1']`. That encodes the tag list of a full clone rather than the property the test name states. The tag list depends on the checkout:

| Environment | `git tag` returns | `missing` | Result |
| --- | --- | --- | --- |
| Full clone (local) | all 32 tags | `['v1.32.1']` | passes |
| Branch / PR CI | nothing (shallow) | — | already skipped |
| **Tag push (Deploy)** | **only `v1.48.0`** | `[]` | **fails** |

On a tag push `actions/checkout` fetches just the pushed tag. It resolves fine, so `missing` is empty, and the assertion fails hunting for a gap that was never in the list to be found.

This test arrived in 5455c5e (#106), which ships in 1.48.0, so this was the first tag push ever to run it. It passed PR CI both times via the shallow-clone skip.

## The fix

Assert that nothing *beyond* the known gap is unresolved, instead of that the gap is always present:

```js
assert.deepEqual(
  missing.filter((tag) => tag !== 'v1.32.1'),
  [],
);
```

## Verification

- **Reproduced the CI failure locally** in a `--depth 1 --branch v1.48.0 --no-tags` clone (`git tag` → exactly `v1.48.0`): fails before the change, 26/26 passes after.
- **Full clone**: `npm run test:scripts` → 85/85, `# skipped 0`, so the tag test genuinely ran against all 32 tags rather than skipping.
- **Still catches a real gap**: fed a tag list containing an unwritten `v9.9.9` alongside `v1.32.1`; it survives the filter, so the assertion still fails as intended.

Test-only change. No version bump, and no release-notes edit, since nothing user-facing changes.

## After merge

`v1.48.0` currently points at 33cf712, which contains the broken test, so re-running the job will fail again. The tag needs to move to the commit that includes this fix.
