### PR TITLE
feat(labels): auto-fit the QR label sheet and remember the layout

### DIFF
--- a/src/app/shared/qr-label-dialog/qr-label-dialog.component.html
+++ b/src/app/shared/qr-label-dialog/qr-label-dialog.component.html
@@ -30,24 +30,6 @@
       </mat-form-field>
 
       <mat-form-field appearance="outline">
-        <mat-label>Columns</mat-label>
-        <mat-select [ngModel]="columns()" (ngModelChange)="columns.set($event)">
-          @for (col of columnOptions; track col) {
-            <mat-option [value]="col">{{ col }}</mat-option>
-          }
-        </mat-select>
-      </mat-form-field>
-
-      <mat-form-field appearance="outline">
-        <mat-label>Rows</mat-label>
-        <mat-select [ngModel]="rows()" (ngModelChange)="rows.set($event)">
-          @for (row of rowOptions; track row) {
-            <mat-option [value]="row">{{ row }}</mat-option>
-          }
-        </mat-select>
-      </mat-form-field>
-
-      <mat-form-field appearance="outline">
         <mat-label>Label Size</mat-label>
         <mat-select
           [ngModel]="labelSize()"
@@ -74,8 +56,68 @@
       </mat-form-field>
     </div>
 
+    <div class="advanced-panel no-print">
+      <button
+        id="toggle-advanced-layout"
+        mat-button
+        type="button"
+        (click)="toggleAdvanced()"
+        [attr.aria-expanded]="showAdvanced()"
+        aria-controls="advanced-layout"
+      >
+        <mat-icon>{{
+          showAdvanced() ? 'expand_less' : 'expand_more'
+        }}</mat-icon>
+        Advanced layout
+      </button>
+
+      @if (showAdvanced()) {
+        <div id="advanced-layout" class="advanced-controls">
+          <mat-form-field appearance="outline">
+            <mat-label>Columns</mat-label>
+            <mat-select
+              [ngModel]="columns()"
+              (ngModelChange)="columnOverride.set($event)"
+            >
+              @for (col of columnOptions(); track col) {
+                <mat-option [value]="col">{{ col }}</mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
+            <mat-label>Rows</mat-label>
+            <mat-select
+              [ngModel]="rows()"
+              (ngModelChange)="rowOverride.set($event)"
+            >
+              @for (row of rowOptions(); track row) {
+                <mat-option [value]="row">{{ row }}</mat-option>
+              }
+            </mat-select>
+          </mat-form-field>
+
+          <button
+            id="reset-to-auto-fit"
+            mat-stroked-button
+            type="button"
+            (click)="resetToAutoFit()"
+            [disabled]="isAutoFit()"
+          >
+            Reset to auto-fit
+          </button>
+        </div>
+      }
+    </div>
+
     <div class="page-info no-print">
-      {{ displayLabels().length }} labels across {{ pages().length }} page(s)
+      <span id="fit-summary">
+        Fits {{ columns() }} x {{ rows() }} per sheet - {{ itemsPerPage() }}
+        labels/page
+      </span>
+      <span>
+        {{ displayLabels().length }} labels across {{ pages().length }} page(s)
+      </span>
     </div>
 
     <div class="print-container">

--- a/src/app/shared/qr-label-dialog/qr-label-dialog.component.scss
+++ b/src/app/shared/qr-label-dialog/qr-label-dialog.component.scss
@@ -196,3 +196,30 @@
 .filament-temp {
   color: rgba(0, 0, 0, 0.6);
 }
+
+.advanced-panel {
+  margin-bottom: 8px;
+}
+
+.advanced-controls {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  flex-wrap: wrap;
+  padding: 8px 0 0 8px;
+
+  mat-form-field {
+    width: auto;
+  }
+}
+
+.page-info {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+
+  #fit-summary {
+    font-weight: 600;
+    color: var(--app-text-primary);
+  }
+}

--- a/src/app/shared/qr-label-dialog/qr-label-dialog.component.spec.ts
+++ b/src/app/shared/qr-label-dialog/qr-label-dialog.component.spec.ts
@@ -13,6 +13,7 @@ import {
 } from './qr-label-dialog.component';
 import { QrCodeService } from 'src/app/core/services/qr-code.service';
 import { LoggingService } from 'src/app/core/services/logging.service';
