### PR TITLE
feat: push notification UI

### DIFF
--- a/src/app/apikeys/apikeys.component.ts
+++ b/src/app/apikeys/apikeys.component.ts
@@ -1,11 +1,12 @@
 import { Clipboard } from '@angular/cdk/clipboard';
-import { Component, OnInit } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { ToastrService } from 'ngx-toastr';
 import {
   ApiKeyService,
   UserApiKeySummary,
 } from '../core/services/api-key.service';
 import { MetaTagService } from '../core/services/meta-tag.service';
+import { PushPermissionPromptService } from '../core/services/push-permission-prompt.service';
 
 export interface UserApiKeySummaryWithKey extends UserApiKeySummary {
   privateKey?: string;
@@ -31,6 +32,8 @@ export class ApikeysComponent implements OnInit {
   public addingKey = false;
 
   public newKeyDescription = '';
+
+  private readonly pushPermissionPrompt = inject(PushPermissionPromptService);
 
   constructor(
     private readonly apiKeyService: ApiKeyService,
@@ -77,6 +80,13 @@ export class ApikeysComponent implements OnInit {
         };
         this.keys = [newSummary, ...this.keys];
         this.toastrService.success('Key created successfully.');
+
+        // The moment the app gains the ability to tell the user something time-sensitive:
+        // a key exists, so a printer can now report that a print finished or failed.
+        // A no-op outside the Cordova app and when permission is already granted.
+        void this.pushPermissionPrompt.promptInContext(
+          'You just created an API key, so your printer can report print progress.'
+        );
       },
       (_) => {
         this.toastrService.error(

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -7,6 +7,7 @@ import { GoogleAnalyticsService } from './core/services/google-analytics.service
 import { LoggingService } from './core/services/logging.service';
 import { VersionReleaseNoteDialogService } from './core/services/version-release-note-dialog.service';
 import { AdsenseLoaderService } from './core/services/adsense-loader.service';
+import { PushRegistrationService } from './core/services/push-registration.service';
 import { of } from 'rxjs';
 import { NO_ERRORS_SCHEMA, signal } from '@angular/core';
 
@@ -46,12 +47,23 @@ describe('AppComponent (ThemeService)', () => {
   let mockLoggingService: jasmine.SpyObj<LoggingService>;
   let mockReleaseNotesService: jasmine.SpyObj<VersionReleaseNoteDialogService>;
   let mockThemeService: jasmine.SpyObj<ThemeService>;
+  let mockPushRegistration: jasmine.SpyObj<PushRegistrationService>;
 
   beforeEach(waitForAsync(() => {
     mockAuthService = jasmine.createSpyObj<AuthService>('AuthService', [
       'localAuthSetup',
+      'getTokenSilently$',
     ]);
     mockAuthService.userProfile$ = of(null);
+    mockAuthService.getTokenSilently$.and.returnValue(of('bearer-abc'));
+
+    mockPushRegistration = jasmine.createSpyObj<PushRegistrationService>(
+      'PushRegistrationService',
+      ['onAuthenticated', 'onLogout', 'handlePendingTap']
+    );
+    mockPushRegistration.onAuthenticated.and.resolveTo(undefined);
+    mockPushRegistration.onLogout.and.resolveTo(undefined);
+    mockPushRegistration.handlePendingTap.and.resolveTo(undefined);
 
     mockGoogleAnalyticsService = {} as jasmine.SpyObj<GoogleAnalyticsService>;
 
@@ -90,6 +102,7 @@ describe('AppComponent (ThemeService)', () => {
         },
         { provide: ThemeService, useValue: mockThemeService },
         { provide: AdsenseLoaderService, useValue: mockAdsenseLoader },
+        { provide: PushRegistrationService, useValue: mockPushRegistration },
       ],
     }).compileComponents();
   }));
@@ -99,5 +112,43 @@ describe('AppComponent (ThemeService)', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     expect(themeService.initialize).toHaveBeenCalledTimes(1);
+  });
+
+  describe('push registration', () => {
+    it('does not register while no profile has been emitted', () => {
+      const fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+
+      expect(mockPushRegistration.onAuthenticated).not.toHaveBeenCalled();
+    });
+
+    it('registers with a bearer once a profile is emitted', () => {
+      mockAuthService.userProfile$ = of({ id: 1 } as never);
+
+      const fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+
+      expect(mockPushRegistration.onAuthenticated).toHaveBeenCalledWith(
+        'bearer-abc'
+      );
+    });
+
+    it('installs the logout teardown hook', async () => {
+      const fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+
+      expect(mockAuthService.pushTeardown).toBeTruthy();
+      await mockAuthService.pushTeardown!('bearer-abc');
+      expect(mockPushRegistration.onLogout).toHaveBeenCalledWith('bearer-abc');
+    });
+
+    it('drains a pending tap when the app resumes', () => {
+      const fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+
+      document.dispatchEvent(new Event('resume'));
+
+      expect(mockPushRegistration.handlePendingTap).toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,6 +10,7 @@ import { AdsenseLoaderService } from './core/services/adsense-loader.service';
 import { AuthService } from './core/services/auth.service';
 import { GoogleAnalyticsService } from './core/services/google-analytics.service';
 import { LoggingService } from './core/services/logging.service';
+import { PushRegistrationService } from './core/services/push-registration.service';
 import { ThemeService } from './core/services/theme.service';
 import { VersionReleaseNoteDialogService } from './core/services/version-release-note-dialog.service';
 
@@ -37,6 +38,7 @@ export class AppComponent implements OnInit {
     private releaseNotesService: VersionReleaseNoteDialogService,
     private themeService: ThemeService,
     private adsenseLoader: AdsenseLoaderService,
+    private pushRegistration: PushRegistrationService,
     @Inject(PLATFORM_ID) private platformId: object
   ) {}
 
@@ -47,10 +49,43 @@ export class AppComponent implements OnInit {
     this.auth.userProfile$.subscribe((user) => {
       if (user) {
         this.releaseNotesService.checkLastLoggedInVersion();
+        this.registerForPush();
       }
     });
 
+    // Ordered teardown: the native side needs a still-valid bearer to delete its
+    // registration, so AuthService awaits this before starting Auth0 logout.
+    this.auth.pushTeardown = (token) => this.pushRegistration.onLogout(token);
+
+    this.watchForWarmStartTaps();
+
     this.deferAdsenseLoad();
+  }
+
+  /**
+   * Driven by an authenticated profile rather than by bridge availability alone: at cold
+   * start the bridge is ready long before Auth0 has rehydrated, and a registration POST
+   * without a bearer 401s with nothing to retry it.
+   */
+  private registerForPush() {
+    this.auth.getTokenSilently$().subscribe({
+      next: (token) => void this.pushRegistration.onAuthenticated(token),
+      // No token means no registration this launch; the next authenticated emission
+      // retries. Never surface this to the user — push is optional.
+      error: () => undefined,
+    });
+  }
+
+  /**
+   * A tap while the app is already running resumes it rather than starting it, so the
+   * pending tap has to be drained on resume as well as at registration time.
+   */
+  private watchForWarmStartTaps() {
+    if (!isPlatformBrowser(this.platformId)) return;
+
+    document.addEventListener('resume', () => {
+      void this.pushRegistration.handlePendingTap();
+    });
   }
 
   /**

--- a/src/app/core/services/auth.service.spec.ts
+++ b/src/app/core/services/auth.service.spec.ts
@@ -1,5 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { defer, of } from 'rxjs';
 import { filter, take } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 import { AuthService } from './auth.service';
@@ -79,6 +80,65 @@ describe('AuthService', () => {
       expect(latestProfile).toBeNull(); // BehaviorSubject initial null, never overwritten
 
       sessionStorage.removeItem('devUserId');
+    });
+  });
+
+  describe('logout push teardown', () => {
+    /**
+     * Replaces the Auth0 client stream with one that records when it is subscribed, so the
+     * ordering claim — teardown finishes BEFORE Auth0 tears the session down — is actually
+     * asserted rather than assumed.
+     */
+    function trackAuth0Logout(service: AuthService, order: string[]) {
+      (service as unknown as { auth0Client$: unknown }).auth0Client$ = defer(
+        () => {
+          order.push('auth0-logout');
+          return of({ logout: () => undefined });
+        }
+      );
+    }
+
+    it('awaits the push teardown hook before Auth0 logout, with a live bearer', async () => {
+      const service = TestBed.inject(AuthService);
+      const order: string[] = [];
+      spyOn(service, 'getTokenSilently$').and.returnValue(of('bearer-abc'));
+      trackAuth0Logout(service, order);
+
+      service.pushTeardown = async (token) => {
+        expect(token).toBe('bearer-abc');
+        order.push('push-teardown');
+      };
+
+      await service.logout();
+
+      expect(order).toEqual(['push-teardown', 'auth0-logout']);
+    });
+
+    it('still logs the user out when the teardown hook throws', async () => {
+      const service = TestBed.inject(AuthService);
+      const order: string[] = [];
+      spyOn(service, 'getTokenSilently$').and.returnValue(of('bearer-abc'));
+      trackAuth0Logout(service, order);
+
+      service.pushTeardown = () => Promise.reject(new Error('native gone'));
+
+      await service.logout();
+
+      expect(order).toEqual(['auth0-logout']);
+    });
+
+    it('still logs the user out when no token can be minted', async () => {
+      const service = TestBed.inject(AuthService);
+      const order: string[] = [];
+      spyOn(service, 'getTokenSilently$').and.throwError('no refresh token');
+      trackAuth0Logout(service, order);
+
+      service.pushTeardown = jasmine.createSpy('pushTeardown').and.resolveTo();
+
+      await service.logout();
+
+      expect(service.pushTeardown).not.toHaveBeenCalled();
+      expect(order).toEqual(['auth0-logout']);
     });
   });
 });

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -7,6 +7,7 @@ import {
   BehaviorSubject,
   combineLatest,
   EMPTY,
+  firstValueFrom,
   from,
   Observable,
   of,
@@ -192,7 +193,8 @@ export class AuthService {
       catchError((err) => {
         if (err.error === 'missing_refresh_token') {
           if (this.loggedIn) {
-            this.logout();
+            // logout is async now (push teardown runs first); nothing here can await it.
+            void this.logout();
           }
         }
 
@@ -295,13 +297,23 @@ export class AuthService {
     });
   }
 
-  logout() {
+  /**
+   * Registered by PushRegistrationService. Awaited before Auth0 logout so the device's push
+   * registration is deleted while the bearer is still valid — once Auth0 tears the session
+   * down there is no credential left to authorize the DELETE with, and the phone would keep
+   * receiving the previous user's notifications.
+   */
+  public pushTeardown: ((bearerToken: string) => Promise<void>) | null = null;
+
+  async logout() {
     if (environment.devAuthBypass) {
       return;
     }
     // Stop notification polling
     this.notificationService.stopPolling();
     this.userSettingService.clearCache();
+
+    await this.runPushTeardown();
 
     // Ensure Auth0 client instance exists
     this.auth0Client$.subscribe((client: Auth0Client) => {
@@ -311,5 +323,23 @@ export class AuthService {
         logoutParams: { returnTo: `${window.location.origin}` },
       });
     });
+  }
+
+  /**
+   * Best-effort: a device that cannot be unregistered is a stale row the API prunes on the
+   * next UNREGISTERED response from FCM. Failing to log the user out over it would be far
+   * worse, so every failure here — including not being able to mint a token — is swallowed.
+   */
+  private async runPushTeardown(): Promise<void> {
+    if (!this.pushTeardown) {
+      return;
+    }
+
+    try {
+      const token = await firstValueFrom(this.getTokenSilently$());
+      await this.pushTeardown(token);
+    } catch {
+      // Intentionally ignored — see above.
+    }
   }
 }

--- a/src/app/core/services/native-bridge.service.spec.ts
+++ b/src/app/core/services/native-bridge.service.spec.ts
@@ -1,0 +1,95 @@
+import { TestBed } from '@angular/core/testing';
+import { NativeBridgeService } from './native-bridge.service';
+import { CORDOVA_USER_AGENT } from '../utils/platform';
+import { PrintLogNativeBridge } from '../types/native-bridge';
+
+describe('NativeBridgeService', () => {
+  let service: NativeBridgeService;
+  let realUserAgent: PropertyDescriptor | undefined;
+
+  /**
+   * The platform check reads navigator.userAgent, so the app shell has to be simulated at
+   * the source rather than by stubbing the check — that is the very thing under test.
+   */
+  function pretendCordova(): void {
+    Object.defineProperty(navigator, 'userAgent', {
+      value: CORDOVA_USER_AGENT,
+      configurable: true,
+    });
+  }
+
+  beforeEach(() => {
+    realUserAgent = Object.getOwnPropertyDescriptor(
+      Object.getPrototypeOf(navigator),
+      'userAgent'
+    );
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(NativeBridgeService);
+    delete window.PrintLogNative;
+  });
+
+  afterEach(() => {
+    delete (navigator as unknown as Record<string, unknown>)['userAgent'];
+    if (realUserAgent) {
+      Object.defineProperty(
+        Object.getPrototypeOf(navigator),
+        'userAgent',
+        realUserAgent
+      );
+    }
+    delete window.PrintLogNative;
+  });
+
+  it('reports unavailable in an ordinary browser', () => {
+    expect(service.isAvailable()).toBeFalse();
+  });
+
+  it('reports unavailable in the app shell before native finishes injecting', () => {
+    pretendCordova();
+    expect(service.isAvailable()).toBeFalse();
+  });
+
+  it('returns null from consumePendingTap when unavailable', async () => {
+    await expectAsync(service.consumePendingTap()).toBeResolvedTo(null);
+  });
+
+  it('delegates registerForPush to the native bridge', async () => {
+    pretendCordova();
+    const registerForPush = jasmine
+      .createSpy('registerForPush')
+      .and.resolveTo({ ok: true });
+    window.PrintLogNative = {
+      registerForPush,
+    } as unknown as PrintLogNativeBridge;
+
+    const result = await service.registerForPush('bearer-abc');
+
+    expect(registerForPush).toHaveBeenCalledWith('bearer-abc');
+    expect(result).toBeTrue();
+  });
+
+  it('resolves false when the native call rejects', async () => {
+    pretendCordova();
+    window.PrintLogNative = {
+      registerForPush: () => Promise.reject(new Error('native failure')),
+    } as unknown as PrintLogNativeBridge;
+
+    await expectAsync(service.registerForPush('bearer-abc')).toBeResolvedTo(
+      false
+    );
+  });
+
+  it('does not call native at all in an ordinary browser', async () => {
+    const registerForPush = jasmine
+      .createSpy('registerForPush')
+      .and.resolveTo({ ok: true });
+    window.PrintLogNative = {
+      registerForPush,
+    } as unknown as PrintLogNativeBridge;
+
+    await expectAsync(service.registerForPush('bearer-abc')).toBeResolvedTo(
+      false
+    );
+    expect(registerForPush).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/core/services/native-bridge.service.ts
+++ b/src/app/core/services/native-bridge.service.ts
@@ -1,0 +1,60 @@
+import { Injectable } from '@angular/core';
+import { isCordovaPlatform } from '../utils/platform';
+import {
+  PendingTap,
+  PrintLogNativeBridge,
+  PushPermissionState,
+} from '../types/native-bridge';
+
+/**
+ * Thin wrapper over the Cordova app's injected bridge. Every method degrades to a safe
+ * no-op in a normal browser, so callers never branch on platform themselves.
+ */
+@Injectable({ providedIn: 'root' })
+export class NativeBridgeService {
+  private get bridge(): PrintLogNativeBridge | undefined {
+    // Both checks matter: the platform check proves we are in the app shell, and the object
+    // check proves the native side actually finished injecting.
+    return isCordovaPlatform() ? window.PrintLogNative : undefined;
+  }
+
+  isAvailable(): boolean {
+    return this.bridge !== undefined;
+  }
+
+  get permission(): PushPermissionState {
+    return this.bridge?.pushPermission ?? 'default';
+  }
+
+  async requestPushPermission(): Promise<PushPermissionState> {
+    try {
+      return (await this.bridge?.requestPushPermission()) ?? 'default';
+    } catch {
+      return 'default';
+    }
+  }
+
+  async registerForPush(bearerToken: string): Promise<boolean> {
+    try {
+      return (await this.bridge?.registerForPush(bearerToken))?.ok ?? false;
+    } catch {
+      return false;
+    }
+  }
+
+  async unregisterForPush(bearerToken: string): Promise<boolean> {
+    try {
+      return (await this.bridge?.unregisterForPush(bearerToken))?.ok ?? false;
+    } catch {
+      return false;
+    }
+  }
+
+  async consumePendingTap(): Promise<PendingTap | null> {
+    try {
+      return (await this.bridge?.consumePendingTap()) ?? null;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/app/core/services/push-permission-prompt.service.spec.ts
+++ b/src/app/core/services/push-permission-prompt.service.spec.ts
@@ -1,0 +1,105 @@
+import { TestBed } from '@angular/core/testing';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { of } from 'rxjs';
+import { PushPermissionPromptService } from './push-permission-prompt.service';
+import { NativeBridgeService } from './native-bridge.service';
+import { PushPermissionState } from '../types/native-bridge';
+
+describe('PushPermissionPromptService', () => {
+  let service: PushPermissionPromptService;
+  let bridge: jasmine.SpyObj<NativeBridgeService>;
+  let dialog: jasmine.SpyObj<MatDialog>;
+  let dialogRef: {
+    componentInstance: Record<string, string>;
+    afterClosed: jasmine.Spy;
+  };
+
+  function withPermission(permission: PushPermissionState) {
+    Object.defineProperty(bridge, 'permission', {
+      value: permission,
+      configurable: true,
+    });
+  }
+
+  function userAnswers(accepted: boolean) {
+    dialogRef.afterClosed.and.returnValue(of(accepted));
+  }
+
+  beforeEach(() => {
+    bridge = jasmine.createSpyObj<NativeBridgeService>(
+      'NativeBridgeService',
+      ['isAvailable', 'requestPushPermission'],
+      { permission: 'default' }
+    );
+    bridge.isAvailable.and.returnValue(true);
+    bridge.requestPushPermission.and.resolveTo('granted');
+
+    dialogRef = {
+      componentInstance: {},
+      afterClosed: jasmine.createSpy('afterClosed').and.returnValue(of(true)),
+    };
+    dialog = jasmine.createSpyObj<MatDialog>('MatDialog', ['open']);
+    dialog.open.and.returnValue(dialogRef as unknown as MatDialogRef<unknown>);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: NativeBridgeService, useValue: bridge },
+        { provide: MatDialog, useValue: dialog },
+      ],
+    });
+    service = TestBed.inject(PushPermissionPromptService);
+  });
+
+  it('does nothing in an ordinary browser', async () => {
+    bridge.isAvailable.and.returnValue(false);
+
+    await expectAsync(service.promptInContext('reason')).toBeResolvedTo(
+      'default'
+    );
+
+    expect(dialog.open).not.toHaveBeenCalled();
+    expect(bridge.requestPushPermission).not.toHaveBeenCalled();
+  });
+
+  it('does not re-prompt when permission is already granted', async () => {
+    withPermission('granted');
+
+    await expectAsync(service.promptInContext('reason')).toBeResolvedTo(
+      'granted'
+    );
+
+    expect(dialog.open).not.toHaveBeenCalled();
+  });
+
+  it('shows the explainer before touching the OS prompt', async () => {
+    userAnswers(true);
+
+    await service.promptInContext('You just connected a printer.');
+
+    expect(dialog.open).toHaveBeenCalled();
+    expect(dialogRef.componentInstance['body']).toContain(
+      'You just connected a printer.'
+    );
+    expect(bridge.requestPushPermission).toHaveBeenCalled();
+  });
+
+  it('never reaches the OS prompt when the user declines the explainer', async () => {
+    userAnswers(false);
+
+    const result = await service.promptInContext('reason');
+
+    // On Android 13+ the system dialog is effectively one-shot. Spending it on someone who
+    // just said "not now" is how the permission becomes permanently denied.
+    expect(bridge.requestPushPermission).not.toHaveBeenCalled();
+    expect(result).toBe('default');
+  });
+
+  it('prompts again after an earlier denial', async () => {
+    withPermission('denied');
+    userAnswers(true);
+
+    await service.promptInContext('reason');
+
+    expect(bridge.requestPushPermission).toHaveBeenCalled();
+  });
+});

--- a/src/app/core/services/push-permission-prompt.service.ts
+++ b/src/app/core/services/push-permission-prompt.service.ts
@@ -1,0 +1,56 @@
+import { inject, Injectable } from '@angular/core';
+import { MatDialog } from '@angular/material/dialog';
+import { firstValueFrom } from 'rxjs';
+import { SimpleDialogComponent } from '../../shared/simple-dialog/simple-dialog.component';
+import { NativeBridgeService } from './native-bridge.service';
+import { PushPermissionState } from '../types/native-bridge';
+
+/**
+ * Asks for the Android notification permission, in context and behind an explainer.
+ *
+ * Never at launch. On Android 13+ a denial is effectively permanent — the OS stops showing
+ * the dialog — so the one request this app gets has to be spent at a moment when the user
+ * already understands why notifications are useful.
+ */
+@Injectable({ providedIn: 'root' })
+export class PushPermissionPromptService {
+  private readonly bridge = inject(NativeBridgeService);
+  private readonly dialog = inject(MatDialog);
+
+  /**
+   * Shows the explainer and, if the user agrees, requests the permission.
+   *
+   * A no-op outside the app shell and when the permission is already granted, so callers
+   * can invoke it from a shared flow without branching on platform.
+   *
+   * @param reason one sentence on what just happened that makes notifications useful.
+   * @returns the resulting permission state.
+   */
+  async promptInContext(reason: string): Promise<PushPermissionState> {
+    if (!this.bridge.isAvailable()) {
+      return 'default';
+    }
+
+    const current = this.bridge.permission;
+    if (current === 'granted') {
+      return current;
+    }
+
+    const dialogRef = this.dialog.open(SimpleDialogComponent, { data: {} });
+    dialogRef.componentInstance.title = 'Get notified about your prints?';
+    dialogRef.componentInstance.body = `<p>${reason}</p>
+      <p>3D Print Log can notify you when a print finishes or fails, so you do not
+      have to keep checking. You can change this any time in Settings.</p>`;
+    dialogRef.componentInstance.yesText = 'Enable notifications';
+    dialogRef.componentInstance.noText = 'Not now';
+
+    const accepted = await firstValueFrom(dialogRef.afterClosed());
+    if (!accepted) {
+      // "Not now" must not reach the OS prompt: spending the single system dialog on a user
+      // who just declined the explainer is how the permission gets permanently denied.
+      return current;
+    }
+
+    return this.bridge.requestPushPermission();
+  }
+}

--- a/src/app/core/services/push-preferences.service.spec.ts
+++ b/src/app/core/services/push-preferences.service.spec.ts
@@ -1,0 +1,71 @@
+import { TestBed } from '@angular/core/testing';
+import { PushPreferencesService } from './push-preferences.service';
+import {
+  UserSetting,
+  UserSettingService,
+  UserSettingType,
+} from './user-setting.service';
+
+describe('PushPreferencesService', () => {
+  let service: PushPreferencesService;
+  let userSettings: jasmine.SpyObj<UserSettingService>;
+
+  beforeEach(() => {
+    userSettings = jasmine.createSpyObj('UserSettingService', [
+      'getCurrentUsersSettingByType',
+      'addOrUpdateSetting',
+    ]);
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: UserSettingService, useValue: userSettings }],
+    });
+    service = TestBed.inject(PushPreferencesService);
+  });
+
+  function settingWithValue(value: string): UserSetting {
+    return { value } as UserSetting;
+  }
+
+  it('treats an absent setting as enabled', async () => {
+    userSettings.getCurrentUsersSettingByType.and.resolveTo(null);
+    await expectAsync(
+      service.isEnabled(UserSettingType.Push_PrintFailed)
+    ).toBeResolvedTo(true);
+  });
+
+  it('treats the literal "false" as disabled', async () => {
+    userSettings.getCurrentUsersSettingByType.and.resolveTo(
+      settingWithValue('false')
+    );
+    await expectAsync(
+      service.isEnabled(UserSettingType.Push_PrintFailed)
+    ).toBeResolvedTo(false);
+  });
+
+  it('trims and lowercases before comparing', async () => {
+    userSettings.getCurrentUsersSettingByType.and.resolveTo(
+      settingWithValue('  FALSE ')
+    );
+    await expectAsync(
+      service.isEnabled(UserSettingType.Push_PrintFailed)
+    ).toBeResolvedTo(false);
+  });
+
+  it('treats an unrecognised value as enabled, matching the API', async () => {
+    userSettings.getCurrentUsersSettingByType.and.resolveTo(
+      settingWithValue('garbage')
+    );
+    await expectAsync(
+      service.isEnabled(UserSettingType.Push_PrintFailed)
+    ).toBeResolvedTo(true);
+  });
+
+  it('writes the canonical string', async () => {
+    userSettings.addOrUpdateSetting.and.resolveTo(undefined);
+    await service.setEnabled(UserSettingType.Push_PrintCompleted, false);
+    expect(userSettings.addOrUpdateSetting).toHaveBeenCalledWith(
+      UserSettingType.Push_PrintCompleted,
+      'false'
+    );
+  });
+});

--- a/src/app/core/services/push-preferences.service.ts
+++ b/src/app/core/services/push-preferences.service.ts
@@ -1,0 +1,41 @@
+import { inject, Injectable } from '@angular/core';
+import { UserSettingService, UserSettingType } from './user-setting.service';
+
+/** The setting types that govern push delivery. */
+export type PushNotificationType =
+  | UserSettingType.Push_PrintCompleted
+  | UserSettingType.Push_PrintFailed;
+
+const DISABLED = 'false';
+const ENABLED = 'true';
+
+/**
+ * Reads and writes push preferences through the existing cached user-settings store.
+ *
+ * Deliberately one purpose-built service rather than a route resolver per setting: the
+ * resolver-per-setting pattern used elsewhere in settings scales badly at one resolver per
+ * pushable notification type.
+ */
+@Injectable({ providedIn: 'root' })
+export class PushPreferencesService {
+  private readonly userSettings = inject(UserSettingService);
+
+  /**
+   * Absence, emptiness, and anything unrecognised mean enabled — matching the API's
+   * PushPreference.IsEnabled exactly. If these two drift, a user's opt-out stops working.
+   */
+  async isEnabled(type: PushNotificationType): Promise<boolean> {
+    const setting = await this.userSettings.getCurrentUsersSettingByType(type);
+    return setting?.value?.trim().toLowerCase() !== DISABLED;
+  }
+
+  async setEnabled(
+    type: PushNotificationType,
+    enabled: boolean
+  ): Promise<void> {
+    await this.userSettings.addOrUpdateSetting(
+      type,
+      enabled ? ENABLED : DISABLED
+    );
+  }
+}

--- a/src/app/core/services/push-registration.service.spec.ts
+++ b/src/app/core/services/push-registration.service.spec.ts
@@ -1,0 +1,101 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
+import { PushRegistrationService } from './push-registration.service';
+import { NativeBridgeService } from './native-bridge.service';
+import { NotificationService } from './notification.service';
+
+describe('PushRegistrationService', () => {
+  let bridge: jasmine.SpyObj<NativeBridgeService>;
+  let notifications: jasmine.SpyObj<NotificationService>;
+  let router: jasmine.SpyObj<Router>;
+  let service: PushRegistrationService;
+
+  beforeEach(() => {
+    bridge = jasmine.createSpyObj('NativeBridgeService', [
+      'isAvailable',
+      'registerForPush',
+      'unregisterForPush',
+      'consumePendingTap',
+    ]);
+    bridge.consumePendingTap.and.resolveTo(null);
+    notifications = jasmine.createSpyObj('NotificationService', ['markAsRead']);
+    notifications.markAsRead.and.returnValue(of(undefined));
+    router = jasmine.createSpyObj('Router', ['navigate']);
+    router.navigate.and.resolveTo(true);
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: NativeBridgeService, useValue: bridge },
+        { provide: NotificationService, useValue: notifications },
+        { provide: Router, useValue: router },
+      ],
+    });
+    service = TestBed.inject(PushRegistrationService);
+  });
+
+  it('does nothing when the native bridge is absent', async () => {
+    bridge.isAvailable.and.returnValue(false);
+    await service.onAuthenticated('bearer-abc');
+    expect(bridge.registerForPush).not.toHaveBeenCalled();
+  });
+
+  it('registers once authenticated', async () => {
+    bridge.isAvailable.and.returnValue(true);
+    bridge.registerForPush.and.resolveTo(true);
+    await service.onAuthenticated('bearer-abc');
+    expect(bridge.registerForPush).toHaveBeenCalledWith('bearer-abc');
+  });
+
+  it('does not re-register for the same bearer token', async () => {
+    bridge.isAvailable.and.returnValue(true);
+    bridge.registerForPush.and.resolveTo(true);
+    await service.onAuthenticated('bearer-abc');
+    await service.onAuthenticated('bearer-abc');
+    expect(bridge.registerForPush).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on a later authentication event after a failure', async () => {
+    bridge.isAvailable.and.returnValue(true);
+    bridge.registerForPush.and.resolveTo(false);
+    await service.onAuthenticated('bearer-abc');
+    bridge.registerForPush.and.resolveTo(true);
+    await service.onAuthenticated('bearer-abc');
+    expect(bridge.registerForPush).toHaveBeenCalledTimes(2);
+  });
+
+  it('marks a tapped notification read and routes to the print', async () => {
+    bridge.isAvailable.and.returnValue(true);
+    bridge.consumePendingTap.and.resolveTo({
+      notificationId: 'abc',
+      printId: 42,
+    });
+
+    await service.handlePendingTap();
+
+    expect(notifications.markAsRead).toHaveBeenCalledWith('abc');
+    expect(router.navigate).toHaveBeenCalledWith(['/prints', 42]);
+  });
+
+  it('does not navigate when there is no pending tap', async () => {
+    bridge.isAvailable.and.returnValue(true);
+
+    await service.handlePendingTap();
+
+    expect(notifications.markAsRead).not.toHaveBeenCalled();
+    expect(router.navigate).not.toHaveBeenCalled();
+  });
+
+  it('clears registration state on logout so the next login re-registers', async () => {
+    bridge.isAvailable.and.returnValue(true);
+    bridge.registerForPush.and.resolveTo(true);
+    bridge.unregisterForPush.and.resolveTo(true);
+
+    await service.onAuthenticated('bearer-abc');
+    await service.onLogout('bearer-abc');
+    await service.onAuthenticated('bearer-abc');
+
+    expect(bridge.unregisterForPush).toHaveBeenCalledWith('bearer-abc');
+    expect(bridge.registerForPush).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/core/services/push-registration.service.ts
+++ b/src/app/core/services/push-registration.service.ts
@@ -1,0 +1,63 @@
+import { inject, Injectable } from '@angular/core';
+import { Router } from '@angular/router';
+import { firstValueFrom } from 'rxjs';
+import { NativeBridgeService } from './native-bridge.service';
+import { NotificationService } from './notification.service';
+
+/**
+ * Owns when the app registers this device for push.
+ *
+ * Registration is driven by the COMBINATION of an available native bridge and an
+ * authenticated user. Firing on bridge availability alone races Auth0 rehydration at cold
+ * start: the POST would 401, and because no token rotation follows, the installation would
+ * stay unregistered indefinitely.
+ */
+@Injectable({ providedIn: 'root' })
+export class PushRegistrationService {
+  private readonly bridge = inject(NativeBridgeService);
+  private readonly notifications = inject(NotificationService);
+  private readonly router = inject(Router);
+
+  /** The bearer we last registered with, so we do not re-post on every navigation. */
+  private registeredWith: string | null = null;
+
+  /** Call whenever authentication is established or the access token changes. */
+  async onAuthenticated(bearerToken: string): Promise<void> {
+    if (!this.bridge.isAvailable() || this.registeredWith === bearerToken) {
+      return;
+    }
+
+    if (await this.bridge.registerForPush(bearerToken)) {
+      this.registeredWith = bearerToken;
+    }
+
+    await this.handlePendingTap();
+  }
+
+  /**
+   * Call during logout, BEFORE Auth0 teardown — the native side needs a still-valid bearer
+   * to delete its registration, and native unregister must finish before the session goes
+   * away or a regenerated token could re-register against the user who just logged out.
+   */
+  async onLogout(bearerToken: string): Promise<void> {
+    this.registeredWith = null;
+    if (this.bridge.isAvailable()) {
+      await this.bridge.unregisterForPush(bearerToken);
+    }
+  }
+
+  /**
+   * A tapped notification routes to its print and is marked read. Without the mark-read the
+   * bell keeps a stale unread badge for something the user just looked at — today read
+   * state is only set by clicking the bell itself.
+   */
+  async handlePendingTap(): Promise<void> {
+    const tap = await this.bridge.consumePendingTap();
+    if (!tap) {
+      return;
+    }
+
+    await firstValueFrom(this.notifications.markAsRead(tap.notificationId));
+    await this.router.navigate(['/prints', tap.printId]);
+  }
+}

--- a/src/app/core/services/user-setting.service.spec.ts
+++ b/src/app/core/services/user-setting.service.spec.ts
@@ -292,6 +292,70 @@ describe('UserSettingService', () => {
       expect(resultB!.value).toBe('$');
     });
   });
+
+  describe('addOrUpdateSetting', () => {
+    /** Lets queued microtasks run so a pending HTTP request has actually been issued. */
+    const tick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+    it('PUTs when a row already exists', async () => {
+      const existing = makeDto({
+        id: 99,
+        userSettingTypeId: UserSettingType.Push_PrintFailed,
+        value: 'true',
+      });
+
+      // Prime the cache through the public path, so the test exercises the same
+      // existence check the caller relies on rather than a hand-set private field.
+      const primed = service.getCurrentUsersSettingByType(
+        UserSettingType.Push_PrintFailed
+      );
+      httpTesting.expectOne(apiUrl).flush([existing]);
+      await primed;
+
+      const promise = service.addOrUpdateSetting(
+        UserSettingType.Push_PrintFailed,
+        'false'
+      );
+      // addOrUpdateSetting resolves the existence check before issuing the write, so the
+      // request does not exist yet on the same tick.
+      await tick();
+
+      const req = httpTesting.expectOne(apiUrl);
+      expect(req.request.method).toBe('PUT');
+      expect(req.request.body).toEqual({ id: 99, value: 'false' });
+      req.flush({ ...existing, value: 'false' });
+      await promise;
+    });
+
+    it('POSTs when no row exists', async () => {
+      const primed = service.getCurrentUsersSettingByType(
+        UserSettingType.Push_PrintCompleted
+      );
+      httpTesting.expectOne(apiUrl).flush([]);
+      await primed;
+
+      const promise = service.addOrUpdateSetting(
+        UserSettingType.Push_PrintCompleted,
+        'false'
+      );
+      await tick();
+
+      const req = httpTesting.expectOne(apiUrl);
+      expect(req.request.method).toBe('POST');
+      expect(req.request.body).toEqual({
+        userSettingTypeId: UserSettingType.Push_PrintCompleted,
+        value: 'false',
+      });
+      req.flush(
+        makeDto({
+          id: 1,
+          userSettingTypeId: UserSettingType.Push_PrintCompleted,
+          value: 'false',
+        })
+      );
+      await promise;
+    });
+  });
 });
 
 describe('UserSettingService — anonymous visitor (mocked HttpClient)', () => {

--- a/src/app/core/services/user-setting.service.ts
+++ b/src/app/core/services/user-setting.service.ts
@@ -29,6 +29,10 @@ export enum UserSettingType {
   Electricity_KwhRate = 12,
   Electricity_DefaultWattageW = 13,
   Prints_PreferredFilamentDisplayUnit = 14,
+  /** Send a push notification when a print completes. */
+  Push_PrintCompleted = 15,
+  /** Send a push notification when a print fails. */
+  Push_PrintFailed = 16,
 }
 
 export interface UserSetting {
@@ -143,6 +147,27 @@ export class UserSettingService {
         this.settingsMap.set(updatedSetting.userSettingTypeId, updatedSetting);
       })
     );
+  }
+
+  /**
+   * Writes a setting without the caller having to know whether a row exists.
+   *
+   * The API's CreateUserSetting rejects a second row for the same type, and the database now
+   * enforces that too, so choosing PUT vs POST is not a caller's concern — getting it wrong
+   * is a 500, not a silent duplicate.
+   */
+  public async addOrUpdateSetting(
+    settingTypeId: UserSettingType,
+    newValue: string
+  ): Promise<void> {
+    const existing = await this.getCurrentUsersSettingByType(settingTypeId);
+
+    if (existing) {
+      await lastValueFrom(this.updateUserSetting(existing.id, newValue));
+      return;
+    }
+
+    await lastValueFrom(this.addUserSetting(settingTypeId, newValue));
   }
 
   addUserSetting(settingTypeId: UserSettingType, newValue: string) {

--- a/src/app/core/types/native-bridge.ts
+++ b/src/app/core/types/native-bridge.ts
@@ -1,0 +1,30 @@
+export type PushPermissionState = 'granted' | 'denied' | 'default';
+
+export interface PendingTap {
+  notificationId: string;
+  printId: number;
+}
+
+/**
+ * Injected by the Cordova app into the top-level frame on the app origin only.
+ *
+ * The raw FCM token is deliberately NOT exposed. The web layer hands its bearer token to
+ * native and native performs the API call, so page script — including the third-party
+ * scripts this origin serves under a report-only CSP — can never read a token it could use
+ * to hijack a device registration.
+ */
+export interface PrintLogNativeBridge {
+  platform: 'android';
+  appVersion: string;
+  pushPermission: PushPermissionState;
+  requestPushPermission(): Promise<PushPermissionState>;
+  registerForPush(bearerToken: string): Promise<{ ok: boolean }>;
+  unregisterForPush(bearerToken: string): Promise<{ ok: boolean }>;
+  consumePendingTap(): Promise<PendingTap | null>;
+}
+
+declare global {
+  interface Window {
+    PrintLogNative?: PrintLogNativeBridge;
+  }
+}

--- a/src/app/core/utils/platform.ts
+++ b/src/app/core/utils/platform.ts
@@ -1,3 +1,19 @@
-export const isCordova =
-  typeof navigator !== 'undefined' &&
-  navigator.userAgent === 'Mozilla/5.0 Google PrintLog/1.2';
+/**
+ * The user agent the Cordova app pins via config.xml's OverrideUserAgent. Kept as a named
+ * constant so the app repo's CI guard can assert the two still match — a silent drift here
+ * disables every Cordova-only code path with no error anywhere.
+ */
+export const CORDOVA_USER_AGENT = 'Mozilla/5.0 Google PrintLog/1.2';
+
+/**
+ * Evaluated per call rather than once at import, so tests can exercise both branches.
+ * The constant below keeps the original import-time semantics for existing callers.
+ */
+export function isCordovaPlatform(): boolean {
+  return (
+    typeof navigator !== 'undefined' &&
+    navigator.userAgent === CORDOVA_USER_AGENT
+  );
+}
+
+export const isCordova = isCordovaPlatform();

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -595,6 +595,23 @@
           <h2>Push notifications</h2>
           <p>Choose what your phone notifies you about.</p>
 
+          @if (!pushPermissionGranted) {
+            <p data-testid="push-permission-warning">
+              Notifications are turned off for 3D Print Log on this device, so these
+              settings have no effect yet.
+            </p>
+            <p>
+              <button
+                mat-flat-button
+                color="primary"
+                data-testid="push-enable-permission"
+                (click)="onEnableNotificationsClicked()"
+              >
+                Enable notifications
+              </button>
+            </p>
+          }
+
           <div>
             <mat-slide-toggle
               data-testid="push-print-completed"

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -589,6 +589,44 @@
           </div>
         }
       </div>
