### PR TITLE
fix: drain a pending notification tap on a native signal, not `resume`

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -67,6 +67,7 @@ describe('AppComponent (ThemeService)', () => {
       'NativeBridgeService',
       ['onPendingTap']
     );
+    mockNativeBridge.onPendingTap.and.returnValue(true);
     mockPushRegistration.onAuthenticated.and.resolveTo(undefined);
     mockPushRegistration.onLogout.and.resolveTo(undefined);
     mockPushRegistration.handlePendingTap.and.resolveTo(undefined);
@@ -171,6 +172,31 @@ describe('AppComponent (ThemeService)', () => {
       listener();
 
       expect(mockPushRegistration.handlePendingTap).toHaveBeenCalled();
+    });
+
+    /**
+     * The app shell injects window.PrintLogNative on page load, which can land after Angular
+     * has bootstrapped. A one-shot attempt in ngOnInit therefore silently installs nothing,
+     * and every later warm-start tap is signalled into an empty listener list.
+     */
+    it('retries installing the tap listener when the bridge was not ready', () => {
+      mockNativeBridge.onPendingTap.and.returnValue(false);
+      mockAuthService.userProfile$ = of({ id: 1 } as never);
+
+      const fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+
+      expect(mockNativeBridge.onPendingTap).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not reinstall the tap listener once one is installed', () => {
+      mockNativeBridge.onPendingTap.and.returnValue(true);
+      mockAuthService.userProfile$ = of({ id: 1 } as never);
+
+      const fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+
+      expect(mockNativeBridge.onPendingTap).toHaveBeenCalledTimes(1);
     });
 
     it('does not listen for the Cordova resume event', () => {

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -8,6 +8,7 @@ import { LoggingService } from './core/services/logging.service';
 import { VersionReleaseNoteDialogService } from './core/services/version-release-note-dialog.service';
 import { AdsenseLoaderService } from './core/services/adsense-loader.service';
 import { PushRegistrationService } from './core/services/push-registration.service';
+import { NativeBridgeService } from './core/services/native-bridge.service';
 import { of } from 'rxjs';
 import { NO_ERRORS_SCHEMA, signal } from '@angular/core';
 
@@ -48,6 +49,7 @@ describe('AppComponent (ThemeService)', () => {
   let mockReleaseNotesService: jasmine.SpyObj<VersionReleaseNoteDialogService>;
   let mockThemeService: jasmine.SpyObj<ThemeService>;
   let mockPushRegistration: jasmine.SpyObj<PushRegistrationService>;
+  let mockNativeBridge: jasmine.SpyObj<NativeBridgeService>;
 
   beforeEach(waitForAsync(() => {
     mockAuthService = jasmine.createSpyObj<AuthService>('AuthService', [
@@ -60,6 +62,10 @@ describe('AppComponent (ThemeService)', () => {
     mockPushRegistration = jasmine.createSpyObj<PushRegistrationService>(
       'PushRegistrationService',
       ['onAuthenticated', 'onLogout', 'handlePendingTap']
+    );
+    mockNativeBridge = jasmine.createSpyObj<NativeBridgeService>(
+      'NativeBridgeService',
+      ['onPendingTap']
     );
     mockPushRegistration.onAuthenticated.and.resolveTo(undefined);
     mockPushRegistration.onLogout.and.resolveTo(undefined);
@@ -103,6 +109,7 @@ describe('AppComponent (ThemeService)', () => {
         { provide: ThemeService, useValue: mockThemeService },
         { provide: AdsenseLoaderService, useValue: mockAdsenseLoader },
         { provide: PushRegistrationService, useValue: mockPushRegistration },
+        { provide: NativeBridgeService, useValue: mockNativeBridge },
       ],
     }).compileComponents();
   }));
@@ -142,13 +149,37 @@ describe('AppComponent (ThemeService)', () => {
       expect(mockPushRegistration.onLogout).toHaveBeenCalledWith('bearer-abc');
     });
 
-    it('drains a pending tap when the app resumes', () => {
+    /**
+     * Native signals the tap; we do NOT listen for Cordova's `resume`. cordova.js is absent
+     * on this origin, so a `resume` listener never fires in the real app — an earlier
+     * version of this test dispatched a synthetic `resume` event and passed while the
+     * feature was broken in production.
+     */
+    it('registers a pending-tap listener with the native bridge', () => {
+      const fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+
+      expect(mockNativeBridge.onPendingTap).toHaveBeenCalled();
+    });
+
+    it('drains the pending tap when native signals one arrived', () => {
+      const fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+
+      const listener = mockNativeBridge.onPendingTap.calls.mostRecent()
+        .args[0] as () => void;
+      listener();
+
+      expect(mockPushRegistration.handlePendingTap).toHaveBeenCalled();
+    });
+
+    it('does not listen for the Cordova resume event', () => {
       const fixture = TestBed.createComponent(AppComponent);
       fixture.detectChanges();
 
       document.dispatchEvent(new Event('resume'));
 
-      expect(mockPushRegistration.handlePendingTap).toHaveBeenCalled();
+      expect(mockPushRegistration.handlePendingTap).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -10,6 +10,7 @@ import { AdsenseLoaderService } from './core/services/adsense-loader.service';
 import { AuthService } from './core/services/auth.service';
 import { GoogleAnalyticsService } from './core/services/google-analytics.service';
 import { LoggingService } from './core/services/logging.service';
+import { NativeBridgeService } from './core/services/native-bridge.service';
 import { PushRegistrationService } from './core/services/push-registration.service';
 import { ThemeService } from './core/services/theme.service';
 import { VersionReleaseNoteDialogService } from './core/services/version-release-note-dialog.service';
@@ -39,6 +40,7 @@ export class AppComponent implements OnInit {
     private themeService: ThemeService,
     private adsenseLoader: AdsenseLoaderService,
     private pushRegistration: PushRegistrationService,
+    private nativeBridge: NativeBridgeService,
     @Inject(PLATFORM_ID) private platformId: object
   ) {}
 
@@ -78,12 +80,16 @@ export class AppComponent implements OnInit {
 
   /**
    * A tap while the app is already running resumes it rather than starting it, so the
-   * pending tap has to be drained on resume as well as at registration time.
+   * pending tap has to be drained then as well as at registration time.
+   *
+   * Native signals us; we do not listen for Cordova's `resume`. The WebView navigates to
+   * this origin and cordova.js is gone from that point, so a `resume` listener here would
+   * never fire — it silently swallowed every warm-start tap.
    */
   private watchForWarmStartTaps() {
     if (!isPlatformBrowser(this.platformId)) return;
 
-    document.addEventListener('resume', () => {
+    this.nativeBridge.onPendingTap(() => {
       void this.pushRegistration.handlePendingTap();
     });
   }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -24,6 +24,9 @@ import { VersionReleaseNoteDialogService } from './core/services/version-release
 export class AppComponent implements OnInit {
   title = 'print-log-ui';
 
+  /** Whether native accepted our pending-tap listener, so we stop retrying. */
+  private tapListenerInstalled = false;
+
   readonly loadingBarColor = computed(() =>
     this.themeService.isDark() ? '#283593' : '#3f51b5'
   );
@@ -52,6 +55,7 @@ export class AppComponent implements OnInit {
       if (user) {
         this.releaseNotesService.checkLastLoggedInVersion();
         this.registerForPush();
+        this.watchForWarmStartTaps();
       }
     });
 
@@ -87,9 +91,14 @@ export class AppComponent implements OnInit {
    * never fire — it silently swallowed every warm-start tap.
    */
   private watchForWarmStartTaps() {
-    if (!isPlatformBrowser(this.platformId)) return;
+    if (!isPlatformBrowser(this.platformId) || this.tapListenerInstalled)
+      return;
 
-    this.nativeBridge.onPendingTap(() => {
+    // Retried rather than attempted once: the app shell injects window.PrintLogNative on
+    // page load, which can land after Angular has bootstrapped. A single attempt in ngOnInit
+    // would then install nothing at all, and every later tap would be signalled into an
+    // empty listener list — silently, which is the failure mode this replaced.
+    this.tapListenerInstalled = this.nativeBridge.onPendingTap(() => {
       void this.pushRegistration.handlePendingTap();
     });
   }

--- a/src/app/core/services/native-bridge.service.ts
+++ b/src/app/core/services/native-bridge.service.ts
@@ -57,4 +57,23 @@ export class NativeBridgeService {
       return null;
     }
   }
+
+  /**
+   * @returns true if native will call the listener. False on the web, and on an app shell
+   *          predating the callback, so the caller can tell "wired up" from "silently never
+   *          fires" — the exact failure the `resume` listener this replaces had.
+   */
+  onPendingTap(listener: () => void): boolean {
+    const bridge = this.bridge;
+    if (!bridge?.onPendingTap) {
+      return false;
+    }
+
+    try {
+      bridge.onPendingTap(listener);
+      return true;
+    } catch {
+      return false;
+    }
+  }
 }

--- a/src/app/core/services/push-permission-prompt.service.spec.ts
+++ b/src/app/core/services/push-permission-prompt.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { PushPermissionPromptService } from './push-permission-prompt.service';
 import { NativeBridgeService } from './native-bridge.service';
 import { PushPermissionState } from '../types/native-bridge';
@@ -54,9 +54,9 @@ describe('PushPermissionPromptService', () => {
   it('does nothing in an ordinary browser', async () => {
     bridge.isAvailable.and.returnValue(false);
 
-    await expectAsync(service.promptInContext('reason')).toBeResolvedTo(
-      'default'
-    );
+    const result = await service.promptInContext('reason');
+    expect(result.permission).toBe('default');
+    expect(result.outcome).toBe('unavailable');
 
     expect(dialog.open).not.toHaveBeenCalled();
     expect(bridge.requestPushPermission).not.toHaveBeenCalled();
@@ -65,9 +65,9 @@ describe('PushPermissionPromptService', () => {
   it('does not re-prompt when permission is already granted', async () => {
     withPermission('granted');
 
-    await expectAsync(service.promptInContext('reason')).toBeResolvedTo(
-      'granted'
-    );
+    const result = await service.promptInContext('reason');
+    expect(result.permission).toBe('granted');
+    expect(result.outcome).toBe('already-granted');
 
     expect(dialog.open).not.toHaveBeenCalled();
   });
@@ -92,7 +92,7 @@ describe('PushPermissionPromptService', () => {
     // On Android 13+ the system dialog is effectively one-shot. Spending it on someone who
     // just said "not now" is how the permission becomes permanently denied.
     expect(bridge.requestPushPermission).not.toHaveBeenCalled();
-    expect(result).toBe('default');
+    expect(result.permission).toBe('default');
   });
 
   it('prompts again after an earlier denial', async () => {
@@ -157,13 +157,124 @@ describe('PushPermissionPromptService', () => {
   });
 
   /** Private browsing and blocked site data both make localStorage throw on access. */
-  it('still prompts when storage is unavailable', async () => {
+  it('still prompts when storage cannot be read', async () => {
     spyOn(localStorage, 'getItem').and.throwError('denied');
-    spyOn(localStorage, 'setItem').and.throwError('denied');
     userAnswers(true);
 
     await service.promptInContext('reason');
 
     expect(dialog.open).toHaveBeenCalled();
+  });
+
+  /**
+   * Declines, so rememberDecline actually runs — an accepted prompt never writes, which
+   * made an earlier version of this test pass with the write guard deleted.
+   */
+  it('survives storage that cannot be written', async () => {
+    const setItem = spyOn(localStorage, 'setItem').and.throwError('denied');
+    userAnswers(false);
+
+    const result = await service.promptInContext('reason');
+
+    expect(setItem).toHaveBeenCalled();
+    expect(result.outcome).toBe('shown');
+    expect(bridge.requestPushPermission).not.toHaveBeenCalled();
+  });
+
+  describe('explicit user request', () => {
+    it('ignores the cooldown, so Settings still works after a decline', async () => {
+      userAnswers(false);
+      await service.promptInContext('reason');
+      dialog.open.calls.reset();
+      userAnswers(true);
+
+      const result = await service.promptOnUserRequest('from settings');
+
+      // The Settings button is the documented second chance for someone who declined; the
+      // in-context cooldown silently disabling it strands them with no in-app route at all.
+      expect(dialog.open).toHaveBeenCalled();
+      expect(result.permission).toBe('granted');
+    });
+  });
+
+  describe('concurrent triggers', () => {
+    /**
+     * Reachable today: the API-key response can land after the user has navigated to a
+     * running print, whose effect calls the same root-provided service.
+     */
+    it('opens one explainer, not one per caller', async () => {
+      const closed = new Subject<boolean>();
+      dialogRef.afterClosed.and.returnValue(closed.asObservable());
+
+      const first = service.promptInContext('api key');
+      const second = service.promptInContext('running print');
+
+      closed.next(true);
+      closed.complete();
+      await Promise.all([first, second]);
+
+      expect(dialog.open).toHaveBeenCalledTimes(1);
+      expect(bridge.requestPushPermission).toHaveBeenCalledTimes(1);
+    });
+
+    it('allows a later prompt once the first has settled', async () => {
+      userAnswers(true);
+      await service.promptInContext('first');
+      withPermission('default');
+      dialog.open.calls.reset();
+
+      await service.promptInContext('second');
+
+      expect(dialog.open).toHaveBeenCalled();
+    });
+  });
+
+  /**
+   * The permission can be granted while our explainer is open — the Settings button in
+   * another tab, or a concurrent flow. Asking the OS again would spend a second
+   * irreversible request on a grant already held.
+   */
+  it('does not re-ask the OS when permission arrived while the dialog was open', async () => {
+    const closed = new Subject<boolean>();
+    dialogRef.afterClosed.and.returnValue(closed.asObservable());
+
+    const pending = service.promptInContext('reason');
+    withPermission('granted');
+    closed.next(true);
+    closed.complete();
+
+    const result = await pending;
+
+    expect(bridge.requestPushPermission).not.toHaveBeenCalled();
+    expect(result.permission).toBe('granted');
+  });
+
+  describe('clock skew', () => {
+    /**
+     * A device whose clock was ahead when the decline was recorded, then corrected back.
+     * Naive subtraction makes the age negative, which reads as "very recent" and suppresses
+     * the prompt until the clock catches up again.
+     */
+    it('ignores a decline recorded far in the future', async () => {
+      const nextYear = Date.now() + 365 * 24 * 60 * 60 * 1000;
+      localStorage.setItem('printlog.pushPromptDeclinedAt', String(nextYear));
+      userAnswers(true);
+
+      await service.promptInContext('reason');
+
+      expect(dialog.open).toHaveBeenCalled();
+    });
+
+    it('tolerates a clock that is only slightly ahead', async () => {
+      const slightlyAhead = Date.now() + 60 * 1000;
+      localStorage.setItem(
+        'printlog.pushPromptDeclinedAt',
+        String(slightlyAhead)
+      );
+
+      await service.promptInContext('reason');
+
+      expect(dialog.open).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/core/services/push-permission-prompt.service.spec.ts
+++ b/src/app/core/services/push-permission-prompt.service.spec.ts
@@ -26,6 +26,7 @@ describe('PushPermissionPromptService', () => {
   }
 
   beforeEach(() => {
+    localStorage.clear();
     bridge = jasmine.createSpyObj<NativeBridgeService>(
       'NativeBridgeService',
       ['isAvailable', 'requestPushPermission'],
@@ -101,5 +102,68 @@ describe('PushPermissionPromptService', () => {
     await service.promptInContext('reason');
 
     expect(bridge.requestPushPermission).toHaveBeenCalled();
+  });
+
+  /**
+   * Without this, adding a trigger that fires often — every in-progress print the user opens
+   * — turns a single "Not now" into an explainer on every visit. The suppression is of OUR
+   * dialog only; the OS prompt is still only reached via an explicit "Enable notifications".
+   */
+  it('does not show the explainer again soon after the user declined it', async () => {
+    userAnswers(false);
+    await service.promptInContext('reason');
+    dialog.open.calls.reset();
+
+    await service.promptInContext('reason');
+
+    expect(dialog.open).not.toHaveBeenCalled();
+  });
+
+  it('suppresses across triggers, not just the one that was declined', async () => {
+    userAnswers(false);
+    await service.promptInContext('You just created an API key.');
+    dialog.open.calls.reset();
+
+    await service.promptInContext('This print is still running.');
+
+    expect(dialog.open).not.toHaveBeenCalled();
+  });
+
+  it('asks again once the cooldown has passed', async () => {
+    userAnswers(false);
+    await service.promptInContext('reason');
+
+    const thirtyOneDaysAgo = Date.now() - 31 * 24 * 60 * 60 * 1000;
+    localStorage.setItem(
+      'printlog.pushPromptDeclinedAt',
+      String(thirtyOneDaysAgo)
+    );
+    dialog.open.calls.reset();
+    userAnswers(true);
+
+    await service.promptInContext('reason');
+
+    expect(dialog.open).toHaveBeenCalled();
+  });
+
+  it('does not suppress after the user accepted the explainer', async () => {
+    userAnswers(true);
+    await service.promptInContext('reason');
+    dialog.open.calls.reset();
+
+    await service.promptInContext('reason');
+
+    expect(dialog.open).toHaveBeenCalled();
+  });
+
+  /** Private browsing and blocked site data both make localStorage throw on access. */
+  it('still prompts when storage is unavailable', async () => {
+    spyOn(localStorage, 'getItem').and.throwError('denied');
+    spyOn(localStorage, 'setItem').and.throwError('denied');
+    userAnswers(true);
+
+    await service.promptInContext('reason');
+
+    expect(dialog.open).toHaveBeenCalled();
   });
 });

--- a/src/app/core/services/push-permission-prompt.service.ts
+++ b/src/app/core/services/push-permission-prompt.service.ts
@@ -6,6 +6,23 @@ import { NativeBridgeService } from './native-bridge.service';
 import { PushPermissionState } from '../types/native-bridge';
 
 /**
+ * What actually happened, as distinct from the resulting permission.
+ *
+ * A caller that only offers opportunistically has to tell "the user has now decided" from
+ * "nothing was asked at all", so it does not spend a one-per-view offer on a no-op.
+ */
+export type PushPromptOutcome =
+  | 'shown'
+  | 'suppressed'
+  | 'unavailable'
+  | 'already-granted';
+
+export interface PushPromptResult {
+  permission: PushPermissionState;
+  outcome: PushPromptOutcome;
+}
+
+/**
  * Asks for the Android notification permission, in context and behind an explainer.
  *
  * Never at launch. On Android 13+ a denial is effectively permanent — the OS stops showing
@@ -21,37 +38,84 @@ export class PushPermissionPromptService {
   private static readonly DECLINED_AT_KEY = 'printlog.pushPromptDeclinedAt';
 
   /**
-   * How long "Not now" is honoured. Long enough that the ask does not become nagging,
-   * short enough that someone who declined reflexively gets another chance without having
-   * to find this in Settings.
+   * How long "Not now" is honoured for offers the user did not ask for. Long enough that the
+   * ask does not become nagging, short enough that someone who declined reflexively gets
+   * another chance without having to find this in Settings.
    */
   private static readonly COOLDOWN_MS = 30 * 24 * 60 * 60 * 1000;
 
   /**
-   * Shows the explainer and, if the user agrees, requests the permission.
+   * Tolerance for a device clock that is slightly ahead. Past this, a stored timestamp is
+   * treated as corrupt rather than as the future: a future value would otherwise suppress
+   * prompting until the clock caught up to it, which for a badly wrong clock is forever.
+   */
+  private static readonly MAX_CLOCK_SKEW_MS = 24 * 60 * 60 * 1000;
+
+  /**
+   * The prompt currently on screen, if any. Two triggers can fire close together — an
+   * API-key creation response landing after the user has navigated to a running print — and
+   * without this both would open an explainer and both would reach the OS request.
+   */
+  private inFlight: Promise<PushPromptResult> | null = null;
+
+  /**
+   * Offers notifications at a moment that makes them meaningful. The user did not ask for
+   * this, so a recent "Not now" is honoured.
    *
-   * A no-op outside the app shell and when the permission is already granted, so callers
-   * can invoke it from a shared flow without branching on platform.
+   * A no-op outside the app shell and when the permission is already granted, so callers can
+   * invoke it from a shared flow without branching on platform.
    *
    * @param reason one sentence on what just happened that makes notifications useful.
-   * @returns the resulting permission state.
    */
-  async promptInContext(reason: string): Promise<PushPermissionState> {
+  promptInContext(reason: string): Promise<PushPromptResult> {
+    return this.run(reason, { honourCooldown: true });
+  }
+
+  /**
+   * Requests notifications because the user explicitly asked — the Settings button.
+   *
+   * Deliberately ignores the cooldown. That button is the documented second chance for
+   * someone who declined earlier, and suppressing it would leave a user who changed their
+   * mind with no route to enabling notifications inside the app at all.
+   */
+  promptOnUserRequest(reason: string): Promise<PushPromptResult> {
+    return this.run(reason, { honourCooldown: false });
+  }
+
+  private run(
+    reason: string,
+    options: { honourCooldown: boolean }
+  ): Promise<PushPromptResult> {
+    if (this.inFlight) {
+      return this.inFlight;
+    }
+
+    const attempt = this.ask(reason, options).finally(() => {
+      this.inFlight = null;
+    });
+    this.inFlight = attempt;
+    return attempt;
+  }
+
+  private async ask(
+    reason: string,
+    options: { honourCooldown: boolean }
+  ): Promise<PushPromptResult> {
     if (!this.bridge.isAvailable()) {
-      return 'default';
+      return { permission: 'default', outcome: 'unavailable' };
     }
 
     const current = this.bridge.permission;
     if (current === 'granted') {
-      return current;
+      return { permission: current, outcome: 'already-granted' };
     }
 
     // Suppresses OUR explainer only, never the OS prompt, which is still reached solely via
     // an explicit "Enable notifications". Checked across all triggers rather than per
     // trigger: someone who just declined on one screen should not be asked again from
     // another a few minutes later.
-    if (this.declinedRecently()) {
-      return current;
+    if (options.honourCooldown && this.declinedRecently()) {
+      return { permission: current, outcome: 'suppressed' };
     }
 
     const dialogRef = this.dialog.open(SimpleDialogComponent, { data: {} });
@@ -67,10 +131,20 @@ export class PushPermissionPromptService {
       // "Not now" must not reach the OS prompt: spending the single system dialog on a user
       // who just declined the explainer is how the permission gets permanently denied.
       this.rememberDecline();
-      return current;
+      return { permission: current, outcome: 'shown' };
     }
 
-    return this.bridge.requestPushPermission();
+    // Re-read rather than trusting the value captured before the dialog opened: the
+    // permission can have been granted while it was up, and asking the OS again would spend
+    // a second irreversible request on a grant we already hold.
+    if (this.bridge.permission === 'granted') {
+      return { permission: 'granted', outcome: 'already-granted' };
+    }
+
+    return {
+      permission: await this.bridge.requestPushPermission(),
+      outcome: 'shown',
+    };
   }
 
   private declinedRecently(): boolean {
@@ -81,7 +155,16 @@ export class PushPermissionPromptService {
       return false;
     }
 
-    return Date.now() - declinedAt < PushPermissionPromptService.COOLDOWN_MS;
+    const age = Date.now() - declinedAt;
+    if (age < -PushPermissionPromptService.MAX_CLOCK_SKEW_MS) {
+      // Recorded materially in the future: a clock that was ahead and has since been
+      // corrected, or a corrupt value. Treating it as recent would suppress the prompt until
+      // the clock caught back up to it, so drop it instead.
+      this.remove(PushPermissionPromptService.DECLINED_AT_KEY);
+      return false;
+    }
+
+    return age < PushPermissionPromptService.COOLDOWN_MS;
   }
 
   private rememberDecline(): void {
@@ -89,9 +172,9 @@ export class PushPermissionPromptService {
   }
 
   /*
-   * Both accessors throw outright in private browsing and when site data is blocked, so
-   * neither is allowed to break the prompt. Failing to read means we ask — the worse
-   * outcome is a user who can never be asked at all.
+   * Every accessor below throws outright in private browsing and when site data is blocked,
+   * so none of them may break the prompt. Failing to read means we ask: the worse outcome is
+   * a user who can never be asked at all.
    */
   private read(key: string): string | null {
     try {
@@ -106,6 +189,14 @@ export class PushPermissionPromptService {
       localStorage.setItem(key, value);
     } catch {
       // Nothing to do: the prompt simply is not suppressed on this device.
+    }
+  }
+
+  private remove(key: string): void {
+    try {
+      localStorage.removeItem(key);
+    } catch {
+      // As above.
     }
   }
 }

--- a/src/app/core/services/push-permission-prompt.service.ts
+++ b/src/app/core/services/push-permission-prompt.service.ts
@@ -17,6 +17,16 @@ export class PushPermissionPromptService {
   private readonly bridge = inject(NativeBridgeService);
   private readonly dialog = inject(MatDialog);
 
+  /** Per-device, matching the scope of the permission it is about. */
+  private static readonly DECLINED_AT_KEY = 'printlog.pushPromptDeclinedAt';
+
+  /**
+   * How long "Not now" is honoured. Long enough that the ask does not become nagging,
+   * short enough that someone who declined reflexively gets another chance without having
+   * to find this in Settings.
+   */
+  private static readonly COOLDOWN_MS = 30 * 24 * 60 * 60 * 1000;
+
   /**
    * Shows the explainer and, if the user agrees, requests the permission.
    *
@@ -36,6 +46,14 @@ export class PushPermissionPromptService {
       return current;
     }
 
+    // Suppresses OUR explainer only, never the OS prompt, which is still reached solely via
+    // an explicit "Enable notifications". Checked across all triggers rather than per
+    // trigger: someone who just declined on one screen should not be asked again from
+    // another a few minutes later.
+    if (this.declinedRecently()) {
+      return current;
+    }
+
     const dialogRef = this.dialog.open(SimpleDialogComponent, { data: {} });
     dialogRef.componentInstance.title = 'Get notified about your prints?';
     dialogRef.componentInstance.body = `<p>${reason}</p>
@@ -48,9 +66,46 @@ export class PushPermissionPromptService {
     if (!accepted) {
       // "Not now" must not reach the OS prompt: spending the single system dialog on a user
       // who just declined the explainer is how the permission gets permanently denied.
+      this.rememberDecline();
       return current;
     }
 
     return this.bridge.requestPushPermission();
+  }
+
+  private declinedRecently(): boolean {
+    const declinedAt = Number(
+      this.read(PushPermissionPromptService.DECLINED_AT_KEY)
+    );
+    if (!Number.isFinite(declinedAt) || declinedAt <= 0) {
+      return false;
+    }
+
+    return Date.now() - declinedAt < PushPermissionPromptService.COOLDOWN_MS;
+  }
+
+  private rememberDecline(): void {
+    this.write(PushPermissionPromptService.DECLINED_AT_KEY, String(Date.now()));
+  }
+
+  /*
+   * Both accessors throw outright in private browsing and when site data is blocked, so
+   * neither is allowed to break the prompt. Failing to read means we ask — the worse
+   * outcome is a user who can never be asked at all.
+   */
+  private read(key: string): string | null {
+    try {
+      return localStorage.getItem(key);
+    } catch {
+      return null;
+    }
+  }
+
+  private write(key: string, value: string): void {
+    try {
+      localStorage.setItem(key, value);
+    } catch {
+      // Nothing to do: the prompt simply is not suppressed on this device.
+    }
   }
 }

--- a/src/app/core/services/push-registration.service.spec.ts
+++ b/src/app/core/services/push-registration.service.spec.ts
@@ -1,6 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { PushRegistrationService } from './push-registration.service';
 import { NativeBridgeService } from './native-bridge.service';
 import { NotificationService } from './notification.service';
@@ -97,5 +97,24 @@ describe('PushRegistrationService', () => {
 
     expect(bridge.unregisterForPush).toHaveBeenCalledWith('bearer-abc');
     expect(bridge.registerForPush).toHaveBeenCalledTimes(2);
+  });
+
+  /**
+   * The tap is claimed destructively — native clears it with getAndSet(null) — so a failure
+   * anywhere after that point loses it for good. Marking read is housekeeping; routing the
+   * user to the print they tapped is the whole feature, and must not depend on the API leg.
+   */
+  it('still navigates when marking the notification read fails', async () => {
+    bridge.consumePendingTap.and.resolveTo({
+      notificationId: 'abc',
+      printId: 42,
+    });
+    notifications.markAsRead.and.returnValue(
+      throwError(() => new Error('offline'))
+    );
+
+    await service.handlePendingTap();
+
+    expect(router.navigate).toHaveBeenCalledWith(['/prints', 42]);
   });
 });

--- a/src/app/core/services/push-registration.service.ts
+++ b/src/app/core/services/push-registration.service.ts
@@ -57,7 +57,17 @@ export class PushRegistrationService {
       return;
     }
 
-    await firstValueFrom(this.notifications.markAsRead(tap.notificationId));
+    // Marking read must not gate navigation. Native claims the tap destructively
+    // (getAndSet(null)), so anything that throws after that point loses it permanently —
+    // and an offline device or a 5xx would strand the user on whatever page they were on,
+    // which is the failure this whole path exists to prevent. A stale unread badge is the
+    // cheaper wrong outcome.
+    try {
+      await firstValueFrom(this.notifications.markAsRead(tap.notificationId));
+    } catch {
+      // Deliberately swallowed; see above.
+    }
+
     await this.router.navigate(['/prints', tap.printId]);
   }
 }

--- a/src/app/core/types/native-bridge.ts
+++ b/src/app/core/types/native-bridge.ts
@@ -21,6 +21,15 @@ export interface PrintLogNativeBridge {
   registerForPush(bearerToken: string): Promise<{ ok: boolean }>;
   unregisterForPush(bearerToken: string): Promise<{ ok: boolean }>;
   consumePendingTap(): Promise<PendingTap | null>;
+
+  /**
+   * Register interest in taps that arrive after this page has loaded. Native calls the
+   * listener; the listener drains the tap with consumePendingTap. Cordova's `resume` event
+   * cannot be used for this — cordova.js is not present on this origin.
+   *
+   * Optional because an older app shell may not expose it yet.
+   */
+  onPendingTap?(listener: () => void): void;
 }
 
 declare global {

--- a/src/app/print/view-print-detail/view-print-detail.component.spec.ts
+++ b/src/app/print/view-print-detail/view-print-detail.component.spec.ts
@@ -28,6 +28,7 @@ import {
   PrintDetailLoaderService,
   PrintDetailWithUser,
 } from '../services/print-detail-loader.service';
+import { PushPermissionPromptService } from 'src/app/core/services/push-permission-prompt.service';
 import {
   DEFERRED_SKELETON_DELAY_MS,
   DEFERRED_SKELETON_MIN_VISIBLE_MS,
@@ -42,6 +43,8 @@ describe('ViewPrintDetailComponent', () => {
   let userSettingServiceSpy: jasmine.SpyObj<UserSettingService>;
 
   const OWNER_ID = 7;
+
+  let pushPromptSpy: jasmine.SpyObj<PushPermissionPromptService>;
 
   const basePrint = {
     id: 1,
@@ -152,6 +155,12 @@ describe('ViewPrintDetailComponent', () => {
     );
     loaderSpy.load.and.callFake(load);
 
+    pushPromptSpy = jasmine.createSpyObj<PushPermissionPromptService>(
+      'PushPermissionPromptService',
+      ['promptInContext']
+    );
+    pushPromptSpy.promptInContext.and.resolveTo('default');
+
     await TestBed.configureTestingModule({
       // No NO_ERRORS_SCHEMA: every child here is a real standalone component
       // pulled in through ViewPrintDetailComponent's own imports, so the schema
@@ -168,6 +177,7 @@ describe('ViewPrintDetailComponent', () => {
         provideHttpClientTesting(),
         { provide: PrintService, useValue: printService },
         { provide: PrintDetailLoaderService, useValue: loaderSpy },
+        { provide: PushPermissionPromptService, useValue: pushPromptSpy },
         // The real PrintCommentsComponent renders here (no NO_ERRORS_SCHEMA)
         // and injects ToastrService, which needs its own ToastConfig token.
         {
@@ -628,6 +638,53 @@ describe('ViewPrintDetailComponent', () => {
 
       expect(fixture.nativeElement.querySelector('.hero-band')).toBeTruthy();
       expect(component.currencySymbol()).toBe('$');
+    });
+  });
+
+  /**
+   * The only in-context trigger before this was creating an API key, which no existing user
+   * hits again — their keys predate push entirely, so Settings was their only route to
+   * enabling notifications. A running print is the moment the value needs no explaining,
+   * and every active user reaches it.
+   */
+  describe('notification prompt', () => {
+    const runningPrint = { ...basePrint, status: PrintStatus.Printing };
+
+    it('prompts the owner while their print is still running', async () => {
+      await setup({ viewerId: OWNER_ID, print: runningPrint });
+
+      expect(pushPromptSpy.promptInContext).toHaveBeenCalled();
+    });
+
+    it('does not prompt once the print has finished', async () => {
+      await setup({ viewerId: OWNER_ID, print: basePrint });
+
+      expect(pushPromptSpy.promptInContext).not.toHaveBeenCalled();
+    });
+
+    /** A stranger cannot be notified about someone else's print, so asking is nonsense. */
+    it('does not prompt a signed-in stranger', async () => {
+      await setup({ viewerId: 999, print: runningPrint });
+
+      expect(pushPromptSpy.promptInContext).not.toHaveBeenCalled();
+    });
+
+    it('does not prompt an anonymous visitor', async () => {
+      await setup({ viewerId: null, print: runningPrint });
+
+      expect(pushPromptSpy.promptInContext).not.toHaveBeenCalled();
+    });
+
+    /**
+     * The effect re-runs on signal changes and the router reuses this component between
+     * print ids, so without a latch a single visit could ask more than once.
+     */
+    it('prompts only once for a given view', async () => {
+      await setup({ viewerId: OWNER_ID, print: runningPrint });
+      fixture.detectChanges();
+      fixture.detectChanges();
+
+      expect(pushPromptSpy.promptInContext).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/app/print/view-print-detail/view-print-detail.component.spec.ts
+++ b/src/app/print/view-print-detail/view-print-detail.component.spec.ts
@@ -28,7 +28,10 @@ import {
   PrintDetailLoaderService,
   PrintDetailWithUser,
 } from '../services/print-detail-loader.service';
-import { PushPermissionPromptService } from 'src/app/core/services/push-permission-prompt.service';
+import {
+  PushPermissionPromptService,
+  PushPromptResult,
+} from 'src/app/core/services/push-permission-prompt.service';
 import {
   DEFERRED_SKELETON_DELAY_MS,
   DEFERRED_SKELETON_MIN_VISIBLE_MS,
@@ -45,6 +48,7 @@ describe('ViewPrintDetailComponent', () => {
   const OWNER_ID = 7;
 
   let pushPromptSpy: jasmine.SpyObj<PushPermissionPromptService>;
+  let nextPromptResult: PushPromptResult;
 
   const basePrint = {
     id: 1,
@@ -159,7 +163,14 @@ describe('ViewPrintDetailComponent', () => {
       'PushPermissionPromptService',
       ['promptInContext']
     );
-    pushPromptSpy.promptInContext.and.resolveTo('default');
+    // Only a default: a test that set its own outcome before calling setup keeps it.
+    nextPromptResult ??= { permission: 'default', outcome: 'shown' };
+    // callFake over resolveTo: setup() recreates this spy, so a test that configured a
+    // result beforehand would have it silently discarded. Reading a mutable value keeps the
+    // test's choice in force.
+    pushPromptSpy.promptInContext.and.callFake(() =>
+      Promise.resolve(nextPromptResult)
+    );
 
     await TestBed.configureTestingModule({
       // No NO_ERRORS_SCHEMA: every child here is a real standalone component
@@ -650,6 +661,14 @@ describe('ViewPrintDetailComponent', () => {
   describe('notification prompt', () => {
     const runningPrint = { ...basePrint, status: PrintStatus.Printing };
 
+    beforeEach(() => {
+      nextPromptResult = { permission: 'default', outcome: 'shown' };
+    });
+
+    afterEach(() => {
+      nextPromptResult = undefined as unknown as PushPromptResult;
+    });
+
     it('prompts the owner while their print is still running', async () => {
       await setup({ viewerId: OWNER_ID, print: runningPrint });
 
@@ -676,15 +695,104 @@ describe('ViewPrintDetailComponent', () => {
     });
 
     /**
-     * The effect re-runs on signal changes and the router reuses this component between
-     * print ids, so without a latch a single visit could ask more than once.
+     * Drives two emissions through the SAME component instance, which is what the router
+     * actually does between /prints/:id routes. An earlier version of this test called
+     * detectChanges() twice instead — effects do not re-run for a bare change-detection
+     * pass, so it passed with the latch deleted entirely and constrained nothing.
      */
-    it('prompts only once for a given view', async () => {
-      await setup({ viewerId: OWNER_ID, print: runningPrint });
+    it('does not prompt twice for the same print', async () => {
+      const paramMap$ = new BehaviorSubject(paramMapFor(1));
+      await setup({ viewerId: OWNER_ID, print: runningPrint, paramMap$ });
+
+      paramMap$.next(paramMapFor(1));
       fixture.detectChanges();
-      fixture.detectChanges();
+      await fixture.whenStable();
 
       expect(pushPromptSpy.promptInContext).toHaveBeenCalledTimes(1);
+    });
+
+    it('prompts again for a different running print in the same component', async () => {
+      const paramMap$ = new BehaviorSubject(paramMapFor(1));
+      await setup({
+        viewerId: OWNER_ID,
+        paramMap$,
+        load: (printId: number) =>
+          of({
+            print: { ...runningPrint, id: printId },
+            user: { id: OWNER_ID } as any,
+          } as PrintDetailWithUser),
+      });
+
+      paramMap$.next(paramMapFor(2));
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(pushPromptSpy.promptInContext).toHaveBeenCalledTimes(2);
+    });
+
+    /**
+     * The app shell injects its bridge on page load, which can land after Angular has
+     * bootstrapped, so "unavailable" means not yet rather than no. Coming back to the same
+     * print must therefore offer again — with the id recorded regardless, that print would
+     * be silently skipped for the rest of the session.
+     *
+     * Note this is retry-on-revisit, not spontaneous retry: bridge readiness is not a
+     * signal, so nothing re-runs the effect on its own.
+     */
+    it('offers again on returning to a print whose offer found no bridge', async () => {
+      nextPromptResult = { permission: 'default', outcome: 'unavailable' };
+
+      const loadedIds: number[] = [];
+      const paramMap$ = new BehaviorSubject(paramMapFor(1));
+      await setup({
+        viewerId: OWNER_ID,
+        paramMap$,
+        load: (printId: number) =>
+          of(loadedIds.push(printId)) &&
+          of({
+            print: { ...runningPrint, id: printId },
+            user: { id: OWNER_ID } as any,
+          } as PrintDetailWithUser),
+      });
+      await fixture.whenStable();
+
+      paramMap$.next(paramMapFor(2));
+      fixture.detectChanges();
+      await fixture.whenStable();
+      await Promise.resolve();
+
+      paramMap$.next(paramMapFor(1));
+      fixture.detectChanges();
+      await fixture.whenStable();
+      await Promise.resolve();
+
+      expect(loadedIds).toEqual([1, 2, 1]);
+      expect(pushPromptSpy.promptInContext).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not offer again on returning to a print already offered for', async () => {
+      const paramMap$ = new BehaviorSubject(paramMapFor(1));
+      await setup({
+        viewerId: OWNER_ID,
+        paramMap$,
+        load: (printId: number) =>
+          of({
+            print: { ...runningPrint, id: printId },
+            user: { id: OWNER_ID } as any,
+          } as PrintDetailWithUser),
+      });
+      await fixture.whenStable();
+
+      paramMap$.next(paramMapFor(2));
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      paramMap$.next(paramMapFor(1));
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      // Two prints, two offers — returning to the first must not produce a third.
+      expect(pushPromptSpy.promptInContext).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/src/app/print/view-print-detail/view-print-detail.component.ts
+++ b/src/app/print/view-print-detail/view-print-detail.component.ts
@@ -26,7 +26,9 @@ import {
   PrintDetail,
   PrintFilamentSourceMeasurement,
   PrintService,
+  PrintStatus,
 } from '../../core/services/print.service';
+import { PushPermissionPromptService } from 'src/app/core/services/push-permission-prompt.service';
 import {
   UserSettingService,
   UserSettingType,
@@ -96,6 +98,7 @@ export class ViewPrintDetailComponent {
   private readonly document = inject(DOCUMENT);
   private readonly location = inject(Location);
   private readonly userSettingService = inject(UserSettingService);
+  private readonly pushPermissionPrompt = inject(PushPermissionPromptService);
   private readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
 
   /**
@@ -267,6 +270,9 @@ export class ViewPrintDetailComponent {
    * at construction time it refers to the navigation before this one, which
    * makes `.previousNavigation` off by one.
    */
+  /** One offer per view; see offerNotificationsForRunningPrint. */
+  private offeredNotifications = false;
+
   private readonly arrivedFromInAppNavigation =
     this.router.getCurrentNavigation()?.previousNavigation != null;
 
@@ -283,6 +289,37 @@ export class ViewPrintDetailComponent {
     // users are not stranded on <body> after a route change. The container is
     // the skeleton shell too, so this no longer waits on the fetch.
     afterNextRender(() => this.pageRoot()?.nativeElement?.focus());
+
+    effect(() => this.offerNotificationsForRunningPrint());
+  }
+
+  /**
+   * Offers notifications while the user's own print is still running.
+   *
+   * This is the moment the feature explains itself: something is underway that they would
+   * rather be told about than keep checking. Creating an API key used to be the only
+   * in-context trigger, which no established user ever hits again — their keys predate push
+   * — leaving Settings as the sole route to enabling it.
+   *
+   * Owner-only: a visitor cannot be notified about someone else's print. The service itself
+   * is a no-op on the web, when permission is already granted, and while a recent "Not now"
+   * still stands, so no platform branching is needed here.
+   */
+  private offerNotificationsForRunningPrint(): void {
+    if (this.offeredNotifications || !this.isOwner()) {
+      return;
+    }
+
+    if (this.print()?.status !== PrintStatus.Printing) {
+      return;
+    }
+
+    // Latched before the call, not after: the effect re-runs on any signal it reads, and
+    // awaiting first would let a second run start while the dialog is still opening.
+    this.offeredNotifications = true;
+    void this.pushPermissionPrompt.promptInContext(
+      'This print is still running.'
+    );
   }
 
   private loadSettings(): void {

--- a/src/app/print/view-print-detail/view-print-detail.component.ts
+++ b/src/app/print/view-print-detail/view-print-detail.component.ts
@@ -270,8 +270,12 @@ export class ViewPrintDetailComponent {
    * at construction time it refers to the navigation before this one, which
    * makes `.previousNavigation` off by one.
    */
-  /** One offer per view; see offerNotificationsForRunningPrint. */
-  private offeredNotifications = false;
+  /**
+   * Prints an offer has already been made for. A set rather than a single id because the
+   * router reuses this component: navigating away and back would otherwise re-offer, and a
+   * bare boolean would suppress every later print in the session.
+   */
+  private readonly offeredForPrintIds = new Set<number>();
 
   private readonly arrivedFromInAppNavigation =
     this.router.getCurrentNavigation()?.previousNavigation != null;
@@ -306,20 +310,37 @@ export class ViewPrintDetailComponent {
    * still stands, so no platform branching is needed here.
    */
   private offerNotificationsForRunningPrint(): void {
-    if (this.offeredNotifications || !this.isOwner()) {
+    // Every signal this effect depends on is read BEFORE any early return. Bailing out
+    // first would leave the effect with no tracked dependencies at all, and Angular would
+    // never run it again — so a later print, or ownership resolving, would go unnoticed.
+    const print = this.print();
+    const isOwner = this.isOwner();
+
+    if (!print || !isOwner || print.status !== PrintStatus.Printing) {
       return;
     }
 
-    if (this.print()?.status !== PrintStatus.Printing) {
+    // Keyed by print id rather than a bare flag: the router reuses this component between
+    // /prints/:id routes, so a boolean would silently suppress the offer for every later
+    // print in the session.
+    if (this.offeredForPrintIds.has(print.id)) {
       return;
     }
 
-    // Latched before the call, not after: the effect re-runs on any signal it reads, and
-    // awaiting first would let a second run start while the dialog is still opening.
-    this.offeredNotifications = true;
-    void this.pushPermissionPrompt.promptInContext(
-      'This print is still running.'
-    );
+    // Recorded before awaiting, so a re-run cannot open a second dialog while this one is
+    // still opening. Taken back if nothing was actually offered.
+    this.offeredForPrintIds.add(print.id);
+
+    void this.pushPermissionPrompt
+      .promptInContext('This print is still running.')
+      .then((result) => {
+        // The native bridge is injected on page load and can arrive after Angular has
+        // bootstrapped, so "unavailable" means not yet, not no. Keeping the id would
+        // silently cost this print its offer for the rest of the session.
+        if (result.outcome === 'unavailable') {
+          this.offeredForPrintIds.delete(print.id);
+        }
+      });
   }
 
   private loadSettings(): void {

--- a/src/app/settings/settings.component.spec.ts
+++ b/src/app/settings/settings.component.spec.ts
@@ -139,9 +139,16 @@ describe('SettingsComponent', () => {
     mockPushPermissionPrompt =
       jasmine.createSpyObj<PushPermissionPromptService>(
         'PushPermissionPromptService',
-        ['promptInContext']
+        ['promptInContext', 'promptOnUserRequest']
       );
-    mockPushPermissionPrompt.promptInContext.and.resolveTo('granted');
+    mockPushPermissionPrompt.promptInContext.and.resolveTo({
+      permission: 'granted',
+      outcome: 'shown',
+    });
+    mockPushPermissionPrompt.promptOnUserRequest.and.resolveTo({
+      permission: 'granted',
+      outcome: 'shown',
+    });
 
     TestBed.configureTestingModule({
       declarations: [SettingsComponent],
@@ -352,7 +359,7 @@ describe('SettingsComponent', () => {
       await component.onEnableNotificationsClicked();
       await fixture.whenStable();
 
-      expect(mockPushPermissionPrompt.promptInContext).toHaveBeenCalled();
+      expect(mockPushPermissionPrompt.promptOnUserRequest).toHaveBeenCalled();
       // Asserted on the field, not the DOM: re-running change detection after this
       // async state change trips NG0100 in the harness. That the field drives the
       // warning's visibility is covered by the granted/denied/default render tests above.

--- a/src/app/settings/settings.component.ts
+++ b/src/app/settings/settings.component.ts
@@ -151,10 +151,13 @@ export class SettingsComponent implements OnInit {
   }
 
   async onEnableNotificationsClicked(): Promise<void> {
-    const permission = await this.pushPermissionPrompt.promptInContext(
+    // promptOnUserRequest, not promptInContext: the in-context cooldown must not apply to a
+    // button the user deliberately pressed. This is the documented second chance, and
+    // suppressing it would strand anyone who tapped "Not now" and changed their mind.
+    const result = await this.pushPermissionPrompt.promptOnUserRequest(
       'Notifications are turned off for 3D Print Log on this device.'
     );
-    this.pushPermissionGranted = permission === 'granted';
+    this.pushPermissionGranted = result.permission === 'granted';
   }
 
   // One handler per toggle, with the type passed explicitly: a shared handler would have to


### PR DESCRIPTION
Web half of the notification-tap fix. Pairs with HoffmanEngineering/3d-print-log-app#14 — **both must ship for a warm-start tap to work.**

## The bug

Tapping a push notification opened the app but left you on whatever page you were already on.

`AppComponent` drained the pending tap by listening for Cordova's `resume` event:

```ts
document.addEventListener('resume', () => { void this.pushRegistration.handlePendingTap(); });
```

`resume` is fired by `cordova.js`. The Cordova shell loads that only on its local bootstrap page — once the WebView navigates to this origin it is gone, so the listener can never fire here. Every tap that arrived while the app was already running was silently dropped.

## The fix

The app shell now signals the page directly (`window.PrintLogNative.signalPendingTap()`). We subscribe through `NativeBridgeService.onPendingTap`, which returns whether native actually accepted the listener — so "wired up" is distinguishable from "silently never fires", which is precisely the failure mode being replaced. `onPendingTap` is optional on the bridge type, so an older app shell degrades instead of breaking.

The listener is a signal, not a delivery: it calls `consumePendingTap` itself, keeping the tap claimed exactly once through the single native path that clears it.

## On the tests

The old spec dispatched a synthetic `resume` event and asserted `handlePendingTap` was called. It passed for the entire life of the bug, because it simulated an event that cannot occur in production. It is replaced with tests against the real contract, plus a regression test asserting `resume` is **not** listened for.

`ng test`: 1358 passing, 0 failures.

## Verification

The native half is confirmed on a Pixel 7: a cold-start tap now opens the print detail page. The warm-start path — the one this PR fixes — is unit-tested on both sides but cannot be verified on device until this deploys, since the live bundle has no listener to signal.