### PR TITLE
fix(filament): keep remaining stats when picking a material by QR scan

### DIFF
--- a/cypress/e2e/filaments/filament-qr-scan.cy.ts
+++ b/cypress/e2e/filaments/filament-qr-scan.cy.ts
@@ -1,0 +1,110 @@
+import * as qrcodeModule from 'qrcode';
+import { apiUrl } from '../../support/api-url';
+import { installFakeCamera } from '../../support/fake-camera';
+
+// Picking a material by QR scan takes a different path than picking it from the
+// list: the list hands back the API's own summary, while the scan looks the
+// material up by id and maps the detail onto a summary. That mapping used to
+// drop the server-computed remaining values, so a scanned spool showed
+// "0 (g) remaining" on the print it was attached to.
+// `qrcode` is CommonJS: depending on the bundler the namespace object is either
+// the module itself or a wrapper with the real API under `.default`. The app's
+// own QrCodeService unwraps it the same way.
+const QRCode =
+  (qrcodeModule as { default?: typeof qrcodeModule }).default ?? qrcodeModule;
+
+describe('Print edit — selecting a material by QR scan', () => {
+  const NOMINAL_WEIGHT_MG = 1000000; // 1,000 g, so "1,000 (g) remaining" is unambiguous
+
+  beforeEach(() => {
+    cy.login();
+  });
+
+  // Seeded through the API rather than the UI: the spec needs a spool with a
+  // known remaining weight and a known id (the id is what goes in the QR code).
+  function seedTrackedFilament(): Cypress.Chainable<{
+    id: string;
+    displayName: string;
+  }> {
+    const displayName = `QR Scan E2E ${Date.now()}`;
+
+    return cy
+      .request({
+        method: 'POST',
+        url: `${apiUrl()}/api/Filaments/`,
+        headers: { 'X-Dev-User-Id': '1' },
+        body: {
+          displayName,
+          brand: 'E2E',
+          materialCategoryNickname: 'filament',
+          materialType: 'PLA',
+          materialDensityGramPerCubicCm: 1.24,
+          colorName: 'Scan Blue',
+          colorHex: '0000FF',
+          colorPattern: 0,
+          colors: ['0000FF'],
+          finishType: 0,
+          effects: [],
+          diameterMm: 1.75,
+          initialTotalWeightMg: NOMINAL_WEIGHT_MG,
+          initialNominalWeightMg: NOMINAL_WEIGHT_MG,
+          spoolWeightMg: 200000,
+          source: 0,
+          isActive: true,
+          purchasePriceValue: '20.00',
+          purchasePriceCurrency: 'USD',
+          filamentAdjustments: [],
+        },
+      })
+      .then((response) => ({ id: response.body.id, displayName }));
+  }
+
+  function openPrintEditWithCamera(filamentId: string) {
+    const labelUrl = `https://localhost:4200/materials/${filamentId}`;
+
+    return cy
+      .wrap(QRCode.toDataURL(labelUrl, { margin: 4, width: 512 }), {
+        log: false,
+      })
+      .then((qrDataUrl) => {
+        cy.visit('/prints/new/edit', {
+          onBeforeLoad: (win) => installFakeCamera(win, qrDataUrl as string),
+        });
+      });
+  }
+
+  it('keeps the remaining amounts on a material selected by scanning its label', () => {
+    seedTrackedFilament().then(({ id, displayName }) => {
+      openPrintEditWithCamera(id);
+
+      cy.get('#edit-print-title').type(`QR scan print ${Date.now()}`);
+      cy.get('#edit-print-printer').click();
+      cy.get('mat-option').first().click();
+
+      cy.get('#add-new-filament-usage-btn').click();
+      cy.get('[data-cy="select-filament-btn"]').first().click();
+
+      // Switch the picker from the list to the scanner and let the real decoder
+      // read the fake camera. Decoding a stream takes longer than a click, so
+      // the wait for the lookup is generous.
+      cy.get('app-filament-search-modal').should('be.visible');
+      cy.intercept('GET', `**/api/Filaments/${id}`).as('filamentLookup');
+      cy.get('.scan-toggle-button').click();
+      cy.get('#qr-reader video', { timeout: 20000 }).should('exist');
+      cy.wait('@filamentLookup', { timeout: 30000 });
+
+      // The dialog closes itself once the scanned material is chosen.
+      cy.get('app-filament-search-modal').should('not.exist');
+
+      cy.get('.filament-entry-card')
+        .first()
+        .should('contain.text', displayName)
+        .invoke('text')
+        .should((text) => {
+          expect(text).to.match(/1,000\s*\(g\) remaining/);
+          expect(text).to.match(/[1-9][\d,]*\s*\(m\) remaining/);
+          expect(text).to.match(/[1-9][\d,]*\s*\(ml\) remaining/);
+        });
+    });
+  });
+});