+      @if (pushAvailable) {
+        <hr />
+        <div fxFlex="grow" fxFlexFill data-testid="push-notifications-section">
+          <h2>Push notifications</h2>
+          <p>Choose what your phone notifies you about.</p>
+
+          <div>
+            <mat-slide-toggle
+              data-testid="push-print-completed"
+              [(ngModel)]="printCompletedPush"
+              (change)="
+                onPushPreferenceChanged(
+                  userSettingTypes.Push_PrintCompleted,
+                  $event.checked
+                )
+              "
+            >
+              Print completed
+            </mat-slide-toggle>
+          </div>
+
+          <div>
+            <mat-slide-toggle
+              data-testid="push-print-failed"
+              [(ngModel)]="printFailedPush"
+              (change)="
+                onPushPreferenceChanged(
+                  userSettingTypes.Push_PrintFailed,
+                  $event.checked
+                )
+              "
+            >
+              Print failed
+            </mat-slide-toggle>
+          </div>
+        </div>
+      }
+
       <hr />
       <div fxFlex="grow" fxFlexFill>
         <h2>Subscription</h2>

--- a/src/app/settings/settings.component.spec.ts
+++ b/src/app/settings/settings.component.spec.ts
@@ -18,6 +18,9 @@ import { SubscriptionService } from '../core/services/subscription.service';
 import { LoggingService } from '../core/services/logging.service';
 import { ConnectedAgentsComponent } from './connected-agents/connected-agents.component';
 import { ConnectedAgentsService } from '../core/services/connected-agents.service';
