### PR TITLE
fix(images): let Add Photo and the carousel + open the camera in the mobile app

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "print-log-ui",
-  "version": "1.48.0",
+  "version": "1.48.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --ssl --host 0.0.0.0 ",

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -28,6 +28,9 @@ export class VersionReleaseNoteDialogService {
   private readonly LOCAL_STORAGE_KEY = 'LastLoggedInVersion';
 
   private releaseNotes: ReleaseNoteHistory = {
+    '1.48.1': {
+      redirect: '1.48.0',
+    },
     '1.48.0': {
       title: '1.48.0 - Spool Photos',
       body: `<p>

--- a/src/app/documentation/docs/docs-filaments/docs-filaments.component.html
+++ b/src/app/documentation/docs/docs-filaments/docs-filaments.component.html
@@ -271,7 +271,9 @@
     <strong>Add Photo</strong> (or drag an image file onto the box) to choose
     one or more pictures, then click
     <button mat-raised-button color="primary">Submit</button> to save them along
-    with the rest of your changes.
+    with the rest of your changes. In the mobile app,
+    <strong>Add Photo</strong> and the <strong>+</strong> tile let you take a
+    new picture with your camera as well as pick one from your gallery.
   </p>
   <p>
     Once a material has more than one photo you can drag the thumbnails to

--- a/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
+++ b/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
@@ -2,6 +2,28 @@
   <h2>Release Notes</h2>
   <hr />
 
+  <h3 id="v1.48.1">1.48.1 - Camera Photos on Mobile</h3>
+  <p>
+    A fix for the mobile app. Adding a photo to a material only ever opened the
+    gallery, with no way to take a new picture. Both <strong>Add Photo</strong>
+    and the <strong>+</strong> tile on the photo carousel now offer the camera,
+    matching the Upload Picture button on a print. The <strong>+</strong> tile
+    on a print's photo carousel offers the camera now too.
+  </p>
+  <h4>Full List of Changes:</h4>
+  <ul>
+    <li>
+      <strong>Take a photo from the camera</strong> - In the mobile app, the
+      material Add Photo button and the + tile on both the material and print
+      photo carousels can now open the camera instead of only the gallery. (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/133"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #133</a
+      >)
+    </li>
+  </ul>
+
   <h3 id="v1.48.0">1.48.0 - Spool Photos</h3>
   <p>
     Materials can now have photos. The new Photos panel lets you add pictures

--- a/src/app/filament/filament-detail/filament-images-panel/filament-images-panel.component.html
+++ b/src/app/filament/filament-detail/filament-images-panel/filament-images-panel.component.html
@@ -7,6 +7,16 @@
     multiple
     (change)="onFilesSelected($event)"
   />
+  <!-- Inside the Cordova app the OS only offers the gallery unless the input
+       asks to capture, so the camera gets its own input. -->
+  <input
+    #cameraInput
+    type="file"
+    class="file-input"
+    accept="image/jpeg,image/png,image/webp"
+    capture="environment"
+    (change)="onFilesSelected($event)"
+  />
 
   <div
     class="image-drop-zone"
@@ -24,7 +34,11 @@
     }
 
     @if (items().length === 0) {
-      <button type="button" mat-stroked-button (click)="imgFileInput.click()">
+      <button
+        type="button"
+        mat-stroked-button
+        (click)="(isCordova ? cameraInput : imgFileInput).click()"
+      >
         <mat-icon>add_a_photo</mat-icon>
         Add Photo
       </button>
@@ -59,7 +73,7 @@
     (imageDeleted)="onImageDeleted($event)"
     (defaultChanged)="onDefaultChanged($event)"
     (imagesReordered)="onImagesReordered($event)"
-    (addClicked)="imgFileInput.click()"
+    (addClicked)="(isCordova ? cameraInput : imgFileInput).click()"
   />
 
   @if (busy()) {

--- a/src/app/filament/filament-detail/filament-images-panel/filament-images-panel.component.spec.ts
+++ b/src/app/filament/filament-detail/filament-images-panel/filament-images-panel.component.spec.ts
@@ -4,9 +4,11 @@ import {
 } from '@angular/common/http/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { FilamentService } from 'src/app/core/services/filament.service';
+import { ImageThumbnailStripComponent } from 'src/app/shared/image-thumbnail-strip/image-thumbnail-strip.component';
 import { DeferredSkeletonController } from 'src/app/shared/skeleton/deferred-skeleton';
 import { environment } from 'src/environments/environment';
 import {
@@ -83,6 +85,63 @@ describe('FilamentImagesPanelComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('add affordances', () => {
+    const fileInputs = () =>
+      fixture.debugElement
+        .queryAll(By.css('input[type="file"]'))
+        .map((el) => el.nativeElement as HTMLInputElement);
+
+    const clickAddPhoto = () => {
+      const button = fixture.debugElement.query(By.css('button'))
+        .nativeElement as HTMLButtonElement;
+      button.click();
+    };
+
+    const clickStripAdd = () => {
+      fixture.debugElement
+        .query(By.directive(ImageThumbnailStripComponent))
+        .componentInstance.addClicked.emit();
+    };
+
+    const setCordova = (value: boolean) => {
+      (component as unknown as { isCordova: boolean }).isCordova = value;
+      fixture.detectChanges();
+    };
+
+    it('offers a camera-capture input alongside the gallery input', () => {
+      const [gallery, camera] = fileInputs();
+
+      expect(gallery.hasAttribute('capture')).toBeFalse();
+      expect(camera.getAttribute('capture')).toBe('environment');
+    });
+
+    it('opens the gallery input from both add affordances in the browser', () => {
+      setCordova(false);
+      const [gallery, camera] = fileInputs();
+      spyOn(gallery, 'click');
+      spyOn(camera, 'click');
+
+      clickAddPhoto();
+      clickStripAdd();
+
+      expect(gallery.click).toHaveBeenCalledTimes(2);
+      expect(camera.click).not.toHaveBeenCalled();
+    });
+
+    it('opens the capture input from both add affordances inside the app', () => {
+      setCordova(true);
+      const [gallery, camera] = fileInputs();
+      spyOn(gallery, 'click');
+      spyOn(camera, 'click');
+
+      clickAddPhoto();
+      clickStripAdd();
+
+      expect(camera.click).toHaveBeenCalledTimes(2);
+      expect(gallery.click).not.toHaveBeenCalled();
+    });
   });
 
   it('stages picked files and issues no HTTP request when there is no filamentId', () => {

--- a/src/app/filament/filament-detail/filament-images-panel/filament-images-panel.component.ts
+++ b/src/app/filament/filament-detail/filament-images-panel/filament-images-panel.component.ts
@@ -19,6 +19,7 @@ import {
   FilamentImage,
   FilamentService,
 } from 'src/app/core/services/filament.service';
+import { isCordova } from 'src/app/core/utils/platform';
 import { FilamentImageComponent } from 'src/app/shared/filament-image/filament-image.component';
 import { ImageCarouselComponent } from 'src/app/shared/image-carousel/image-carousel.component';
 import { ImageThumbnailStripComponent } from 'src/app/shared/image-thumbnail-strip/image-thumbnail-strip.component';
@@ -60,6 +61,8 @@ let nextStagedKey = 1;
 })
 export class FilamentImagesPanelComponent {
   private readonly filamentService = inject(FilamentService);
+  /** Picks which hidden file input the add affordances open. */
+  protected readonly isCordova = isCordova;
   private readonly destroyRef = inject(DestroyRef);
 
   filamentId = input<string | null>(null);

--- a/src/app/print/edit-print-detail/edit-print-detail.component.html
+++ b/src/app/print/edit-print-detail/edit-print-detail.component.html
@@ -92,7 +92,7 @@
           (imageDeleted)="onImageDeleted($event)"
           (defaultChanged)="onDefaultChanged($event)"
           (imagesReordered)="onImagesReordered($event)"
-          (addClicked)="imgFileInput.click()"
+          (addClicked)="(isCordova ? cameraInput : imgFileInput).click()"
         />
       </div>
       <mat-card-content


### PR DESCRIPTION
## Problem

In the mobile (Cordova) app, the material **Add Photo** button and the **+** tile on the photo carousel only opened the gallery/file explorer. There was no way to go straight to the camera. The print editor's **Upload Picture** button already offered the camera, because it clicks a second hidden input carrying `capture="environment"`.

## Change

- The material photos panel gains that same `capture="environment"` input, and both add affordances (**Add Photo** and the thumbnail strip's **+**) route to it when running inside the app.
- The print editor's **+** tile now routes to the capture input too; it was always going to the gallery input, which is the second half of the report.
- Desktop/browser behavior is unchanged: both still open the normal gallery picker.
- Materials docs note the camera option in the mobile app.

## Tests

Three new specs on `FilamentImagesPanelComponent`: the capture input exists with `capture="environment"`, both affordances click the gallery input in the browser, and both click the camera input when `isCordova` is true.

`filament-images-panel` suite 21/21 pass; `npm run lint:brief` clean.