--- a/cypress/support/fake-camera.js
+++ b/cypress/support/fake-camera.js
@@ -1,0 +1,70 @@
+/**
+ * Puts a QR code in front of the app's camera.
+ *
+ * There is no way to hold a printed label up to a headless browser, and the
+ * scanner is not a seam we can stub from a spec — `QrScannerService` reaches
+ * for `html5-qrcode`, which reaches for `navigator.mediaDevices`. So we replace
+ * the camera itself: a canvas with the QR drawn on it, published as a
+ * MediaStream. Everything above that — camera enumeration, the video element,
+ * the real decoder, `parseFilamentUrl` — runs exactly as it does in production.
+ *
+ * Call from `cy.visit`'s `onBeforeLoad`, before the app boots:
+ *
+ *   cy.visit('/prints/new/edit', {
+ *     onBeforeLoad: (win) => installFakeCamera(win, qrDataUrl),
+ *   });
+ *
+ * @param win the application window
+ * @param qrDataUrl a PNG data URL of the QR code, from `QRCode.toDataURL`
+ */
+export function installFakeCamera(win, qrDataUrl) {
+  const canvas = win.document.createElement('canvas');
+  canvas.width = 640;
+  canvas.height = 480;
+  const ctx = canvas.getContext('2d');
+
+  const image = new win.Image();
+  image.src = qrDataUrl;
+
+  // html5-qrcode decodes a `qrbox`-sized crop from the middle of the frame, and
+  // how big that crop is in source pixels depends on how the browser laid the
+  // video out inside the dialog. Rather than guess one size that lands inside
+  // it, sweep the QR from small to large: within a second or so some frame puts
+  // the whole code, quiet zone included, inside the crop.
+  let size = 140;
+  const drawFrame = () => {
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    size = size >= 360 ? 140 : size + 20;
+    ctx.drawImage(
+      image,
+      (canvas.width - size) / 2,
+      (canvas.height - size) / 2,
+      size,
+      size
+    );
+  };
+  drawFrame();
+  win.setInterval(drawFrame, 100);
+
+  const fakeCamera = {
+    deviceId: 'e2e-fake-camera',
+    kind: 'videoinput',
+    label: 'E2E Fake Back Camera',
+    groupId: 'e2e-fake-camera-group',
+  };
+
+  Object.defineProperty(win.navigator, 'mediaDevices', {
+    configurable: true,
+    value: {
+      // A fresh stream per call on purpose: `Html5Qrcode.getCameras()` opens a
+      // stream just to unlock device labels and then stops its tracks. Handing
+      // out one shared stream would leave the scanner with a dead track.
+      getUserMedia: () => Promise.resolve(canvas.captureStream(10)),
+      enumerateDevices: () => Promise.resolve([fakeCamera]),
+      getSupportedConstraints: () => ({}),
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    },
+  });
+}