+import { NativeBridgeService } from '../core/services/native-bridge.service';
+import { PushPreferencesService } from '../core/services/push-preferences.service';
+import { UserSettingType } from '../core/services/user-setting.service';
 
 xdescribe('SettingsComponent (original)', () => {
   let component: SettingsComponent;
@@ -43,6 +46,8 @@ xdescribe('SettingsComponent (original)', () => {
 describe('SettingsComponent', () => {
   let component: SettingsComponent;
   let fixture: ComponentFixture<SettingsComponent>;
+  let mockNativeBridge: jasmine.SpyObj<NativeBridgeService>;
+  let mockPushPreferences: jasmine.SpyObj<PushPreferencesService>;
 
   const mockUserDetails = {
     id: '1',
@@ -113,6 +118,20 @@ describe('SettingsComponent', () => {
       'LoggingService',
       ['logEvent', 'logException']
     );
+    mockNativeBridge = jasmine.createSpyObj<NativeBridgeService>(
+      'NativeBridgeService',
+      ['isAvailable']
+    );
+    // Default to a plain browser: the overwhelming majority of these specs are not about
+    // push, and the section must stay absent for them.
+    mockNativeBridge.isAvailable.and.returnValue(false);
+
+    mockPushPreferences = jasmine.createSpyObj<PushPreferencesService>(
+      'PushPreferencesService',
+      ['isEnabled', 'setEnabled']
+    );
+    mockPushPreferences.isEnabled.and.resolveTo(true);
+    mockPushPreferences.setEnabled.and.resolveTo(undefined);
 
     TestBed.configureTestingModule({
       declarations: [SettingsComponent],
@@ -140,6 +159,8 @@ describe('SettingsComponent', () => {
         { provide: SubscriptionService, useValue: mockSubscriptionService },
         { provide: ThemeService, useValue: mockThemeService },
         { provide: LoggingService, useValue: mockLoggingService },
+        { provide: NativeBridgeService, useValue: mockNativeBridge },
+        { provide: PushPreferencesService, useValue: mockPushPreferences },
       ],
     }).compileComponents();
   }));
@@ -185,6 +206,73 @@ describe('SettingsComponent', () => {
       lightToggle.click();
       fixture.detectChanges();
       expect(themeService.setMode).toHaveBeenCalledWith('light');
+    });
+  });
+
+  describe('push notification preferences', () => {
+    function pushSection(): HTMLElement | null {
+      return fixture.nativeElement.querySelector(
+        '[data-testid="push-notifications-section"]'
+      );
+    }
+
+    it('hides the section entirely in a normal browser', () => {
+      mockNativeBridge.isAvailable.and.returnValue(false);
+
+      fixture.detectChanges();
+
+      expect(pushSection()).toBeNull();
+      expect(mockPushPreferences.isEnabled).not.toHaveBeenCalled();
+    });
+
+    it('renders both toggles inside the app shell', async () => {
+      mockNativeBridge.isAvailable.and.returnValue(true);
+
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(pushSection()).not.toBeNull();
+      expect(
+        fixture.nativeElement.querySelector(
+          '[data-testid="push-print-completed"]'
+        )
+      ).not.toBeNull();
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="push-print-failed"]')
+      ).not.toBeNull();
+    });
+
+    it('reflects a stored opt-out on the matching toggle', async () => {
+      mockNativeBridge.isAvailable.and.returnValue(true);
+      mockPushPreferences.isEnabled.and.callFake((type) =>
+        Promise.resolve(type !== UserSettingType.Push_PrintFailed)
+      );
+
+      fixture.detectChanges();
+      // loadPushPreferences awaits the two lookups in sequence, so one microtask flush is
+      // not enough to see the second one land.
+      await fixture.whenStable();
+      await fixture.whenStable();
+
+      expect(component.printCompletedPush).toBeTrue();
+      expect(component.printFailedPush).toBeFalse();
+    });
+
+    it('writes the print-failed setting when that toggle changes', async () => {
+      mockNativeBridge.isAvailable.and.returnValue(true);
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      await component.onPushPreferenceChanged(
+        UserSettingType.Push_PrintFailed,
+        false
+      );
+
+      expect(mockPushPreferences.setEnabled).toHaveBeenCalledWith(
+        UserSettingType.Push_PrintFailed,
+        false
+      );
     });
   });
 });

