### PR TITLE
fix: estimate Nylon filament usage

### DIFF
--- a/src/app/core/services/file-parsers/anycubic/anycubic-file-parser.service.spec.ts
+++ b/src/app/core/services/file-parsers/anycubic/anycubic-file-parser.service.spec.ts
@@ -46,6 +46,24 @@ describe('AnycubicFileParserService filament estimates', () => {
     service = TestBed.inject(AnycubicFileParserService);
   });
 
+  it('should estimate Nylon weight from filament length and diameter', () => {
+    const testGcode = `; filament used [g] = 0.0
+; filament_type = Nylon
+; filament_diameter = 1.75
+; filament used [mm] = 1000`;
+
+    expect(service.estimateFilamentUsageInMg(testGcode)).toBe(2549);
+  });
+
+  it('should return undefined for a material it has no density for', () => {
+    const testGcode = `; filament used [g] = 0.0
+; filament_type = TPU
+; filament_diameter = 1.75
+; filament used [mm] = 1000`;
+
+    expect(service.estimateFilamentUsageInMg(testGcode)).toBeUndefined();
+  });
+
   it('should return undefined when diameter or length is missing or zero', () => {
     const invalidInputs = [
       `; filament_type = PLA

--- a/src/app/core/services/file-parsers/anycubic/anycubic-file-parser.service.ts
+++ b/src/app/core/services/file-parsers/anycubic/anycubic-file-parser.service.ts
@@ -9,23 +9,7 @@ import {
   PrintStatus,
 } from '../../print.service';
 import { EditPrintDetailComponent } from 'src/app/print/edit-print-detail/edit-print-detail.component';
-
-//
-export interface MaterialDensityGramsPerCubicCm {
-  PLA: number;
-  ABS: number;
-  PETG: number;
-  Nylon: number;
-}
-
-export class MaterialDensities {
-  static materials: MaterialDensityGramsPerCubicCm = {
-    PLA: 1.24,
-    ABS: 1.04,
-    PETG: 1.23,
-    Nylon: 1.06,
-  };
-}
+import { calculateFilamentWeightInMg } from '../filament-usage.utils';
 
 @Injectable({
   providedIn: 'root',
@@ -115,46 +99,11 @@ export class AnycubicFileParserService implements GcodeNewPrintParser {
       return undefined;
     }
 
-    if (filamentType.includes('PLA')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.PLA,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
-    } else if (filamentType.includes('ABS')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.ABS,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
-    } else if (filamentType.includes('PETG')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.PETG,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
-    }
-
-    // Only PLA, ABS and PETG are handled above, so anything else is unknown
-    // rather than zero. Note MaterialDensities also declares Nylon, which this
-    // chain never reaches -- see #100.
-    return undefined;
-  }
-
-  private calculateWeightInMg(
-    materialDensityGramsPerCubicCm: number,
-    lengthInMm: number,
-    diameterInMm: number
-  ) {
-    const radiusInMm = diameterInMm / 2;
-    const filamentAreaInMm2 = Math.PI * radiusInMm * radiusInMm;
-
-    const volume = filamentAreaInMm2 * lengthInMm;
-
-    const densityInCubicMm = materialDensityGramsPerCubicCm / 1000;
-
-    const weightInGrams = volume * densityInCubicMm;
-    return Math.floor(weightInGrams * 1000);
+    return calculateFilamentWeightInMg(
+      filamentType,
+      filamentUsageLengthInMM,
+      filamentDiameter
+    );
   }
 
   parseSettingsIntoNotes(gcode: string): string {

--- a/src/app/core/services/file-parsers/creality-print/creality-print-file-parser.service.spec.ts
+++ b/src/app/core/services/file-parsers/creality-print/creality-print-file-parser.service.spec.ts
@@ -59,6 +59,22 @@ Adaptive Layers:0`);
   });
 
   describe('estimateFilamentUsageInMg', () => {
+    it('should estimate Nylon weight from filament length and diameter', () => {
+      const testGcode = `; filament_type:Nylon
+; filament_diameter:1.75
+; filament used [mm]:1000`;
+
+      expect(service.estimateFilamentUsageInMg(testGcode)).toBe(2549);
+    });
+
+    it('should return undefined for a material it has no density for', () => {
+      const testGcode = `; filament_type:TPU
+; filament_diameter:1.75
+; filament used [mm]:1000`;
+
+      expect(service.estimateFilamentUsageInMg(testGcode)).toBeUndefined();
+    });
+
     it('should return undefined when diameter or length is missing or zero', () => {
       const invalidInputs = [
         `; filament_type = PLA

--- a/src/app/core/services/file-parsers/creality-print/creality-print-file-parser.service.ts
+++ b/src/app/core/services/file-parsers/creality-print/creality-print-file-parser.service.ts
@@ -9,23 +9,7 @@ import {
   PrintStatus,
 } from '../../print.service';
 import { FilamentSummary } from '../../filament.service';
-
-//
-export interface MaterialDensityGramsPerCubicCm {
-  PLA: number;
-  ABS: number;
-  PETG: number;
-  Nylon: number;
-}
-
-export class MaterialDensities {
-  static materials: MaterialDensityGramsPerCubicCm = {
-    PLA: 1.24,
-    ABS: 1.04,
-    PETG: 1.23,
-    Nylon: 1.06,
-  };
-}
+import { calculateFilamentWeightInMg } from '../filament-usage.utils';
 
 @Injectable({
   providedIn: 'root',
@@ -115,46 +99,11 @@ export class CrealityPrintFileParserService implements GcodeNewPrintParser {
       return undefined;
     }
 
-    if (filamentType.includes('PLA')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.PLA,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
-    } else if (filamentType.includes('ABS')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.ABS,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
-    } else if (filamentType.includes('PETG')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.PETG,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
-    }
-
-    // Only PLA, ABS and PETG are handled above, so anything else is unknown
-    // rather than zero. Note MaterialDensities also declares Nylon, which this
-    // chain never reaches -- see #100.
-    return undefined;
-  }
-
-  private calculateWeightInMg(
-    materialDensityGramsPerCubicCm: number,
-    lengthInMm: number,
-    diameterInMm: number
-  ) {
-    const radiusInMm = diameterInMm / 2;
-    const filamentAreaInMm2 = Math.PI * radiusInMm * radiusInMm;
-
-    const volume = filamentAreaInMm2 * lengthInMm;
-
-    const densityInCubicMm = materialDensityGramsPerCubicCm / 1000;
-
-    const weightInGrams = volume * densityInCubicMm;
-    return Math.floor(weightInGrams * 1000);
+    return calculateFilamentWeightInMg(
+      filamentType,
+      filamentUsageLengthInMM,
+      filamentDiameter
+    );
   }
 
   parseSettingsIntoNotes(gcode: string): string {

--- a/src/app/core/services/file-parsers/filament-usage.utils.ts
+++ b/src/app/core/services/file-parsers/filament-usage.utils.ts
@@ -1,0 +1,27 @@
+const MATERIAL_DENSITIES = [
+  ['PLA', 1.24],
+  ['ABS', 1.04],
+  ['PETG', 1.23],
+  ['Nylon', 1.06],
+] as const;
+
+export function calculateFilamentWeightInMg(
+  filamentType: string,
+  lengthInMm: number,
+  diameterInMm: number
+): number | undefined {
+  const materialDensity = MATERIAL_DENSITIES.find(([material]) =>
+    filamentType.includes(material)
+  )?.[1];
+
+  if (materialDensity === undefined) {
+    return undefined;
+  }
+
+  const radiusInMm = diameterInMm / 2;
+  const filamentAreaInMm2 = Math.PI * radiusInMm * radiusInMm;
+  const volumeInCubicMm = filamentAreaInMm2 * lengthInMm;
+  const weightInGrams = volumeInCubicMm * (materialDensity / 1000);
+
+  return Math.floor(weightInGrams * 1000);
+}

--- a/src/app/core/services/file-parsers/orca/orca-file-parser.service.spec.ts
+++ b/src/app/core/services/file-parsers/orca/orca-file-parser.service.spec.ts
@@ -38,6 +38,24 @@ describe('OrcaFileParserService', () => {
   });
 
   describe('estimateFilamentUsageInMg', () => {
+    it('should estimate Nylon weight from filament length and diameter', () => {
+      const testGcode = `; filament used [g] = 0.0
+; filament_type = Nylon
+; filament_diameter = 1.75
+; filament used [mm] = 1000`;
+
+      expect(service.estimateFilamentUsageInMg(testGcode)).toBe(2549);
+    });
+
+    it('should return undefined for a material it has no density for', () => {
+      const testGcode = `; filament used [g] = 0.0
+; filament_type = TPU
+; filament_diameter = 1.75
+; filament used [mm] = 1000`;
+
+      expect(service.estimateFilamentUsageInMg(testGcode)).toBeUndefined();
+    });
+
     it('should return undefined when diameter or length is missing or zero', () => {
       const invalidInputs = [
         `; filament_type = PLA

--- a/src/app/core/services/file-parsers/orca/orca-file-parser.service.ts
+++ b/src/app/core/services/file-parsers/orca/orca-file-parser.service.ts
@@ -2,23 +2,7 @@ import { Injectable } from '@angular/core';
 import parse from 'parse-duration';
 import { GcodeNewPrintParser } from '../../gcode-file-parser.service';
 import { PrintDetail, PrintStatus } from '../../print.service';
-
-//
-export interface MaterialDensityGramsPerCubicCm {
-  PLA: number;
-  ABS: number;
-  PETG: number;
-  Nylon: number;
-}
-
-export class MaterialDensities {
-  static materials: MaterialDensityGramsPerCubicCm = {
-    PLA: 1.24,
-    ABS: 1.04,
-    PETG: 1.23,
-    Nylon: 1.06,
-  };
-}
+import { calculateFilamentWeightInMg } from '../filament-usage.utils';
 
 @Injectable({
   providedIn: 'root',
@@ -71,46 +55,11 @@ export class OrcaFileParserService implements GcodeNewPrintParser {
       return undefined;
     }
 
-    if (filamentType.includes('PLA')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.PLA,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
-    } else if (filamentType.includes('ABS')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.ABS,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
-    } else if (filamentType.includes('PETG')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.PETG,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
-    }
-
-    // Only PLA, ABS and PETG are handled above, so anything else is unknown
-    // rather than zero. Note MaterialDensities also declares Nylon, which this
-    // chain never reaches -- see #100.
-    return undefined;
-  }
-
-  private calculateWeightInMg(
-    materialDensityGramsPerCubicCm: number,
-    lengthInMm: number,
-    diameterInMm: number
-  ) {
-    const radiusInMm = diameterInMm / 2;
-    const filamentAreaInMm2 = Math.PI * radiusInMm * radiusInMm;
-
-    const volume = filamentAreaInMm2 * lengthInMm;
-
-    const densityInCubicMm = materialDensityGramsPerCubicCm / 1000;
-
-    const weightInGrams = volume * densityInCubicMm;
-    return Math.floor(weightInGrams * 1000);
+    return calculateFilamentWeightInMg(
+      filamentType,
+      filamentUsageLengthInMM,
+      filamentDiameter
+    );
   }
 
   parseSettingsIntoNotes(gcode: string): string {

--- a/src/app/core/services/file-parsers/prusa/prusa-slicer-file-parser.service.spec.ts
+++ b/src/app/core/services/file-parsers/prusa/prusa-slicer-file-parser.service.spec.ts
@@ -61,16 +61,13 @@ describe('PrusaSlicerFileParserService', () => {
       expect(service.estimateFilamentUsageInMg(testGcode)).toBeUndefined();
     });
 
-    // Characterizes existing behavior that is WRONG: a Nylon density is declared
-    // in MaterialDensities but the material chain never branches on it, so a
-    // valid Nylon file loses its estimate. Tracked in #100.
-    it('should currently return undefined for Nylon despite having its density', () => {
+    it('should estimate Nylon weight from filament length and diameter', () => {
       const testGcode = `; total filament used [g] = 0.0
 ; filament_type = Nylon
 ; filament_diameter = 1.75
 ; filament used [mm] = 1000`;
 
-      expect(service.estimateFilamentUsageInMg(testGcode)).toBeUndefined();
+      expect(service.estimateFilamentUsageInMg(testGcode)).toBe(2549);
     });
 
     it('should return undefined when the diameter is missing', () => {

--- a/src/app/core/services/file-parsers/prusa/prusa-slicer-file-parser.service.ts
+++ b/src/app/core/services/file-parsers/prusa/prusa-slicer-file-parser.service.ts
@@ -2,23 +2,7 @@ import { Injectable } from '@angular/core';
 import parse from 'parse-duration';
 import { GcodeNewPrintParser } from '../../gcode-file-parser.service';
 import { PrintDetail, PrintStatus } from '../../print.service';
-
-//
-export interface MaterialDensityGramsPerCubicCm {
-  PLA: number;
-  ABS: number;
-  PETG: number;
-  Nylon: number;
-}
-
-export class MaterialDensities {
-  static materials: MaterialDensityGramsPerCubicCm = {
-    PLA: 1.24,
-    ABS: 1.04,
-    PETG: 1.23,
-    Nylon: 1.06,
-  };
-}
+import { calculateFilamentWeightInMg } from '../filament-usage.utils';
 
 @Injectable({
   providedIn: 'root',
@@ -71,46 +55,11 @@ export class PrusaSlicerFileParserService implements GcodeNewPrintParser {
       return undefined;
     }
 
-    if (filamentType.includes('PLA')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.PLA,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
-    } else if (filamentType.includes('ABS')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.ABS,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
-    } else if (filamentType.includes('PETG')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.PETG,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
-    }
-
-    // Only PLA, ABS and PETG are handled above, so anything else is unknown
-    // rather than zero. Note MaterialDensities also declares Nylon, which this
-    // chain never reaches -- see #100.
-    return undefined;
-  }
-
-  private calculateWeightInMg(
-    materialDensityGramsPerCubicCm: number,
-    lengthInMm: number,
-    diameterInMm: number
-  ) {
-    const radiusInMm = diameterInMm / 2;
-    const filamentAreaInMm2 = Math.PI * radiusInMm * radiusInMm;
-
-    const volume = filamentAreaInMm2 * lengthInMm;
-
-    const densityInCubicMm = materialDensityGramsPerCubicCm / 1000;
-
-    const weightInGrams = volume * densityInCubicMm;
-    return Math.floor(weightInGrams * 1000);
+    return calculateFilamentWeightInMg(
+      filamentType,
+      filamentUsageLengthInMM,
+      filamentDiameter
+    );
   }
 
   parseSettingsIntoNotes(gcode: string): string {


### PR DESCRIPTION
## Summary
- Fix Nylon filament weight estimates for Prusa, Orca, Creality Print, and Anycubic parser paths.
- Share the ordered material-density lookup and weight calculation across the parsers.
- Add regression coverage for Nylon and preserve `undefined` for unsupported materials.

## Validation
- `npx ng test --no-watch --browsers ChromeHeadless --include="src/app/core/services/file-parsers/**/*.spec.ts"`
- `npm run test:ci`
- `npm run lint`
- `npm run typecheck:strict`
- `npm run build:dev`
- `npm run prettier` (repository baseline currently reports 723 existing files; staged-file hook formatted the changed files)

Fixes #100