--- a/src/app/core/utils/filament-summary.spec.ts
+++ b/src/app/core/utils/filament-summary.spec.ts
@@ -1,0 +1,94 @@
+import {
+  ColorPatternType,
+  FilamentDetail,
+  FilamentFinishType,
+  FilamentSourceMeasurement,
+} from '../services/filament.service';
+import { filamentDetailToSummary } from './filament-summary';
+
+function buildDetail(overrides: Partial<FilamentDetail> = {}): FilamentDetail {
+  return {
+    id: 'filament-1',
+    displayName: 'Test Filament',
+    brand: 'Brand',
+    materialCategoryNickname: 'PLA',
+    materialType: 'PLA',
+    materialDensityGramPerCubicCm: 1.24,
+    colorName: 'Red',
+    colorHex: 'FF0000',
+    colorPattern: ColorPatternType.Solid,
+    colors: ['FF0000'],
+    finishType: FilamentFinishType.Standard,
+    effects: [],
+    diameterMm: 1.75,
+    initialTotalWeightMg: null,
+    source: FilamentSourceMeasurement.Weight,
+    initialNominalWeightMg: 1000000,
+    initialNominalLengthM: 330,
+    initialNominalVolumeMl: 800,
+    spoolWeightMg: null,
+    tempRangeStart: null,
+    tempRangeEnd: null,
+    recommendedTemp: 210,
+    recommendedBedTemp: null,
+    isActive: true,
+    purchaseDate: null,
+    purchaseLocation: '',
+    purchasePriceValue: '20.00',
+    purchasePriceCurrency: 'USD',
+    purchaseNotes: '',
+    storageLocation: 'Shelf',
+    initialLayerTimeS: null,
+    layerTimeS: null,
+    meltingTemperature: null,
+    inertGas: '',
+    materialRefreshRatio: null,
+    notes: '',
+    isFavorite: false,
+    filamentAdjustments: [],
+    filamentRemaining: 750000,
+    filamentLengthRemainingInM: 248,
+    filamentVolumeRemainingInMl: 605,
+    ...overrides,
+  };
+}
+
+describe('filamentDetailToSummary', () => {
+  it('carries the server-computed remaining values through', () => {
+    const summary = filamentDetailToSummary(buildDetail());
+
+    expect(summary.filamentRemaining).toBe(750000);
+    expect(summary.filamentLengthRemainingInM).toBe(248);
+    expect(summary.filamentVolumeRemainingInMl).toBe(605);
+  });
+
+  it('falls back to null when the spool is untracked', () => {
+    const summary = filamentDetailToSummary(
+      buildDetail({
+        filamentRemaining: undefined,
+        filamentLengthRemainingInM: undefined,
+        filamentVolumeRemainingInMl: undefined,
+      })
+    );
+
+    expect(summary.filamentRemaining).toBeNull();
+    expect(summary.filamentLengthRemainingInM).toBeNull();
+    expect(summary.filamentVolumeRemainingInMl).toBeNull();
+  });
+
+  it('copies the identifying fields the picker displays', () => {
+    const summary = filamentDetailToSummary(buildDetail());
+
+    expect(summary.id).toBe('filament-1');
+    expect(summary.displayName).toBe('Test Filament');
+    expect(summary.colorName).toBe('Red');
+    expect(summary.materialType).toBe('PLA');
+    expect(summary.purchasePriceValue).toBe('20.00');
+  });
+
+  it('defaults the diameter when the detail has none', () => {
+    const summary = filamentDetailToSummary(buildDetail({ diameterMm: null }));
+
+    expect(summary.diameterMm).toBe(1.75);
+  });
+});

--- a/src/app/core/utils/filament-summary.ts
+++ b/src/app/core/utils/filament-summary.ts
@@ -1,0 +1,43 @@
+import { FilamentDetail, FilamentSummary } from '../services/filament.service';
+
+/**
+ * Maps a `FilamentDetail` (the single-filament endpoint) onto the
+ * `FilamentSummary` shape the list endpoint returns, so callers that only have
+ * a detail — QR scans, id-based resolvers — feed the same UI.
+ *
+ * `createdDate`, `loadedInPrinter`, and `materialCategory` are not part of the
+ * detail payload, so they come back empty; the server-computed remaining
+ * values are carried through.
+ */
+export function filamentDetailToSummary(
+  detail: FilamentDetail
+): FilamentSummary {
+  return {
+    id: detail.id,
+    displayName: detail.displayName,
+    brand: detail.brand,
+    materialCategoryNickname: detail.materialCategoryNickname,
+    materialType: detail.materialType,
+    materialDensityGramPerCubicCm: detail.materialDensityGramPerCubicCm,
+    colorName: detail.colorName,
+    colorHex: detail.colorHex,
+    colorPattern: detail.colorPattern,
+    colors: detail.colors,
+    finishType: detail.finishType,
+    effects: detail.effects,
+    recommendedTemp: detail.recommendedTemp,
+    isActive: detail.isActive,
+    notes: detail.notes,
+    isFavorite: detail.isFavorite,
+    createdDate: '',
+    filamentRemaining: detail.filamentRemaining ?? null,
+    filamentLengthRemainingInM: detail.filamentLengthRemainingInM ?? null,
+    filamentVolumeRemainingInMl: detail.filamentVolumeRemainingInMl ?? null,
+    purchasePriceValue: detail.purchasePriceValue,
+    initialNominalWeightMg: detail.initialNominalWeightMg,
+    diameterMm: detail.diameterMm ?? 1.75,
+    loadedInPrinter: null,
+    storageLocation: detail.storageLocation,
+    materialCategory: null as any,
+  };
+}