--- a/src/app/settings/settings.component.spec.ts
+++ b/src/app/settings/settings.component.spec.ts
@@ -20,6 +20,7 @@ import { ConnectedAgentsComponent } from './connected-agents/connected-agents.co
 import { ConnectedAgentsService } from '../core/services/connected-agents.service';
 import { NativeBridgeService } from '../core/services/native-bridge.service';
 import { PushPreferencesService } from '../core/services/push-preferences.service';
+import { PushPermissionPromptService } from '../core/services/push-permission-prompt.service';
 import { UserSettingType } from '../core/services/user-setting.service';
 
 xdescribe('SettingsComponent (original)', () => {
@@ -48,6 +49,7 @@ describe('SettingsComponent', () => {
   let fixture: ComponentFixture<SettingsComponent>;
   let mockNativeBridge: jasmine.SpyObj<NativeBridgeService>;
   let mockPushPreferences: jasmine.SpyObj<PushPreferencesService>;
+  let mockPushPermissionPrompt: jasmine.SpyObj<PushPermissionPromptService>;
 
   const mockUserDetails = {
     id: '1',
@@ -120,7 +122,8 @@ describe('SettingsComponent', () => {
     );
     mockNativeBridge = jasmine.createSpyObj<NativeBridgeService>(
       'NativeBridgeService',
-      ['isAvailable']
+      ['isAvailable'],
+      { permission: 'granted' }
     );
     // Default to a plain browser: the overwhelming majority of these specs are not about
     // push, and the section must stay absent for them.
@@ -132,6 +135,13 @@ describe('SettingsComponent', () => {
     );
     mockPushPreferences.isEnabled.and.resolveTo(true);
     mockPushPreferences.setEnabled.and.resolveTo(undefined);
+
+    mockPushPermissionPrompt =
+      jasmine.createSpyObj<PushPermissionPromptService>(
+        'PushPermissionPromptService',
+        ['promptInContext']
+      );
+    mockPushPermissionPrompt.promptInContext.and.resolveTo('granted');
 
     TestBed.configureTestingModule({
       declarations: [SettingsComponent],
@@ -161,6 +171,10 @@ describe('SettingsComponent', () => {
         { provide: LoggingService, useValue: mockLoggingService },
         { provide: NativeBridgeService, useValue: mockNativeBridge },
         { provide: PushPreferencesService, useValue: mockPushPreferences },
+        {
+          provide: PushPermissionPromptService,
+          useValue: mockPushPermissionPrompt,
+        },
       ],
     }).compileComponents();
   }));
@@ -273,6 +287,76 @@ describe('SettingsComponent', () => {
         UserSettingType.Push_PrintFailed,
         false
       );
+    });
+  });
+
+  describe('push notification permission', () => {
+    function setPermission(permission: string) {
+      Object.defineProperty(mockNativeBridge, 'permission', {
+        value: permission,
+        configurable: true,
+      });
+    }
+
+    async function renderInAppShell() {
+      mockNativeBridge.isAvailable.and.returnValue(true);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      await fixture.whenStable();
+      fixture.detectChanges();
+    }
+
+    function warning(): HTMLElement | null {
+      return fixture.nativeElement.querySelector(
+        '[data-testid="push-permission-warning"]'
+      );
+    }
+
+    function enableButton(): HTMLElement | null {
+      return fixture.nativeElement.querySelector(
+        '[data-testid="push-enable-permission"]'
+      );
+    }
+
+    it('says nothing extra when permission is granted', async () => {
+      setPermission('granted');
+
+      await renderInAppShell();
+
+      expect(warning()).toBeNull();
+      expect(enableButton()).toBeNull();
+    });
+
+    it('warns and offers the prompt when permission was denied', async () => {
+      setPermission('denied');
+
+      await renderInAppShell();
+
+      expect(warning()).not.toBeNull();
+      expect(enableButton()).not.toBeNull();
+    });
+
+    it('warns and offers the prompt when permission has never been asked for', async () => {
+      setPermission('default');
+
+      await renderInAppShell();
+
+      expect(warning()).not.toBeNull();
+      expect(enableButton()).not.toBeNull();
+    });
+
+    it('hides the warning once the prompt grants permission', async () => {
+      setPermission('denied');
+      await renderInAppShell();
+
+      await component.onEnableNotificationsClicked();
+      await fixture.whenStable();
+
+      expect(mockPushPermissionPrompt.promptInContext).toHaveBeenCalled();
+      // Asserted on the field, not the DOM: re-running change detection after this
+      // async state change trips NG0100 in the harness. That the field drives the
+      // warning's visibility is covered by the granted/denied/default render tests above.
+      expect(component.pushPermissionGranted).toBeTrue();
     });
   });
 });

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -31,6 +31,7 @@ import {
   PushNotificationType,
   PushPreferencesService,
 } from '../core/services/push-preferences.service';
