### PR TITLE
feat: bump version to 1.49.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "print-log-ui",
-  "version": "1.49.0",
+  "version": "1.49.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve --ssl --host 0.0.0.0 ",

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -28,6 +28,9 @@ export class VersionReleaseNoteDialogService {
   private readonly LOCAL_STORAGE_KEY = 'LastLoggedInVersion';
 
   private releaseNotes: ReleaseNoteHistory = {
+    '1.49.1': {
+      redirect: '1.49.0',
+    },
     '1.49.0': {
       title: '1.49.0 - Push Notifications',
       body: `<p>

--- a/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
+++ b/src/app/documentation/docs/docs-release-notes/docs-release-notes.component.html
@@ -2,6 +2,65 @@
   <h2>Release Notes</h2>
   <hr />
 
+  <h3 id="v1.49.1">1.49.1 - Push Notification Fixes</h3>
+  <p>
+    Follow-up fixes to the push notifications that shipped in 1.49.0. Tapping a
+    notification now opens the print it is about, instead of just opening the app
+    to whatever page you were last on. Turning notifications on from
+    <a routerLink="/settings">Settings</a> works on the first tap (it previously
+    took two, even though the first one had already been granted). Notification
+    timestamps are also correct now: the notification tray no longer shows a print
+    as finishing years ago, and times in the app are no longer shifted by your time
+    zone.
+  </p>
+  <h4>Full List of Changes:</h4>
+  <ul>
+    <li>
+      <strong>Tapping a notification opens the print</strong> - a tapped print
+      notification now navigates to that print, whether the app was closed or
+      already open, and still does so when the device is offline (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/154"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #154</a
+      >, <a
+        href="https://github.com/HoffmanEngineering/3d-print-log-app/pull/14"
+        rel="noreferrer noopener"
+        target="_blank"
+        >Android app PR #14</a
+      >)
+    </li>
+    <li>
+      <strong>Enabling notifications works on the first tap</strong> - Settings no
+      longer reports notifications as off after you have just allowed them (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-app/pull/14"
+        rel="noreferrer noopener"
+        target="_blank"
+        >Android app PR #14</a
+      >)
+    </li>
+    <li>
+      <strong>Notifications are offered while a print is running</strong> - opening
+      one of your own in-progress prints now offers to enable notifications, rather
+      than leaving Settings as the only way to find the option (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-ui/pull/154"
+        rel="noreferrer noopener"
+        target="_blank"
+        >PR #154</a
+      >)
+    </li>
+    <li>
+      <strong>Notification timestamps are correct</strong> - the notification tray
+      no longer shows a just-finished print as years old, and notification times in
+      the app are no longer offset by your time zone (<a
+        href="https://github.com/HoffmanEngineering/3d-print-log-api/pull/108"
+        rel="noreferrer noopener"
+        target="_blank"
+        >API PR #108</a
+      >)
+    </li>
+  </ul>
+
   <h3 id="v1.49.0">1.49.0 - Push Notifications</h3>
   <p>
     <strong>Push notifications</strong> have arrived. If you send print events to


### PR DESCRIPTION
Patch release covering the push notification fixes from #154, #157, the Android app's #14, and the API's #108.

## Release body preview

This is what the GitHub Release will say, rendered with the same command the deploy workflow runs (`node scripts/extract-release-notes.mjs v1.49.1`):

> Follow-up fixes to the push notifications that shipped in 1.49.0. Tapping a notification now opens the print it is about, instead of just opening the app to whatever page you were last on. Turning notifications on from Settings works on the first tap (it previously took two, even though the first one had already been granted). Notification timestamps are also correct now: the notification tray no longer shows a print as finishing years ago, and times in the app are no longer shifted by your time zone.

Four bullets follow it, each linked to the PR that delivered it.

## Attribution note

Two of the four fixes were delivered by the **Android app** repo, not this one, so those bullets link `3d-print-log-app#14` rather than `#154`. The first-tap enable fix in particular was entirely app-side (the native bridge was reporting a permission result before Android had answered), even though the symptom appeared in this repo's Settings page and was originally filed here as #153. Linking #154 for it would have pointed users at a change that does not contain the fix.

The timestamp bullet links the API PR, since that fix is entirely server-side and is already deployed as API v1.10.1.

## Dialog

Patch release, so `version-release-note-dialog.service.ts` gets a redirect entry only (`1.49.1 -> 1.49.0`), keeping the step-down chain unbroken. No dialog notes, as this is a fix-up of the release immediately before it.

## Checks

- `npm run test:scripts`: 85 passing, which includes the release-notes converter test that fails on any unrendered HTML in this file
- Release body and title both render with no stray tags; the `routerLink` to Settings resolved to an absolute URL
- Both linked PRs confirmed `MERGED` before linking
- `docs-release-notes.component.html` diff is 59 additions and 0 deletions, so the pre-existing formatting drift in that file was not disturbed

## After merge

Push `v1.49.1` to build, wait for approval on the `production` environment, then deploy and publish the GitHub Release automatically from the notes above.