--- a/src/app/print/resolvers/filament-list-resolver.service.ts
+++ b/src/app/print/resolvers/filament-list-resolver.service.ts
@@ -6,6 +6,7 @@ import {
 } from '../../core/services/filament.service';
 import { forkJoin, of } from 'rxjs';
 import { map } from 'rxjs';
+import { filamentDetailToSummary } from '../../core/utils/filament-summary';
 
 @Injectable()
 export class FilamentListResolverService {
@@ -18,39 +19,6 @@ export class FilamentListResolverService {
     }
     return forkJoin(
       ids.map((id) => this.filamentService.getFilamentDetail(id))
-    ).pipe(
-      map((details) =>
-        details.map(
-          (d): FilamentSummary => ({
-            id: d.id,
-            displayName: d.displayName,
-            brand: d.brand,
-            materialCategoryNickname: d.materialCategoryNickname,
-            materialType: d.materialType,
-            materialDensityGramPerCubicCm: d.materialDensityGramPerCubicCm,
-            colorName: d.colorName,
-            colorHex: d.colorHex,
-            colorPattern: d.colorPattern,
-            colors: d.colors,
-            finishType: d.finishType,
-            effects: d.effects,
-            recommendedTemp: d.recommendedTemp,
-            isActive: d.isActive,
-            notes: d.notes,
-            isFavorite: d.isFavorite,
-            createdDate: '',
-            filamentRemaining: null,
-            filamentLengthRemainingInM: null,
-            filamentVolumeRemainingInMl: null,
-            purchasePriceValue: d.purchasePriceValue,
-            initialNominalWeightMg: d.initialNominalWeightMg,
-            diameterMm: d.diameterMm ?? 0,
-            loadedInPrinter: null,
-            storageLocation: d.storageLocation,
-            materialCategory: null as any,
-          })
-        )
-      )
-    );
+    ).pipe(map((details) => details.map(filamentDetailToSummary)));
   }
 }

--- a/src/app/shared/filament-search-modal/filament-search-modal.component.spec.ts
+++ b/src/app/shared/filament-search-modal/filament-search-modal.component.spec.ts
@@ -4,24 +4,83 @@ import {
   MatDialogRef,
   MAT_DIALOG_DATA,
 } from '@angular/material/dialog';
+import { of } from 'rxjs';
 import { LoggingService } from 'src/app/core/services/logging.service';
-import { FilamentService } from 'src/app/core/services/filament.service';
+import {
+  ColorPatternType,
+  FilamentDetail,
+  FilamentFinishType,
+  FilamentService,
+  FilamentSourceMeasurement,
+} from 'src/app/core/services/filament.service';
 
 import { FilamentSearchModalComponent } from './filament-search-modal.component';