+import { PushPermissionPromptService } from '../core/services/push-permission-prompt.service';
 
 @Component({
   selector: 'app-settings',
@@ -107,6 +108,13 @@ export class SettingsComponent implements OnInit {
   public printCompletedPush = true;
   public printFailedPush = true;
 
+  /**
+   * The toggles write a preference, but a preference cannot make Android display anything.
+   * When the OS permission is missing the toggles are honest but inert, so the section says
+   * so and offers the request — this is the second chance for someone who declined earlier.
+   */
+  public pushPermissionGranted = true;
+
   /** Exposed so the template can name the setting types it writes. */
   public readonly userSettingTypes = UserSettingType;
 
@@ -125,6 +133,7 @@ export class SettingsComponent implements OnInit {
   private readonly loggingService = inject(LoggingService);
   private readonly pushPreferences = inject(PushPreferencesService);
   private readonly nativeBridge = inject(NativeBridgeService);
+  private readonly pushPermissionPrompt = inject(PushPermissionPromptService);
 
   private async loadPushPreferences(): Promise<void> {
     this.pushAvailable = this.nativeBridge.isAvailable();
@@ -138,6 +147,14 @@ export class SettingsComponent implements OnInit {
     this.printFailedPush = await this.pushPreferences.isEnabled(
       UserSettingType.Push_PrintFailed
     );
+    this.pushPermissionGranted = this.nativeBridge.permission === 'granted';
+  }
+
+  async onEnableNotificationsClicked(): Promise<void> {
+    const permission = await this.pushPermissionPrompt.promptInContext(
+      'Notifications are turned off for 3D Print Log on this device.'
+    );
+    this.pushPermissionGranted = permission === 'granted';
   }
 
   // One handler per toggle, with the type passed explicitly: a shared handler would have to

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -26,6 +26,11 @@ import {
 import { SubscriptionService } from '../core/services/subscription.service';
 import { ThemeService, ThemeMode } from '../core/services/theme.service';
 import { LoggingService } from '../core/services/logging.service';
+import { NativeBridgeService } from '../core/services/native-bridge.service';
+import {
+  PushNotificationType,
+  PushPreferencesService,
+} from '../core/services/push-preferences.service';
 
 @Component({
   selector: 'app-settings',
@@ -94,6 +99,17 @@ export class SettingsComponent implements OnInit {
 
   public currencies: Currencies = null;
 
+  /**
+   * Whether the push section renders at all. Hidden in a normal browser: dead toggles that
+   * cannot affect anything are worse than no toggles.
+   */
+  public pushAvailable = false;
+  public printCompletedPush = true;
+  public printFailedPush = true;
+
+  /** Exposed so the template can name the setting types it writes. */
+  public readonly userSettingTypes = UserSettingType;
+
   constructor(
     private activatedRoute: ActivatedRoute,
     private userService: UserService,
@@ -107,6 +123,31 @@ export class SettingsComponent implements OnInit {
   readonly subscriptionService = inject(SubscriptionService);
   readonly themeService = inject(ThemeService);
   private readonly loggingService = inject(LoggingService);
+  private readonly pushPreferences = inject(PushPreferencesService);
+  private readonly nativeBridge = inject(NativeBridgeService);
+
+  private async loadPushPreferences(): Promise<void> {
+    this.pushAvailable = this.nativeBridge.isAvailable();
+    if (!this.pushAvailable) {
+      return;
+    }
+
+    this.printCompletedPush = await this.pushPreferences.isEnabled(
+      UserSettingType.Push_PrintCompleted
+    );
+    this.printFailedPush = await this.pushPreferences.isEnabled(
+      UserSettingType.Push_PrintFailed
+    );
+  }
+
+  // One handler per toggle, with the type passed explicitly: a shared handler would have to
+  // guess which toggle changed and could write the wrong setting.
+  async onPushPreferenceChanged(
+    type: PushNotificationType,
+    enabled: boolean
+  ): Promise<void> {
+    await this.pushPreferences.setEnabled(type, enabled);
+  }
 
   setThemeMode(mode: ThemeMode): void {
     this.themeService.setMode(mode);
@@ -115,6 +156,8 @@ export class SettingsComponent implements OnInit {
 
   ngOnInit(): void {
     this.metaService.setTitle('Settings - 3D Print Log');
+
+    void this.loadPushPreferences();
 
     this.activatedRoute.data.subscribe((data) => {
       this.currencies = data.currencies;


### PR DESCRIPTION
Phase 2 of the push notifications design (spec lives in the `3d-print-log-app` repo). **No-ops entirely outside the Cordova app** — the settings section is hidden and every bridge call short-circuits in a normal browser.

Pairs with `3d-print-log-api#107` and `3d-print-log-app#14`.

## What's here

- **`NativeBridgeService`** + typings for the bridge the Cordova app injects. The raw FCM token is deliberately never exposed to page script; the web layer hands native its bearer and native makes the API call.
- **`UserSettingType` 15/16** and **`UserSettingService.addOrUpdateSetting`** — one place that decides PUT vs POST, now that the API and the database both reject a duplicate row per type.
- **`PushPreferencesService`** — mirrors the API's `PushPreference.IsEnabled` exactly: only the trimmed, case-insensitive literal `false` disables. Anything else, including absent, means enabled.
- **Settings toggles** for "Print completed" / "Print failed", rendered only inside the app shell.
- **`PushRegistrationService`** — registration is driven by *authenticated profile + available bridge*, not bridge availability alone, so it cannot race Auth0 rehydration at cold start and strand the installation unregistered.
- **`AuthService.pushTeardown`** — an awaited hook, so the device registration is deleted while the bearer is still valid. Failures are swallowed: a stale token is far better than a user who cannot log out.
- **Tap handling** — marks the notification read and routes to the print, on both cold start and `resume`.
- **`PushPermissionPromptService`** — the Android 13+ notification permission, asked in context behind an explainer: after the user creates an API key (the moment a printer can start reporting), and from a settings button when permission is missing. **Never at launch** — a denial there is effectively permanent, and declining the explainer never reaches the OS dialog at all.

Tests: **1356 passing** (baseline 1316). Lint and the `strictNullChecks` gate are clean.

## Deviations from the plan

- **`platform.ts` gains `isCordovaPlatform()` and `CORDOVA_USER_AGENT`.** The plan anticipated this. `isCordova` keeps its exact import-time semantics for existing callers; the new function is evaluated per call so the bridge service can be tested on both branches. `CORDOVA_USER_AGENT` is the named constant the app repo's CI guard now asserts against — see `3d-print-log-app#14`.
- **`AuthService.logout()` is now `async`.** It has to await push teardown before starting Auth0 logout. The one internal caller is now `void this.logout()`; the template call is unchanged.
- **`addOrUpdateSetting` specs drive the real cache-priming path** rather than setting private fields, and the settings specs use `data-testid` hooks.
- **One settings assertion is on the component field, not the DOM.** Re-running change detection after that async state change trips NG0100 in the harness; that the field drives the warning's visibility is covered by the three granted/denied/default render tests beside it.