+import { ToastrService } from 'ngx-toastr';
 import {
   ColorPatternType,
   FilamentEffect,
@@ -26,6 +27,7 @@ describe('QrLabelDialogComponent', () => {
   let mockDialogRef: jasmine.SpyObj<MatDialogRef<QrLabelDialogComponent>>;
   let mockQrCodeService: jasmine.SpyObj<QrCodeService>;
   let mockLoggingService: jasmine.SpyObj<LoggingService>;
+  let mockToastr: jasmine.SpyObj<ToastrService>;
 
   const mockFilament: FilamentSummary = {
     id: 'test-id-123',
@@ -66,7 +68,12 @@ describe('QrLabelDialogComponent', () => {
       'generateSvg',
       'generateFilamentUrl',
     ]);
-    mockLoggingService = jasmine.createSpyObj('LoggingService', ['logEvent']);
+    mockLoggingService = jasmine.createSpyObj('LoggingService', [
+      'logEvent',
+      'logException',
+    ]);
+    mockToastr = jasmine.createSpyObj('ToastrService', ['warning']);
+    localStorage.removeItem('qr_label_layout');
 
     mockQrCodeService.generateFilamentUrl.and.callFake(
       (id: string) => `https://example.com/materials/${id}`
@@ -82,6 +89,7 @@ describe('QrLabelDialogComponent', () => {
         { provide: MAT_DIALOG_DATA, useValue: mockDialogData },
         { provide: QrCodeService, useValue: mockQrCodeService },
         { provide: LoggingService, useValue: mockLoggingService },
+        { provide: ToastrService, useValue: mockToastr },
       ],
     }).compileComponents();
 
@@ -89,15 +97,21 @@ describe('QrLabelDialogComponent', () => {
     component = fixture.componentInstance;
   });
 
+  afterEach(() => {
+    localStorage.removeItem('qr_label_layout');
+  });
+
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should initialize with default settings', () => {
-    expect(component.columns()).toBe(2);
-    expect(component.rows()).toBe(5);
+  it('should initialize with a grid that fills the default sheet', () => {
     expect(component.labelSize()).toBe('medium');
     expect(component.paperSize()).toBe('A4');
+    // Medium labels on A4: 2 across, 8 down.
+    expect(component.columns()).toBe(2);
+    expect(component.rows()).toBe(8);
+    expect(component.isAutoFit()).toBe(true);
     expect(component.loading()).toBe(true);
   });
 
@@ -119,7 +133,8 @@ describe('QrLabelDialogComponent', () => {
     expect(mockDialogRef.close).toHaveBeenCalled();
   });
 
-  it('should open print window when print is called', async () => {
+  function stubPrintWindow() {
+    const listeners: Record<string, () => void> = {};
     const mockPrintWindow = {
       document: {
         write: jasmine.createSpy('write'),
@@ -128,10 +143,19 @@ describe('QrLabelDialogComponent', () => {
       focus: jasmine.createSpy('focus'),
       print: jasmine.createSpy('print'),
       close: jasmine.createSpy('close'),
-      onload: null as (() => void) | null,
+      addEventListener: (event: string, handler: () => void) => {
+        listeners[event] = handler;
+      },
+      fire: (event: string) => listeners[event]?.(),
+      hasListener: (event: string) => Boolean(listeners[event]),
     };
 
     spyOn(window, 'open').and.returnValue(mockPrintWindow as unknown as Window);
+    return mockPrintWindow;
+  }
+
+  it('prints as soon as the document is written, without waiting on load', async () => {
+    const mockPrintWindow = stubPrintWindow();
 
     fixture.detectChanges();
     await fixture.whenStable();
@@ -141,24 +165,147 @@ describe('QrLabelDialogComponent', () => {
     expect(window.open).toHaveBeenCalledWith('', '_blank');
     expect(mockPrintWindow.document.write).toHaveBeenCalled();
     expect(mockPrintWindow.document.close).toHaveBeenCalled();
+    expect(mockPrintWindow.focus).toHaveBeenCalled();
+    expect(mockPrintWindow.print).toHaveBeenCalled();
+  });
 
-    // Simulate onload callback
-    if (mockPrintWindow.onload) {
-      mockPrintWindow.onload();
-      expect(mockPrintWindow.focus).toHaveBeenCalled();
-      expect(mockPrintWindow.print).toHaveBeenCalled();
-      expect(mockPrintWindow.close).toHaveBeenCalled();
-    }
+  it('leaves the print window open until the print finishes', async () => {
+    const mockPrintWindow = stubPrintWindow();
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    component.print();
+
+    // Closing during printing cancels the job in browsers where print() does
+    // not block, so the window survives until afterprint.
+    expect(mockPrintWindow.close).not.toHaveBeenCalled();
+    expect(mockPrintWindow.hasListener('afterprint')).toBe(true);
+
+    mockPrintWindow.fire('afterprint');
+    expect(mockPrintWindow.close).toHaveBeenCalled();
+  });
+
+  it('warns instead of alerting when the print window is blocked', async () => {
+    spyOn(window, 'open').and.returnValue(null);
+
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    component.print();
+
+    expect(mockToastr.warning).toHaveBeenCalled();
+    expect(mockLoggingService.logEvent).toHaveBeenCalledWith(
+      'QrLabelDialog_PrintPopupBlocked'
+    );
   });
 
   it('should compute items per page based on columns and rows', () => {
-    component.columns.set(2);
-    component.rows.set(5);
+    component.columnOverride.set(2);
+    component.rowOverride.set(5);
     expect(component.itemsPerPage()).toBe(10);
 
-    component.columns.set(3);
-    component.rows.set(4);
+    component.labelSize.set('small');
+    component.columnOverride.set(3);
+    component.rowOverride.set(4);
     expect(component.itemsPerPage()).toBe(12);
+  });
+
+  describe('grid fitting', () => {
+    it('re-fits the grid when the paper or label size changes', () => {
+      component.labelSize.set('large');
+      expect(component.columns()).toBe(2);
+      expect(component.rows()).toBe(7);
+
+      component.paperSize.set('A5');
+      expect(component.columns()).toBe(1);
+      expect(component.rows()).toBe(5);
+    });
+
+    it('only offers column and row counts that fit the sheet', () => {
+      component.paperSize.set('A5');
+      component.labelSize.set('large');
+
+      expect(component.columnOptions()).toEqual([1]);
+      expect(component.rowOptions()).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('caps an override that no longer fits instead of overflowing the page', () => {
+      component.labelSize.set('small');
+      component.columnOverride.set(3);
+      expect(component.columns()).toBe(3);
+
+      // Large labels only fit two across, so the stored 3 has to give way.
+      component.labelSize.set('large');
+      expect(component.columns()).toBe(2);
+    });
+
+    it('returns to auto-fit when the override is cleared', () => {
+      component.columnOverride.set(1);
+      component.rowOverride.set(2);
+      expect(component.isAutoFit()).toBe(false);
+
+      component.resetToAutoFit();
+
+      expect(component.isAutoFit()).toBe(true);
+      expect(component.columns()).toBe(2);
+      expect(component.rows()).toBe(8);
+    });
+  });
+
+  describe('remembered layout', () => {
+    function createDialog() {
+      const created = TestBed.createComponent(QrLabelDialogComponent);
+      created.detectChanges();
+      return created.componentInstance;
+    }
+
+    it('restores the layout chosen last time', () => {
+      fixture.detectChanges();
+      component.paperSize.set('Letter');
+      component.labelSize.set('small');
+      component.copies.set(3);
+      component.columnOverride.set(2);
+      fixture.detectChanges();
+
+      const reopened = createDialog();
+
+      expect(reopened.paperSize()).toBe('Letter');
+      expect(reopened.labelSize()).toBe('small');
+      expect(reopened.copies()).toBe(3);
+      expect(reopened.columnOverride()).toBe(2);
+    });
+
+    it('falls back to the defaults when the stored layout is unreadable', () => {
+      localStorage.setItem('qr_label_layout', 'not json');
+
+      const reopened = createDialog();
+
+      expect(reopened.paperSize()).toBe('A4');
+      expect(reopened.labelSize()).toBe('medium');
+    });
+
+    it('ignores a stored paper size the dialog no longer offers', () => {
+      localStorage.setItem(
+        'qr_label_layout',
+        JSON.stringify({ paperSize: 'Legal', labelSize: 'medium', copies: 1 })
+      );
+
+      const reopened = createDialog();
+
+      expect(reopened.paperSize()).toBe('A4');
+    });
+
+    it('clamps a stored copy count that is out of range', () => {
+      localStorage.setItem(
+        'qr_label_layout',
+        JSON.stringify({ paperSize: 'A4', labelSize: 'medium', copies: 999 })
+      );
+
+      const reopened = createDialog();
+
+      expect(reopened.copies()).toBe(10);
+    });
   });
 
   it('should compute pages array based on labels and items per page', fakeAsync(() => {
@@ -166,8 +313,8 @@ describe('QrLabelDialogComponent', () => {
     flushMicrotasks();
     fixture.detectChanges();
 
-    component.columns.set(2);
-    component.rows.set(5);
+    component.columnOverride.set(2);
+    component.rowOverride.set(5);
 
     // With 1 label and 10 items per page, should have 1 page
     expect(component.pages().length).toBe(1);
@@ -175,7 +322,8 @@ describe('QrLabelDialogComponent', () => {
   }));
 
   it('should compute grid style based on columns', () => {
-    component.columns.set(3);
+    component.labelSize.set('small');
+    component.columnOverride.set(3);
     expect(component.gridStyle()).toEqual({
       'grid-template-columns': 'repeat(3, 1fr)',
     });
@@ -258,6 +406,7 @@ describe('QrLabelDialogComponent', () => {
           },
           { provide: QrCodeService, useValue: mockQrCodeService },
           { provide: LoggingService, useValue: mockLoggingService },
+          { provide: ToastrService, useValue: mockToastr },
         ],
       }).compileComponents();
 
@@ -279,10 +428,9 @@ describe('QrLabelDialogComponent', () => {
       flushMicrotasks();
       fixture.detectChanges();
 
-      // Default: 2 columns x 5 rows = 10 items per page
-      // 15 labels = 2 pages (10 + 5)
-      component.columns.set(2);
-      component.rows.set(5);
+      // 2 columns x 5 rows = 10 items per page; 15 labels = 2 pages (10 + 5)
+      component.columnOverride.set(2);
+      component.rowOverride.set(5);
 
       expect(component.pages().length).toBe(2);
       expect(component.pages()[0].length).toBe(10);

--- a/src/app/shared/qr-label-dialog/qr-label-dialog.component.ts
+++ b/src/app/shared/qr-label-dialog/qr-label-dialog.component.ts
@@ -1,13 +1,15 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  PLATFORM_ID,
   computed,
+  effect,
   inject,
   OnDestroy,
   OnInit,
   signal,
 } from '@angular/core';
-import { CommonModule, DOCUMENT } from '@angular/common';
+import { CommonModule, DOCUMENT, isPlatformBrowser } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import {
   MAT_DIALOG_DATA,
@@ -25,13 +27,18 @@ import { FilamentSummary } from 'src/app/core/services/filament.service';
 import { LoggingService } from 'src/app/core/services/logging.service';
 import { QrCodeService } from 'src/app/core/services/qr-code.service';
 import { MatInputModule } from '@angular/material/input';
+import { ToastrService } from 'ngx-toastr';
+import {
+  LABEL_DIMENSIONS,
+  LabelSize,
+  PAPER_DIMENSIONS,
+  PaperSize,
+  fitGrid,
+} from './qr-label-layout';
 
 export interface QrLabelDialogData {
   filaments: FilamentSummary[];
 }
-
-export type LabelSize = 'small' | 'medium' | 'large';
-export type PaperSize = 'A4' | 'Letter' | 'A5';
 
 interface LabelData {
   filament: FilamentSummary;
@@ -40,22 +47,23 @@ interface LabelData {
   url: string;
 }
 
-interface PaperDimensions {
-  width: number;
-  height: number;
+/**
+ * The layout choices remembered between visits. Printing labels is repetitive -
+ * the same paper, the same label stock - so re-picking every control on every
+ * open is pure friction.
+ */
+interface StoredLayout {
+  paperSize: PaperSize;
+  labelSize: LabelSize;
+  copies: number;
+  columnOverride: number | null;
+  rowOverride: number | null;
 }
 
-const PAPER_DIMENSIONS: Record<PaperSize, PaperDimensions> = {
-  A4: { width: 210, height: 297 },
-  Letter: { width: 216, height: 279 },
-  A5: { width: 148, height: 210 },
-};
+const LAYOUT_STORAGE_KEY = 'qr_label_layout';
 
-const LABEL_DIMENSIONS: Record<LabelSize, { width: number; height: number }> = {
-  small: { width: 50, height: 25 },
-  medium: { width: 70, height: 30 },
-  large: { width: 90, height: 35 },
-};
+const MIN_COPIES = 1;
+const MAX_COPIES = 10;
 
 @Component({
   selector: 'app-qr-label-dialog',
@@ -81,12 +89,12 @@ export class QrLabelDialogComponent implements OnInit, OnDestroy {
   private readonly loggingService = inject(LoggingService);
   private readonly sanitizer = inject(DomSanitizer);
   private readonly document = inject(DOCUMENT);
+  private readonly toastr = inject(ToastrService);
+  private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
-  readonly columns = signal(2);
-  readonly rows = signal(5);
-  readonly copies = signal(1);
+  readonly copies = signal(MIN_COPIES);
   readonly safeCopies = computed(() =>
-    Math.max(1, Math.min(10, this.copies()))
+    Math.max(MIN_COPIES, Math.min(MAX_COPIES, this.copies()))
   );
   readonly labelSize = signal<LabelSize>('medium');
   readonly paperSize = signal<PaperSize>('A4');
@@ -94,8 +102,15 @@ export class QrLabelDialogComponent implements OnInit, OnDestroy {
   readonly error = signal<string | null>(null);
   readonly labels = signal<LabelData[]>([]);
 
-  readonly columnOptions = [1, 2, 3, 4];
-  readonly rowOptions = [3, 4, 5, 6, 7, 8, 9, 10];
+  /**
+   * Manual grid choices. Null means "however many fit", which is what almost
+   * everyone wants; the selects behind Advanced layout set these for the rare
+   * sheet of pre-cut labels that does not match the auto-fit.
+   */
+  readonly columnOverride = signal<number | null>(null);
+  readonly rowOverride = signal<number | null>(null);
+  readonly showAdvanced = signal(false);
+
   readonly labelSizeOptions: { value: LabelSize; label: string }[] = [
     { value: 'small', label: 'Small (50x25mm)' },
     { value: 'medium', label: 'Medium (70x30mm)' },
@@ -106,6 +121,27 @@ export class QrLabelDialogComponent implements OnInit, OnDestroy {
     { value: 'Letter', label: 'Letter (216x279mm)' },
     { value: 'A5', label: 'A5 (148x210mm)' },
   ];
+
+  /** The most labels of the chosen size that fit the chosen sheet. */
+  readonly autoFitGrid = computed(() =>
+    fitGrid(this.paperDimensions(), this.labelDimensions())
+  );
+
+  // An override is capped by what fits, so shrinking the paper (or growing the
+  // label) can never leave a stale choice that overflows the page.
+  readonly columns = computed(() =>
+    Math.min(this.columnOverride() ?? Infinity, this.autoFitGrid().columns)
+  );
+  readonly rows = computed(() =>
+    Math.min(this.rowOverride() ?? Infinity, this.autoFitGrid().rows)
+  );
+
+  readonly columnOptions = computed(() => range(this.autoFitGrid().columns));
+  readonly rowOptions = computed(() => range(this.autoFitGrid().rows));
+
+  readonly isAutoFit = computed(
+    () => this.columnOverride() === null && this.rowOverride() === null
+  );
 
   readonly itemsPerPage = computed(() => this.columns() * this.rows());
 
@@ -138,6 +174,14 @@ export class QrLabelDialogComponent implements OnInit, OnDestroy {
   readonly gridStyle = computed(() => ({
     'grid-template-columns': `repeat(${this.columns()}, 1fr)`,
   }));
+
+  constructor() {
+    this.restoreLayout();
+
+    // Remembered as they change rather than on print, so a layout picked and
+    // then abandoned is still there next time.
+    effect(() => this.persistLayout());
+  }
 
   ngOnInit(): void {
     this.loggingService.logEvent('QrLabelDialog_Opened', {
@@ -204,23 +248,29 @@ export class QrLabelDialogComponent implements OnInit, OnDestroy {
       labelSize: this.labelSize(),
     });
 
-    // Open a new window for printing
     const printWindow = window.open('', '_blank');
     if (!printWindow) {
-      alert('Please allow popups to print labels');
+      this.loggingService.logEvent('QrLabelDialog_PrintPopupBlocked');
+      this.toastr.warning(
+        'Your browser blocked the print window. Allow popups for this site, then print again.',
+        'Popup blocked'
+      );
       return;
     }
 
-    const content = this.generatePrintHtml();
-    printWindow.document.write(content);
+    printWindow.document.write(this.generatePrintHtml());
     printWindow.document.close();
 
-    // Wait for content to load, then print
-    printWindow.onload = () => {
-      printWindow.focus();
-      printWindow.print();
-      printWindow.close();
-    };
+    // Print as soon as the document is written instead of waiting on `onload`.
+    // Everything the sheet needs is inline - the QR codes are SVG markup and the
+    // styles are a <style> block - so there is nothing left to load, and a load
+    // event that has already gone by would never reach a handler attached here.
+    printWindow.focus();
+    // Closing straight after `print()` races browsers that do not block on the
+    // print dialog, which cancels the job. A window left open is recoverable;
+    // a cancelled print is not.
+    printWindow.addEventListener('afterprint', () => printWindow.close());
+    printWindow.print();
   }
 
   private generatePrintHtml(): string {
@@ -465,7 +515,110 @@ export class QrLabelDialogComponent implements OnInit, OnDestroy {
     this.copies.set(this.safeCopies());
   }
 
+  toggleAdvanced(): void {
+    this.showAdvanced.update((shown) => !shown);
+  }
+
+  resetToAutoFit(): void {
+    this.columnOverride.set(null);
+    this.rowOverride.set(null);
+  }
+
+  private restoreLayout(): void {
+    const stored = this.readStoredLayout();
+    if (!stored) {
+      return;
+    }
+
+    this.paperSize.set(stored.paperSize);
+    this.labelSize.set(stored.labelSize);
+    this.copies.set(stored.copies);
+    this.columnOverride.set(stored.columnOverride);
+    this.rowOverride.set(stored.rowOverride);
+  }
+
+  /**
+   * Reads the remembered layout, ignoring anything that is not a value this
+   * dialog currently offers. Storage is shared with older and newer builds of
+   * the app and is editable by hand, so a stored paper size that no longer
+   * exists has to fall back to the defaults rather than render an empty select.
+   */
+  private readStoredLayout(): StoredLayout | null {
+    if (!this.isBrowser) {
+      return null;
+    }
+
+    try {
+      const raw = localStorage.getItem(LAYOUT_STORAGE_KEY);
+      if (!raw) {
+        return null;
+      }
+
+      const parsed = JSON.parse(raw) as Partial<StoredLayout>;
+      const paperSize = parsed.paperSize;
+      const labelSize = parsed.labelSize;
+
+      if (
+        !paperSize ||
+        !(paperSize in PAPER_DIMENSIONS) ||
+        !labelSize ||
+        !(labelSize in LABEL_DIMENSIONS)
+      ) {
+        return null;
+      }
+
+      return {
+        paperSize,
+        labelSize,
+        copies: clampCopiesValue(parsed.copies),
+        columnOverride: readOverride(parsed.columnOverride),
+        rowOverride: readOverride(parsed.rowOverride),
+      };
+    } catch {
+      // Corrupt, or storage is unavailable (private mode): defaults are fine.
+      return null;
+    }
+  }
+
+  private persistLayout(): void {
+    if (!this.isBrowser) {
+      return;
+    }
+
+    const layout: StoredLayout = {
+      paperSize: this.paperSize(),
+      labelSize: this.labelSize(),
+      copies: this.safeCopies(),
+      columnOverride: this.columnOverride(),
+      rowOverride: this.rowOverride(),
+    };
+
+    try {
+      localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(layout));
+    } catch {
+      // Storage full or blocked - failing to remember a layout is not an error
+      // worth showing anyone.
+    }
+  }
+
   close(): void {
     this.dialogRef.close();
   }
+}
+
+function range(count: number): number[] {
+  return Array.from({ length: count }, (_, index) => index + 1);
+}
+
+function clampCopiesValue(value: unknown): number {
+  const copies = Math.floor(Number(value));
+  if (!Number.isFinite(copies)) {
+    return MIN_COPIES;
+  }
+  return Math.max(MIN_COPIES, Math.min(MAX_COPIES, copies));
+}
+
+function readOverride(value: unknown): number | null {
+  const override = Math.floor(Number(value));
+  return Number.isFinite(override) && override >= 1 ? override : null;
 }

--- a/src/app/shared/qr-label-dialog/qr-label-layout.spec.ts
+++ b/src/app/shared/qr-label-dialog/qr-label-layout.spec.ts
@@ -1,0 +1,46 @@
+import { LABEL_DIMENSIONS, PAPER_DIMENSIONS, fitGrid } from './qr-label-layout';
+
+describe('qr-label-layout', () => {
+  describe('fitGrid', () => {
+    it('fills an A4 sheet with medium labels', () => {
+      // 190mm usable width / 70mm labels => 2 across;
+      // 277mm usable height / 30mm labels => 8 down.
+      expect(fitGrid(PAPER_DIMENSIONS.A4, LABEL_DIMENSIONS.medium)).toEqual({
+        columns: 2,
+        rows: 8,
+      });
+    });
+
+    it('fits fewer large labels than small ones on the same sheet', () => {
+      const small = fitGrid(PAPER_DIMENSIONS.A4, LABEL_DIMENSIONS.small);
+      const large = fitGrid(PAPER_DIMENSIONS.A4, LABEL_DIMENSIONS.large);
+
+      expect(small).toEqual({ columns: 3, rows: 10 });
+      expect(large).toEqual({ columns: 2, rows: 7 });
+    });
+
+    it('accounts for the smaller A5 sheet', () => {
+      expect(fitGrid(PAPER_DIMENSIONS.A5, LABEL_DIMENSIONS.large)).toEqual({
+        columns: 1,
+        rows: 5,
+      });
+    });
+
+    it('accounts for the wider Letter sheet', () => {
+      expect(fitGrid(PAPER_DIMENSIONS.Letter, LABEL_DIMENSIONS.medium)).toEqual(
+        {
+          columns: 2,
+          rows: 7,
+        }
+      );
+    });
+
+    it('never returns a grid with no cells', () => {
+      // A label wider and taller than any sheet still has to render one per page
+      // rather than a page that can hold nothing.
+      expect(
+        fitGrid({ width: 40, height: 40 }, { width: 500, height: 500 })
+      ).toEqual({ columns: 1, rows: 1 });
+    });
+  });
+});

--- a/src/app/shared/qr-label-dialog/qr-label-layout.ts
+++ b/src/app/shared/qr-label-dialog/qr-label-layout.ts
@@ -1,0 +1,58 @@
+export type LabelSize = 'small' | 'medium' | 'large';
+export type PaperSize = 'A4' | 'Letter' | 'A5';
+
+export interface Dimensions {
+  width: number;
+  height: number;
+}
+
+export interface Grid {
+  columns: number;
+  rows: number;
+}
+
+export const PAPER_DIMENSIONS: Record<PaperSize, Dimensions> = {
+  A4: { width: 210, height: 297 },
+  Letter: { width: 216, height: 279 },
+  A5: { width: 148, height: 210 },
+};
+
+export const LABEL_DIMENSIONS: Record<LabelSize, Dimensions> = {
+  small: { width: 50, height: 25 },
+  medium: { width: 70, height: 30 },
+  large: { width: 90, height: 35 },
+};
+
+/** Page padding, in mm — must match the `.print-page` padding in both the preview and the print stylesheet. */
+export const PAGE_PADDING_MM = 10;
+
+/** Gap between labels, in mm — must match the `.print-grid` gap in both stylesheets. */
+export const LABEL_GAP_MM = 3;
+
+function fitAlong(available: number, cell: number): number {
+  // n cells need n * cell + (n - 1) * gap, which rearranges to this. At least
+  // one either way: a page that holds nothing is worse than one that overflows.
+  return Math.max(
+    1,
+    Math.floor((available + LABEL_GAP_MM) / (cell + LABEL_GAP_MM))
+  );
+}
+
+/**
+ * The largest grid of labels that fits on a sheet.
+ *
+ * Paper size, label size, columns, and rows used to be four independent
+ * choices, which let the dialog lay out (say) four 90mm labels across 190mm of
+ * usable A4 — the preview overflowed and the printed sheet was unusable. The
+ * grid is derived from the paper and label size instead, and this is also the
+ * ceiling for a manual override.
+ */
+export function fitGrid(paper: Dimensions, label: Dimensions): Grid {
+  const usableWidth = paper.width - PAGE_PADDING_MM * 2;
+  const usableHeight = paper.height - PAGE_PADDING_MM * 2;
+
+  return {
+    columns: fitAlong(usableWidth, label.width),
+    rows: fitAlong(usableHeight, label.height),
+  };
+}


### PR DESCRIPTION
Quality-of-life work on QR label creation, from the discussion after #134.

## 1. The grid now fits the paper

Paper size, label size, columns, and rows were four independent controls with no relationship enforced. 4 columns of large labels is 360mm of labels across 190mm of usable A4 — and since the grid uses `1fr` columns while `.qr-code` holds a hard 28mm `min-width`, cells squeezed to 47.5mm and crushed the text. 10 rows of large is 350mm down a 277mm page, and `.print-page` is a fixed-mm box, so it simply spilled. `columnOptions` offered `4`, which does not fit any paper at any label size.

New `qr-label-layout.ts` derives the grid instead:

```ts
fitGrid(paper, label) → { columns, rows }
// usable = paper − 2 × 10mm page padding; cells separated by the existing 3mm gap
```

| Paper + label | Grid |
|---|---|
| A4 + medium | 2 × 8 |
| A4 + large | 2 × 7 |
| A4 + small | 3 × 10 |
| A5 + large | 1 × 5 |
| Letter + medium | 2 × 7 |

`columns`/`rows` became `computed`, reading `columnOverride ?? autoFit` and clamped to what fits — so an override that stops fitting (shrink the paper, grow the label) gives way instead of overflowing. The two selects moved behind an **Advanced layout** toggle with option lists computed from the fit, plus **Reset to auto-fit**. The header reads `Fits 2 × 8 per sheet — 16 labels/page`.

**Visible change:** the default A4 sheet goes from 10 medium labels to 16, because auto-fit uses the whole page.

## 2. The layout is remembered

One `qr_label_layout` localStorage key holds `{ paperSize, labelSize, copies, columnOverride, rowOverride }`, written by an `effect()` on change (so a layout picked and then abandoned still returns) and read on init. Every field is validated against the options the dialog currently offers; a stored paper size that no longer exists, a copy count out of range, or corrupt JSON falls back to the defaults rather than rendering an empty select. Guarded with `isPlatformBrowser`.

Deliberately localStorage rather than a `UserSettingType` — that would need the API's enum extended, and this keeps the change UI-only for now.

## 3. Print window

- The popup-blocked path used a raw `alert()`; it now raises a toastr warning like the rest of the app and logs `QrLabelDialog_PrintPopupBlocked`.
- `printWindow.onload` was assigned *after* `document.write`/`document.close()` — a load event that has already gone by never reaches a handler attached there, and the failure mode is a silent no-print. Everything on the sheet is inline (QR codes are SVG markup, styles are a `<style>` block), so there is nothing to wait for: it now prints straight after the write. I removed the dependency rather than determining whether the event happens to fire in each browser, since the fix is correct either way.
- The window closed immediately after `print()`, which cancels the job in browsers where `print()` does not block. It now closes on `afterprint`. A window left open is recoverable; a cancelled print is not.

## Testing

- `qr-label-layout.spec.ts` — new: every paper × label combination, and the floor of one cell per page.
- `qr-label-dialog.component.spec.ts` — re-fitting on paper/label change, clamped option lists, an override capped when it stops fitting, reset-to-auto-fit, and four persistence cases (restore, corrupt JSON, unknown paper size, out-of-range copies). The print tests now assert printing without a load event, that the window survives until `afterprint`, and the toastr warning.

Full unit suite green (1316). Verified in Chrome against the dev API: A5 + large renders `Fits 1 × 5 per sheet`, the Columns list collapses to `[1]`, and the layout comes back both on reopen and after a page reload. I did not trigger a real print — that opens a modal print dialog — so the print-window behavior is covered by unit tests only.