+
+function buildDetail(): FilamentDetail {
+  return {
+    id: 'filament-1',
+    displayName: 'Test Filament',
+    brand: 'Brand',
+    materialCategoryNickname: 'PLA',
+    materialType: 'PLA',
+    materialDensityGramPerCubicCm: 1.24,
+    colorName: 'Red',
+    colorHex: 'FF0000',
+    colorPattern: ColorPatternType.Solid,
+    colors: ['FF0000'],
+    finishType: FilamentFinishType.Standard,
+    effects: [],
+    diameterMm: 1.75,
+    initialTotalWeightMg: null,
+    source: FilamentSourceMeasurement.Weight,
+    initialNominalWeightMg: 1000000,
+    initialNominalLengthM: 330,
+    initialNominalVolumeMl: 800,
+    spoolWeightMg: null,
+    tempRangeStart: null,
+    tempRangeEnd: null,
+    recommendedTemp: 210,
+    recommendedBedTemp: null,
+    isActive: true,
+    purchaseDate: null,
+    purchaseLocation: '',
+    purchasePriceValue: '20.00',
+    purchasePriceCurrency: 'USD',
+    purchaseNotes: '',
+    storageLocation: 'Shelf',
+    initialLayerTimeS: null,
+    layerTimeS: null,
+    meltingTemperature: null,
+    inertGas: '',
+    materialRefreshRatio: null,
+    notes: '',
+    isFavorite: false,
+    filamentAdjustments: [],
+    filamentRemaining: 750000,
+    filamentLengthRemainingInM: 248,
+    filamentVolumeRemainingInMl: 605,
+  };
+}
 
 describe('FilamentSearchModalComponent', () => {
   let component: FilamentSearchModalComponent;
   let fixture: ComponentFixture<FilamentSearchModalComponent>;
+  let mockFilamentService: jasmine.SpyObj<FilamentService>;
+  let mockDialogRef: jasmine.SpyObj<MatDialogRef<FilamentSearchModalComponent>>;
 
   beforeEach(async () => {
     const mockLogger = jasmine.createSpyObj<LoggingService>('LoggingService', [
       'logEvent',
     ]);
 
-    const mockFilamentService = jasmine.createSpyObj<FilamentService>(
+    mockFilamentService = jasmine.createSpyObj<FilamentService>(
       'FilamentService',
-      ['getCurrentUserFilamentSummaries']
+      ['getCurrentUserFilamentSummaries', 'getFilamentDetail']
     );
+
+    mockDialogRef = jasmine.createSpyObj<
+      MatDialogRef<FilamentSearchModalComponent>
+    >('MatDialogRef', ['close']);
 
     await TestBed.configureTestingModule({
       declarations: [FilamentSearchModalComponent],
@@ -29,8 +88,8 @@ describe('FilamentSearchModalComponent', () => {
       providers: [
         { provide: LoggingService, useValue: mockLogger },
         { provide: FilamentService, useValue: mockFilamentService },
-        { provide: MatDialogRef, useValue: {} },
-        { provide: MAT_DIALOG_DATA, useValue: [] },
+        { provide: MatDialogRef, useValue: mockDialogRef },
+        { provide: MAT_DIALOG_DATA, useValue: {} },
       ],
     }).compileComponents();
   });
@@ -43,5 +102,36 @@ describe('FilamentSearchModalComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('handleQrScanned', () => {
+    it('keeps the remaining filament values from the scanned material', () => {
+      mockFilamentService.getFilamentDetail.and.returnValue(of(buildDetail()));
+
+      component.handleQrScanned({
+        success: true,
+        filamentId: 'filament-1',
+        rawText: 'https://www.3dprintlog.com/materials/filament-1',
+      });
+
+      expect(mockDialogRef.close).toHaveBeenCalled();
+      const selected = mockDialogRef.close.calls.mostRecent().args[0];
+      expect(selected.filamentRemaining).toBe(750000);
+      expect(selected.filamentLengthRemainingInM).toBe(248);
+      expect(selected.filamentVolumeRemainingInMl).toBe(605);
+    });
+
+    it('keeps the remaining values when adding in multi-select mode', () => {
+      component.data.multiSelect = true;
+      mockFilamentService.getFilamentDetail.and.returnValue(of(buildDetail()));
+
+      component.handleQrScanned({
+        success: true,
+        filamentId: 'filament-1',
+        rawText: 'https://www.3dprintlog.com/materials/filament-1',
+      });
+
+      expect(component.selectedFilaments()[0].filamentRemaining).toBe(750000);
+    });
   });
 });

--- a/src/app/shared/filament-search-modal/filament-search-modal.component.ts
+++ b/src/app/shared/filament-search-modal/filament-search-modal.component.ts
@@ -7,6 +7,7 @@ import {
 } from 'src/app/core/services/filament.service';
 import { LoggingService } from 'src/app/core/services/logging.service';
 import { QrScanResult } from 'src/app/core/services/qr-scanner.service';
+import { filamentDetailToSummary } from 'src/app/core/utils/filament-summary';
 
 export interface DialogData {
   otherFilamentOption: any;
@@ -113,35 +114,9 @@ export class FilamentSearchModalComponent {
           filamentId: filament.id,
         });
 
-        // Map FilamentDetail to FilamentSummary format
-        const summary: FilamentSummary = {
-          id: filament.id,
-          displayName: filament.displayName,
-          brand: filament.brand,
-          materialCategoryNickname: filament.materialCategoryNickname,
-          materialType: filament.materialType,
-          materialDensityGramPerCubicCm: filament.materialDensityGramPerCubicCm,
-          colorName: filament.colorName,
-          colorHex: filament.colorHex,
-          colorPattern: filament.colorPattern,
-          colors: filament.colors,
-          finishType: filament.finishType,
-          effects: filament.effects,
-          recommendedTemp: filament.recommendedTemp,
-          isActive: filament.isActive,
-          notes: filament.notes,
-          isFavorite: filament.isFavorite,
-          createdDate: '',
-          filamentRemaining: null,
-          filamentLengthRemainingInM: null,
-          filamentVolumeRemainingInMl: null,
-          purchasePriceValue: filament.purchasePriceValue,
-          initialNominalWeightMg: filament.initialNominalWeightMg,
-          diameterMm: filament.diameterMm ?? 1.75,
-          loadedInPrinter: null,
-          storageLocation: filament.storageLocation,
-          materialCategory: null as any,
-        };
+        // Map FilamentDetail to the FilamentSummary shape the picker expects,
+        // including the server-computed remaining values.
+        const summary = filamentDetailToSummary(filament);
 
         if (this.data.multiSelect) {
           // In multi-select mode: add to selection and switch back to list


### PR DESCRIPTION
## Problem

Selecting a filament by QR code while editing a print loaded the right material, but the little stats panel showed **0 (g) / 0 (m) / 0 (ml) remaining**. Picking the same filament from the material list showed the correct values.

## Root cause

The list path gets a `FilamentSummary` straight from the API. The QR path calls `getFilamentDetail` and maps `FilamentDetail` → `FilamentSummary` by hand in `handleQrScanned`, and that mapping hardcoded the three remaining fields to `null`:

```ts
filamentRemaining: null,
filamentLengthRemainingInM: null,
filamentVolumeRemainingInMl: null,
```

The detail endpoint returns all three (the material detail page's remaining-filament calculator reads them), so they were simply being dropped on the floor.

## Fix

- New `filamentDetailToSummary` helper in `src/app/core/utils/filament-summary.ts` that carries the server-computed remaining values through.
- `FilamentSearchModalComponent.handleQrScanned` uses it (both single- and multi-select paths).
- `FilamentListResolverService` had the identical hand-rolled mapping with the same nulls, so it now shares the helper as well. (Side effect: its `diameterMm` fallback moves from `0` to the helper's `1.75`, matching the picker.)

## Tests

- `filament-summary.spec.ts` — new: values carried through, `undefined` → `null` for untracked spools, identifying fields copied, diameter default.
- `filament-search-modal.component.spec.ts` — new regression tests for the QR path in single- and multi-select mode.

Verified the new tests fail against the old mapping (3 failures) and pass with the fix. `npm run lint:brief` clean; the full `print/` suite (329 specs) passes.

## E2E coverage

`cypress/e2e/filaments/filament-qr-scan.cy.ts` scans a label end to end. There is no way to hold a printed QR code up to a headless browser, and the decoder is not a seam a spec can reach, so `cypress/support/fake-camera.js` replaces the camera instead: a canvas with the QR drawn on it, published as a `MediaStream` from a stubbed `navigator.mediaDevices`. Camera enumeration, the video element, the real `html5-qrcode` decoder, and `parseFilamentUrl` all run as they do in production.

The one trick worth knowing: `html5-qrcode` decodes a `qrbox`-sized crop from the center of the frame, and the source-pixel size of that crop depends on how the video got laid out in the dialog. The fake camera sweeps the QR from small to large across frames so some frame lands the whole code inside the crop. The spec passes in ~4.5s.

Verified against the old mapping, where it fails with the reported symptom:

```
expected 'QR Scan E2E … 0 (g) remaining   (m) remaining   (ml) remaining …'
to match /1,000\s*\(g\) remaining/
```
