### PR TITLE
feat(docs): client-side search over /docs

### DIFF
--- a/cypress/e2e/documentation/docs-search.cy.ts
+++ b/cypress/e2e/documentation/docs-search.cy.ts
@@ -1,0 +1,142 @@
+// End-to-end coverage for the /docs search palette.
+//
+// These deliberately cover the things the unit tests CANNOT reach:
+//
+//   - Real focus. The dialog spec can only assert the `autoFocus` value passed
+//     to MatDialog; whether the caret actually lands in the input depends on
+//     CDK's focus trap running in a real browser. That distinction is the whole
+//     bug `autoFocus: false` caused, so it is worth a browser to prove.
+//   - Real scrolling. MatDialog pins `html` while it is open and RESTORES the
+//     scroll position when it closes, which is why navigation is deferred until
+//     afterClosed(). Nothing in jsdom or a component fixture models that.
+//   - The real index through the real engine. A unit test mocks
+//     DocsSearchService, so nothing there proves the generated JSON, MiniSearch
+//     and the emit pipeline agree with one another.
+//
+// /docs is public, so none of this calls cy.login() and none of it needs the
+// API — the pages are prerendered and the index is a static import.
+
+// Ctrl+K, with the modifier RELEASED. `release: false` would leave Ctrl held
+// for the rest of the test, turning the next `.type('material')` into a string
+// of chords that never reach the input.
+const openWithShortcut = () => cy.get('body').type('{ctrl}k');
+
+describe('Documentation search', () => {
+  beforeEach(() => {
+    cy.visit('/docs/getting-started?devUserId=anonymous');
+
+    // /docs is a lazy chunk, and the keyboard shortcut is a host listener on a
+    // component inside it. Typing before it has rendered sends the chord into a
+    // page that is not listening yet, which fails as "the palette never opened"
+    // and sends you looking in the wrong place entirely.
+    cy.get('[data-cy=docs-search-button]', { timeout: 20000 }).should(
+      'be.visible'
+    );
+  });
+
+  it('puts the caret in the search box when opened with the keyboard', () => {
+    // The regression that motivated this file: `autoFocus: false` left focus on
+    // the dialog panel, so Ctrl+K opened a palette you could not type into.
+    openWithShortcut();
+
+    cy.get('[data-cy=docs-search-input]')
+      .should('be.visible')
+      .and('have.focus');
+  });
+
+  it('puts the caret in the search box when opened with the toolbar button', () => {
+    cy.get('[data-cy=docs-search-button]').click();
+
+    cy.get('[data-cy=docs-search-input]')
+      .should('be.visible')
+      .and('have.focus');
+  });
+
+  it('finds a section and deep-links to its heading', () => {
+    openWithShortcut();
+    cy.get('[data-cy=docs-search-input]').type('material');
+
+    cy.get('[data-cy=docs-search-result]').should('have.length.greaterThan', 0);
+    cy.get('[data-cy=docs-search-result]').first().click();
+
+    // The fragment survives the close, and the anchor it names is actually on
+    // the page it landed on.
+    cy.location('hash').should('not.be.empty');
+    cy.location('hash').then((hash) => {
+      cy.get(hash).should('exist');
+    });
+  });
+
+  it('scrolls to the section rather than the top of the page', () => {
+    // MatDialog restores the scroll position as it closes, so a navigation
+    // issued before then is scrolled correctly and then silently undone. This
+    // is the assertion that would have caught that.
+    openWithShortcut();
+    cy.get('[data-cy=docs-search-input]').type('material');
+
+    // A result that names an anchor; a page-level hit has nothing to scroll to.
+    cy.get('[data-cy=docs-search-result]').first().click();
+    cy.location('hash').should('not.be.empty');
+
+    cy.window().its('scrollY').should('be.greaterThan', 0);
+  });
+
+  it('searches the code samples on the integration pages', () => {
+    // Proves the generated index, MiniSearch and the emit pipeline agree: this
+    // flag lives inside a <pre> whose content is an interpolated constant, so
+    // it only matches if both the code indexing and the binding resolution
+    // survived the whole build.
+    openWithShortcut();
+    cy.get('[data-cy=docs-search-input]').type('callback-port');
+
+    cy.get('[data-cy=docs-search-result]')
+      .should('have.length.greaterThan', 0)
+      .first()
+      .should('contain.text', 'Connect an AI Assistant');
+  });
+
+  it('opens the highlighted result with the arrow keys and Enter', () => {
+    openWithShortcut();
+    cy.get('[data-cy=docs-search-input]').type('material');
+    cy.get('[data-cy=docs-search-result]').should('have.length.greaterThan', 1);
+
+    // Focus never leaves the input: selection is conveyed by
+    // aria-activedescendant, which is what the arrow keys drive.
+    cy.get('[data-cy=docs-search-input]')
+      .type('{downarrow}')
+      .should('have.attr', 'aria-activedescendant', 'docs-search-result-1');
+
+    cy.get('[data-cy=docs-search-input]').type('{enter}');
+
+    cy.location('pathname').should('include', '/docs/');
+    cy.get('[data-cy=docs-search-input]').should('not.exist');
+  });
+
+  it('offers feedback when nothing matched', () => {
+    openWithShortcut();
+    cy.get('[data-cy=docs-search-input]').type('zzzznotathinginthedocs');
+
+    cy.get('[data-cy=docs-search-empty]').should('be.visible');
+    cy.get('[data-cy=docs-search-result]').should('not.exist');
+  });
+
+  it('closes on Escape without navigating', () => {
+    cy.location('pathname').then((before) => {
+      openWithShortcut();
+      cy.get('[data-cy=docs-search-input]').should('be.visible').type('{esc}');
+
+      cy.get('[data-cy=docs-search-input]').should('not.exist');
+      cy.location('pathname').should('eq', before);
+    });
+  });
+
+  it('does not stack a second palette when opened twice', () => {
+    // Three entry points share one dialog ref precisely so this cannot happen.
+    openWithShortcut();
+    cy.get('[data-cy=docs-search-input]').should('be.visible');
+
+    openWithShortcut();
+
+    cy.get('[data-cy=docs-search-input]').should('have.length', 1);
+  });
+});

--- a/cypress/e2e/documentation/docs-search.cy.ts
+++ b/cypress/e2e/documentation/docs-search.cy.ts
@@ -52,33 +52,55 @@ describe('Documentation search', () => {
       .and('have.focus');
   });
 
-  it('finds a section and deep-links to its heading', () => {
+  it('finds a section and deep-links to the heading that result named', () => {
     openWithShortcut();
     cy.get('[data-cy=docs-search-input]').type('material');
-
     cy.get('[data-cy=docs-search-result]').should('have.length.greaterThan', 0);
-    cy.get('[data-cy=docs-search-result]').first().click();
 
-    // The fragment survives the close, and the anchor it names is actually on
-    // the page it landed on.
-    cy.location('hash').should('not.be.empty');
-    cy.location('hash').then((hash) => {
-      cy.get(hash).should('exist');
-    });
+    // The result's own title is read out of the DOM rather than hard-coded, so
+    // this stays honest as the docs change: it proves the destination matches
+    // WHICHEVER result was clicked, instead of pinning a ranking that a future
+    // edit can reshuffle.
+    cy.get('[data-cy=docs-search-result]')
+      .first()
+      .find('.docs-search__result-title')
+      .invoke('text')
+      .then((title) => {
+        const heading = title.trim();
+        cy.get('[data-cy=docs-search-result]').first().click();
+
+        cy.location('hash').should('not.be.empty');
+        cy.location('hash').then((hash) => {
+          // The anchor exists, is on screen, and is the heading the result
+          // advertised — not merely some element carrying that id.
+          cy.get(hash).should('be.visible').and('contain.text', heading);
+        });
+      });
   });
 
-  it('scrolls to the section rather than the top of the page', () => {
+  it('scrolls the section into view rather than landing at the top', () => {
     // MatDialog restores the scroll position as it closes, so a navigation
-    // issued before then is scrolled correctly and then silently undone. This
-    // is the assertion that would have caught that.
+    // issued before then is scrolled correctly and then silently undone.
+    //
+    // Asserted on the TARGET's position, not on a scroll offset: the docs
+    // scroll `mat-sidenav-content` on desktop and the document on mobile
+    // (documentation.component.ts), so `window.scrollY` answers the wrong
+    // question on one of the two layouts. Where the heading ended up on screen
+    // is the thing that actually matters, and it is layout-independent.
     openWithShortcut();
     cy.get('[data-cy=docs-search-input]').type('material');
-
-    // A result that names an anchor; a page-level hit has nothing to scroll to.
     cy.get('[data-cy=docs-search-result]').first().click();
-    cy.location('hash').should('not.be.empty');
 
-    cy.window().its('scrollY').should('be.greaterThan', 0);
+    cy.location('hash').should('not.be.empty');
+    cy.location('hash').then((hash) => {
+      cy.get(hash).then(($el) => {
+        const top = $el[0].getBoundingClientRect().top;
+        expect(top, 'heading is inside the viewport').to.be.within(
+          0,
+          Cypress.config('viewportHeight')
+        );
+      });
+    });
   });
 
   it('searches the code samples on the integration pages', () => {
@@ -106,10 +128,23 @@ describe('Documentation search', () => {
       .type('{downarrow}')
       .should('have.attr', 'aria-activedescendant', 'docs-search-result-1');
 
-    cy.get('[data-cy=docs-search-input]').type('{enter}');
+    // Captured BEFORE Enter. Asserting `pathname` contains '/docs/' afterwards
+    // was already true of the starting page, so removing the navigation
+    // entirely still passed — the test proved only that Enter closed the
+    // dialog. Verified by mutation: dropping navigateByUrl now fails here.
+    cy.get('#docs-search-result-1 .docs-search__result-title')
+      .invoke('text')
+      .then((title) => {
+        const chosen = title.trim();
 
-    cy.location('pathname').should('include', '/docs/');
-    cy.get('[data-cy=docs-search-input]').should('not.exist');
+        cy.location('href').then((before) => {
+          cy.get('[data-cy=docs-search-input]').type('{enter}');
+
+          cy.get('[data-cy=docs-search-input]').should('not.exist');
+          cy.location('href').should('not.eq', before);
+          cy.contains(chosen).should('be.visible');
+        });
+      });
   });
 
   it('offers feedback when nothing matched', () => {
@@ -121,13 +156,52 @@ describe('Documentation search', () => {
   });
 
   it('closes on Escape without navigating', () => {
-    cy.location('pathname').then((before) => {
+    // The whole href, not just the pathname: closing must not leave a fragment
+    // or a query behind either, and a pathname comparison would not notice.
+    cy.location('href').then((before) => {
       openWithShortcut();
       cy.get('[data-cy=docs-search-input]').should('be.visible').type('{esc}');
 
       cy.get('[data-cy=docs-search-input]').should('not.exist');
-      cy.location('pathname').should('eq', before);
+      cy.location('href').should('eq', before);
     });
+  });
+
+  it('opens from the sidebar box as well as the toolbar', () => {
+    // The third entry point. It had a test hook and no test, which is the
+    // shape of a gap that stays invisible until the entry point breaks.
+    cy.get('[data-cy=docs-sidebar-search]').click();
+
+    cy.get('[data-cy=docs-search-input]')
+      .should('be.visible')
+      .and('have.focus');
+  });
+
+  it('can be closed and opened again', () => {
+    // DocsSearchOpener holds ONE ref and clears it from afterClosed(). If that
+    // teardown regressed, the second open would find a stale ref and do
+    // nothing at all — and every other test here opens the palette exactly
+    // once, so none of them would notice.
+    openWithShortcut();
+    cy.get('[data-cy=docs-search-input]').should('be.visible').type('{esc}');
+    cy.get('[data-cy=docs-search-input]').should('not.exist');
+
+    openWithShortcut();
+
+    cy.get('[data-cy=docs-search-input]')
+      .should('be.visible')
+      .and('have.focus');
+  });
+
+  it('has no accessibility violations while open', () => {
+    // The palette drives selection through aria-activedescendant against a
+    // listbox whose options are deliberately not focusable, which is the kind
+    // of hand-rolled ARIA that is easy to get subtly wrong.
+    openWithShortcut();
+    cy.get('[data-cy=docs-search-input]').type('material');
+    cy.get('[data-cy=docs-search-result]').should('have.length.greaterThan', 0);
+
+    cy.checkA11yWithReport('.docs-search');
   });
 
   it('does not stack a second palette when opened twice', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "print-log-ui",
-  "version": "1.47.0",
+  "version": "1.49.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "print-log-ui",
-      "version": "1.47.0",
+      "version": "1.49.1",
       "dependencies": {
         "@angular/animations": "^21.2.12",
         "@angular/cdk": "^21.2.10",
@@ -33,6 +33,7 @@
         "d3": "^7.9.0",
         "html5-qrcode": "^2.3.8",
         "lodash-es": "^4.18.1",
+        "minisearch": "^7.2.0",
         "ng2-adsense": "^13.0.0",
         "ngx-toastr": "^19.1.0",
         "parse-duration": "^1.1.2",
@@ -14688,6 +14689,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg=="
     },
     "node_modules/minizlib": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "d3": "^7.9.0",
     "html5-qrcode": "^2.3.8",
     "lodash-es": "^4.18.1",
+    "minisearch": "^7.2.0",
     "ng2-adsense": "^13.0.0",
     "ngx-toastr": "^19.1.0",
     "parse-duration": "^1.1.2",

--- a/scripts/docs-build-lib.test.mjs
+++ b/scripts/docs-build-lib.test.mjs
@@ -362,13 +362,17 @@ test('indexes the whole release history for search, not just the page', () => {
     readDocSources(withSources({ 'release-notes.md': RELEASE_PAGE })),
     releases(12)
   );
-  const [entry] = JSON.parse(files.get('docs-search-index.json')).filter(
+  const sections = JSON.parse(files.get('docs-search-index.json')).filter(
     (row) => row.path === 'docs/release-notes'
   );
 
-  // A reader searching for a two-year-old release should still find it; the
-  // component expands the archive to reach the anchor it lands on.
-  assert.match(entry.text, /What changed in 1\.2\.0\./);
+  // A reader searching for a two-year-old release should still find it, and land
+  // on that release rather than the top of the changelog; the component expands
+  // the archive to reach the anchor.
+  const archived = sections.find((row) => row.url.endsWith('#v1.2.0'));
+
+  assert.ok(archived, 'the archived release has no section of its own');
+  assert.match(archived.text, /What changed in 1\.2\.0\./);
 });
 
 test('leaves a page that is not the release index alone', () => {

--- a/scripts/docs-emit.mjs
+++ b/scripts/docs-emit.mjs
@@ -211,11 +211,15 @@ const SECTION_HEADING = /<h([1-3])([^>]*)>([\s\S]*?)<\/h\1\s*>/g;
  * Splits one rendered page into searchable sections.
  *
  * @param {string} template
- * @param {{ path: string, navLabel: string, group: string }} page
+ * @param {{ path: string, navLabel: string, group: string,
+ *   constants?: Record<string, string> }} page
  * @returns {object[]}
  */
 export function sectionsOf(template, page) {
-  const source = stripComments(template);
+  // Before `plainText`, which decodes `&#123;`/`&#125;` — the escapes an author
+  // writes to SHOW a brace. Resolving after that step would treat those as
+  // bindings and substitute into text that deliberately escaped itself.
+  const source = resolveBindings(stripComments(template), page.constants);
 
   const headings = [];
   for (const match of source.matchAll(SECTION_HEADING)) {
@@ -234,7 +238,8 @@ export function sectionsOf(template, page) {
   // with the nav label rather than left blank, so a hit there still names
   // something the reader recognises from the sidebar.
   const lead = plainText(
-    source.slice(0, headings.length ? headings[0].at : source.length)
+    source.slice(0, headings.length ? headings[0].at : source.length),
+    { keepCode: true }
   );
   if (lead) {
     sections.push({ title: page.navLabel, anchor: null, text: lead });
@@ -248,7 +253,7 @@ export function sectionsOf(template, page) {
     sections.push({
       title: heading.title,
       anchor: heading.anchor,
-      text: plainText(body),
+      text: plainText(body, { keepCode: true }),
     });
   });
 
@@ -302,6 +307,70 @@ function stripComments(template) {
   return template.replace(/<!--[\s\S]*?-->/g, ' ');
 }
 
+/**
+ * An interpolated string literal, e.g. `{{' ...text... '}}`.
+ *
+ * Authors wrap a sample in one when the sample itself contains braces — the
+ * Moonraker config on the Klipper page is Jinja, so `{% set %}` would otherwise
+ * be parsed as Angular syntax. The reader sees the literal, so the index takes
+ * the literal and drops the wrapper.
+ */
+const STRING_BINDING = /\{\{\s*(['"])([\s\S]*?)\1\s*\}\}/g;
+
+/** An Angular binding to a single frontmatter constant, e.g. `{{ mcpEndpoint }}`. */
+const CONSTANT_BINDING = /\{\{\s*([A-Za-z_$][\w$]*)\s*\}\}/g;
+
+/** A constant referring to a sibling, e.g. `${this.mcpEndpoint}`. */
+const CONSTANT_REFERENCE = /\$\{\s*this\.([A-Za-z_$][\w$]*)\s*\}/g;
+
+/**
+ * Substitutes what a template's interpolations render to.
+ *
+ * The reader sees the VALUE — `https://api.3dprintlog.com/mcp` — so that is
+ * what the index has to hold. Left alone, the binding was stored verbatim:
+ * the endpoint was unsearchable and any excerpt covering it showed a reader
+ * the literal `{{ mcpEndpoint }}`.
+ *
+ * A binding with no matching constant is left as authored rather than dropped,
+ * so a typo stays visible instead of silently emptying a section.
+ *
+ * @param {string} template
+ * @param {Record<string, string> | undefined} constants
+ */
+function resolveBindings(template, constants) {
+  const text = template.replace(
+    STRING_BINDING,
+    (_binding, _quote, literal) =>
+      // A space, not nothing: the wrapper often sits tight against the prose
+      // before it, and dropping it outright would fuse two words together.
+      ` ${literal} `
+  );
+
+  if (!constants) {
+    return text;
+  }
+
+  return text.replace(CONSTANT_BINDING, (binding, name) =>
+    name in constants ? constantValue(constants, name, new Set()) : binding
+  );
+}
+
+/** One constant with its `${this.sibling}` references resolved. */
+function constantValue(constants, name, seen) {
+  if (seen.has(name)) {
+    // Constants are authored by hand, so a cycle is a mistake rather than an
+    // impossibility. Stop at the name instead of recursing forever.
+    return `\${this.${name}}`;
+  }
+  seen.add(name);
+
+  return String(constants[name]).replace(
+    CONSTANT_REFERENCE,
+    (reference, sibling) =>
+      sibling in constants ? constantValue(constants, sibling, seen) : reference
+  );
+}
+
 function headingsOf(template) {
   const headings = [];
   for (const match of stripComments(template).matchAll(
@@ -345,9 +414,22 @@ const CHARACTER_REFERENCES = {
   '&nbsp;': ' ',
 };
 
-function plainText(template) {
-  let text = stripComments(template)
-    .replace(/<pre[\s\S]*?<\/pre>/g, ' ')
+/**
+ * @param {string} template
+ * @param {{ keepCode?: boolean }} [options] `keepCode` indexes `<pre>` blocks
+ *   rather than dropping them. The commands and endpoints on the integration
+ *   pages are exactly what a reader searches for — `--callback-port` matched
+ *   nothing while these were stripped. Headings and descriptions leave it off:
+ *   a heading never contains a code block, and a meta description that opened
+ *   with a shell command would read as noise.
+ */
+function plainText(template, { keepCode = false } = {}) {
+  let text = stripComments(template);
+  if (!keepCode) {
+    text = text.replace(/<pre[\s\S]*?<\/pre>/g, ' ');
+  }
+
+  text = text
     .replace(/<[^>]+>/g, ' ')
     // Numeric references decode before the named ones so that `&amp;` stays
     // last: `&amp;#64;` is an authored literal and must not become `@`.

--- a/scripts/docs-emit.mjs
+++ b/scripts/docs-emit.mjs
@@ -178,25 +178,91 @@ export function emitManifestTs() {
 }
 
 /**
+ * The search index: one entry per heading SECTION, not per page.
+ *
+ * Page-level entries would be useless on exactly the pages a reader most needs
+ * help with. `docs/release-notes` alone is 78 KB of prose under 155 headings —
+ * a hit on it says "the answer is somewhere in the changelog". A section entry
+ * instead names the heading it matched and deep-links to that heading's anchor.
+ *
+ * Sections are cut at h1-h3. h4 and below stay inside their parent: "Full List
+ * of Changes:" appears under every one of the 99 releases and would fragment
+ * each of them into a section whose title says nothing.
+ *
  * @param {object} manifest
  * @param {Record<string, string>} templates rendered template per slug
  */
 export function emitSearchIndexJson(manifest, templates) {
-  const entries = manifest.pages
-    .filter((page) => !page.dormant)
-    .map((page) => {
-      const template = templates[page.slug] ?? '';
-      return {
-        path: page.path,
-        title: page.title,
-        navLabel: page.navLabel,
-        group: page.group,
-        headings: headingsOf(template),
-        text: plainText(template),
-      };
-    });
+  const entries = [];
+
+  for (const page of manifest.pages.filter((p) => !p.dormant)) {
+    for (const section of sectionsOf(templates[page.slug] ?? '', page)) {
+      entries.push(section);
+    }
+  }
 
   return `${JSON.stringify(entries, null, 2)}\n`;
+}
+
+/** Sections are cut at these levels; deeper headings stay with their parent. */
+const SECTION_HEADING = /<h([1-3])([^>]*)>([\s\S]*?)<\/h\1\s*>/g;
+
+/**
+ * Splits one rendered page into searchable sections.
+ *
+ * @param {string} template
+ * @param {{ path: string, navLabel: string, group: string }} page
+ * @returns {object[]}
+ */
+export function sectionsOf(template, page) {
+  const source = stripComments(template);
+
+  const headings = [];
+  for (const match of source.matchAll(SECTION_HEADING)) {
+    const id = /\sid="([^"]+)"/.exec(match[2]);
+    headings.push({
+      title: plainText(match[3]),
+      anchor: id ? id[1] : null,
+      at: match.index,
+      after: match.index + match[0].length,
+    });
+  }
+
+  const sections = [];
+
+  // Anything before the first heading belongs to the page itself. It is titled
+  // with the nav label rather than left blank, so a hit there still names
+  // something the reader recognises from the sidebar.
+  const lead = plainText(
+    source.slice(0, headings.length ? headings[0].at : source.length)
+  );
+  if (lead) {
+    sections.push({ title: page.navLabel, anchor: null, text: lead });
+  }
+
+  headings.forEach((heading, i) => {
+    const body = source.slice(
+      heading.after,
+      i + 1 < headings.length ? headings[i + 1].at : source.length
+    );
+    sections.push({
+      title: heading.title,
+      anchor: heading.anchor,
+      text: plainText(body),
+    });
+  });
+
+  return sections.map((section, ordinal) => ({
+    // Ordinal, not the anchor: a section is indexed whether or not its heading
+    // declares one, and MiniSearch needs an id for every document.
+    id: `${page.path}::${ordinal}`,
+    path: page.path,
+    url: section.anchor ? `/${page.path}#${section.anchor}` : `/${page.path}`,
+    title: section.title,
+    page: page.navLabel,
+    group: page.group,
+    text: section.text,
+  }));
 }
 
 export function emitFiguresTs(manifest, templates) {

--- a/scripts/docs-emit.mjs
+++ b/scripts/docs-emit.mjs
@@ -314,8 +314,14 @@ function stripComments(template) {
  * Moonraker config on the Klipper page is Jinja, so `{% set %}` would otherwise
  * be parsed as Angular syntax. The reader sees the literal, so the index takes
  * the literal and drops the wrapper.
+ *
+ * The quote is matched by a negated class rather than a backreference so that
+ * the scan cannot run past the closing quote: an expression such as
+ * `{{ 'a' + 'b' }}` stops matching and is left alone rather than being
+ * half-evaluated into `a' + 'b`, and an unclosed `{{'` cannot rescan the rest
+ * of the document once per opening.
  */
-const STRING_BINDING = /\{\{\s*(['"])([\s\S]*?)\1\s*\}\}/g;
+const STRING_BINDING = /\{\{\s*(?:'([^']*)'|"([^"]*)")\s*\}\}/g;
 
 /** An Angular binding to a single frontmatter constant, e.g. `{{ mcpEndpoint }}`. */
 const CONSTANT_BINDING = /\{\{\s*([A-Za-z_$][\w$]*)\s*\}\}/g;
@@ -340,10 +346,10 @@ const CONSTANT_REFERENCE = /\$\{\s*this\.([A-Za-z_$][\w$]*)\s*\}/g;
 function resolveBindings(template, constants) {
   const text = template.replace(
     STRING_BINDING,
-    (_binding, _quote, literal) =>
+    (_binding, single, double) =>
       // A space, not nothing: the wrapper often sits tight against the prose
       // before it, and dropping it outright would fuse two words together.
-      ` ${literal} `
+      ` ${escapeSubstitution(single ?? double)} `
   );
 
   if (!constants) {
@@ -351,8 +357,29 @@ function resolveBindings(template, constants) {
   }
 
   return text.replace(CONSTANT_BINDING, (binding, name) =>
-    name in constants ? constantValue(constants, name, new Set()) : binding
+    name in constants
+      ? escapeSubstitution(constantValue(constants, name, new Set()))
+      : binding
   );
+}
+
+/**
+ * Re-encodes a substituted value so the pipeline reads it as text.
+ *
+ * What a binding renders is TEXT — Angular escapes it, so a reader who sees
+ * `echo <your-api-key>` sees those angle brackets. Splicing the raw value back
+ * into the template would hand it to the heading scanner and the tag stripper
+ * instead: `<your-api-key>` vanished as though it were a tag, and a literal
+ * `<h2 id="x">` opened a section that does not exist on the page.
+ *
+ * Numeric references, not `&lt;`, because `plainText` decodes those itself and
+ * this has to survive whether or not a name is in its table.
+ */
+function escapeSubstitution(value) {
+  return String(value)
+    .replace(/&/g, '&#38;')
+    .replace(/</g, '&#60;')
+    .replace(/>/g, '&#62;');
 }
 
 /** One constant with its `${this.sibling}` references resolved. */
@@ -367,7 +394,12 @@ function constantValue(constants, name, seen) {
   return String(constants[name]).replace(
     CONSTANT_REFERENCE,
     (reference, sibling) =>
-      sibling in constants ? constantValue(constants, sibling, seen) : reference
+      sibling in constants
+        ? // A copy, not the same set: `seen` marks the chain currently being
+          // resolved, so sharing one across siblings would read the SECOND
+          // mention of a constant as a cycle and leave it unresolved.
+          constantValue(constants, sibling, new Set(seen))
+        : reference
   );
 }
 

--- a/scripts/docs-emit.test.mjs
+++ b/scripts/docs-emit.test.mjs
@@ -278,6 +278,102 @@ test('commented-out markup reaches none of the projections', () => {
   );
 });
 
+test('the search index holds the code samples a reader searches for', () => {
+  // `--callback-port` matched nothing while <pre> was stripped, which is most
+  // of the point of searching an integration page.
+  const index = JSON.parse(
+    emitSearchIndexJson(buildManifest([page()]), {
+      prints:
+        '<p>Run this:</p><pre><code>claude mcp add --callback-port 8400</code></pre>',
+    })
+  );
+
+  assert.match(index[0].text, /claude mcp add --callback-port 8400/);
+});
+
+test('the search index substitutes the constants a template interpolates', () => {
+  // The reader sees the value, so the index has to hold the value: storing the
+  // binding left the endpoint unsearchable and showed `{{ mcpEndpoint }}` in
+  // any excerpt that covered it.
+  const index = JSON.parse(
+    emitSearchIndexJson(
+      buildManifest([
+        page({
+          constants: { mcpEndpoint: 'https://api.3dprintlog.com/mcp' },
+        }),
+      ]),
+      { prints: '<p>Point it at {{ mcpEndpoint }} to connect.</p>' }
+    )
+  );
+
+  assert.equal(
+    index[0].text,
+    'Point it at https://api.3dprintlog.com/mcp to connect.'
+  );
+});
+
+test('a constant that references a sibling resolves through to the value', () => {
+  const index = JSON.parse(
+    emitSearchIndexJson(
+      buildManifest([
+        page({
+          constants: {
+            endpoint: 'https://api.3dprintlog.com/mcp',
+            command: 'claude mcp add ${this.endpoint} --callback-port 8400',
+          },
+        }),
+      ]),
+      { prints: '<pre><code>{{ command }}</code></pre>' }
+    )
+  );
+
+  assert.equal(
+    index[0].text,
+    'claude mcp add https://api.3dprintlog.com/mcp --callback-port 8400'
+  );
+});
+
+test('an interpolated string literal is indexed as the literal it renders', () => {
+  // Authors wrap a sample in one when the sample itself contains braces; the
+  // Klipper page's Moonraker config is Jinja.
+  const index = JSON.parse(
+    emitSearchIndexJson(buildManifest([page()]), {
+      prints: `<pre><code>{{'
+[notifier 3d_print_log]
+events: *
+'}}</code></pre>`,
+    })
+  );
+
+  assert.match(index[0].text, /\[notifier 3d_print_log\] events: \*/);
+  assert.doesNotMatch(index[0].text, /[{}]{2}/);
+});
+
+test('a binding with no matching constant is left as authored', () => {
+  // Emptying it would hide the typo; leaving it keeps the mistake visible.
+  const index = JSON.parse(
+    emitSearchIndexJson(
+      buildManifest([page({ constants: { endpoint: 'https://example.com' } })]),
+      { prints: '<p>Use {{ notAConstant }} here.</p>' }
+    )
+  );
+
+  assert.equal(index[0].text, 'Use {{ notAConstant }} here.');
+});
+
+test('an escaped brace is shown, not treated as a binding', () => {
+  // `&#123;` is what an author writes to SHOW a brace. Resolving bindings after
+  // the decode step would substitute into text that escaped itself on purpose.
+  const index = JSON.parse(
+    emitSearchIndexJson(
+      buildManifest([page({ constants: { endpoint: 'https://example.com' } })]),
+      { prints: '<p>Write &#123;&#123; endpoint &#125;&#125; to bind it.</p>' }
+    )
+  );
+
+  assert.equal(index[0].text, 'Write {{ endpoint }} to bind it.');
+});
+
 test('the search index decodes the character references the renderer emits', () => {
   const index = JSON.parse(
     emitSearchIndexJson(buildManifest([page()]), {

--- a/scripts/docs-emit.test.mjs
+++ b/scripts/docs-emit.test.mjs
@@ -149,7 +149,7 @@ test('docs.server-routes.ts exports prerender entries only, with no catch-all', 
   assert.doesNotMatch(ts, /docs\/old/);
 });
 
-test('the search index carries the plain text of each page, not its markup', () => {
+test('the search index carries the plain text of each section, not its markup', () => {
   const index = JSON.parse(
     emitSearchIndexJson(buildManifest([page()]), {
       prints: '<h2>Prints</h2>\n<p>Log a <strong>print</strong>.</p>',
@@ -158,24 +158,94 @@ test('the search index carries the plain text of each page, not its markup', () 
 
   assert.deepEqual(index, [
     {
+      id: 'docs/prints::0',
       path: 'docs/prints',
-      title: 'Tracking Prints | 3D Print Log Docs',
-      navLabel: 'Prints',
+      url: '/docs/prints',
+      title: 'Prints',
+      page: 'Prints',
       group: 'features',
-      headings: ['Prints'],
-      text: 'Prints Log a print.',
+      text: 'Log a print.',
     },
   ]);
 });
 
-test('the search index records a heading anchor when the page declares one', () => {
+test('the search index deep-links a section whose heading declares an anchor', () => {
   const index = JSON.parse(
     emitSearchIndexJson(buildManifest([page()]), {
-      prints: '<h3 id="usage">Usage</h3>',
+      prints: '<h3 id="usage">Usage</h3>\n<p>How to log one.</p>',
     })
   );
 
-  assert.deepEqual(index[0].headings, ['Usage#usage']);
+  assert.equal(index[0].url, '/docs/prints#usage');
+  assert.equal(index[0].title, 'Usage');
+});
+
+test('the search index cuts one entry per h1-h3 heading', () => {
+  const index = JSON.parse(
+    emitSearchIndexJson(buildManifest([page()]), {
+      prints: [
+        '<h2 id="a">First</h2>',
+        '<p>Alpha.</p>',
+        '<h3 id="b">Second</h3>',
+        '<p>Beta.</p>',
+      ].join('\n'),
+    })
+  );
+
+  assert.deepEqual(
+    index.map((s) => [s.title, s.text]),
+    [
+      ['First', 'Alpha.'],
+      ['Second', 'Beta.'],
+    ]
+  );
+});
+
+test('the search index keeps h4 and deeper inside their parent section', () => {
+  // "Full List of Changes:" sits under all 99 releases. Cutting on it would
+  // mint 99 sections whose titles say nothing about what they contain.
+  const index = JSON.parse(
+    emitSearchIndexJson(buildManifest([page()]), {
+      prints: [
+        '<h3 id="v1">1.0.0 - Spool Photos</h3>',
+        '<p>Summary.</p>',
+        '<h4>Full List of Changes:</h4>',
+        '<p>Detail.</p>',
+      ].join('\n'),
+    })
+  );
+
+  assert.equal(index.length, 1);
+  assert.equal(index[0].title, '1.0.0 - Spool Photos');
+  assert.match(index[0].text, /Detail\./);
+});
+
+test('the search index titles a pre-heading lead with the page nav label', () => {
+  const index = JSON.parse(
+    emitSearchIndexJson(buildManifest([page()]), {
+      prints: '<p>Intro prose.</p>\n<h2 id="a">First</h2>\n<p>Alpha.</p>',
+    })
+  );
+
+  assert.deepEqual(
+    index.map((s) => [s.title, s.text]),
+    [
+      ['Prints', 'Intro prose.'],
+      ['First', 'Alpha.'],
+    ]
+  );
+});
+
+test('the search index gives every section a unique id', () => {
+  // Two headings can share a title, and most declare no anchor at all, so the
+  // id cannot be derived from either.
+  const index = JSON.parse(
+    emitSearchIndexJson(buildManifest([page()]), {
+      prints: '<h2>Setup</h2>\n<p>One.</p>\n<h2>Setup</h2>\n<p>Two.</p>',
+    })
+  );
+
+  assert.equal(new Set(index.map((s) => s.id)).size, index.length);
 });
 
 test('commented-out markup reaches none of the projections', () => {
@@ -195,8 +265,13 @@ test('commented-out markup reaches none of the projections', () => {
     emitSearchIndexJson(buildManifest([page()]), { prints: template })
   );
 
-  assert.equal(index[0].text, 'Setup Install the plugin.');
-  assert.deepEqual(index[0].headings, ['Setup']);
+  assert.equal(index[0].title, 'Setup');
+  assert.equal(index[0].text, 'Install the plugin.');
+  assert.equal(
+    index.length,
+    1,
+    'the commented-out heading must not open a section'
+  );
   assert.doesNotMatch(
     emitFiguresTs(buildManifest([page()]), { prints: template }),
     /old\.png/

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -200,6 +200,13 @@ export const appRoutes: Routes = [
   imports: [
     RouterModule.forRoot(appRoutes, {
       scrollPositionRestoration: 'enabled',
+      // Without this, scrollPositionRestoration scrolls a fragment navigation
+      // back to the top: the router does not look at the `#anchor` at all, so
+      // every deep link into a docs page landed at the top of it. The two
+      // settings are designed to work together — with anchorScrolling on, a
+      // navigation carrying a fragment scrolls to that element instead of
+      // being restored.
+      anchorScrolling: 'enabled',
       preloadingStrategy: SelectivePreloadStrategy,
     }),
   ],

--- a/src/app/core/routing/anchor-scrolling.spec.ts
+++ b/src/app/core/routing/anchor-scrolling.spec.ts
@@ -1,0 +1,31 @@
+import { ExtraOptions, ROUTER_CONFIGURATION } from '@angular/router';
+import { TestBed } from '@angular/core/testing';
+
+import { AppRoutingModule } from '../../app-routing.module';
+
+/**
+ * Pins the two scrolling options, which only work as a pair.
+ *
+ * `scrollPositionRestoration: 'enabled'` alone scrolls a fragment navigation
+ * back to the top: the router never looks at the `#anchor`, so it treats the
+ * arrival as a fresh page and restores position zero. Every deep link into a
+ * docs page — a search result, a cross-page anchor, a bookmarked release note —
+ * landed at the top of the page instead of at the thing it named.
+ *
+ * Turning either off silently breaks that again, and it is invisible in unit
+ * tests of the pages themselves, so it is asserted here.
+ */
+describe('router scrolling configuration', () => {
+  function options(): ExtraOptions {
+    TestBed.configureTestingModule({ imports: [AppRoutingModule] });
+    return TestBed.inject(ROUTER_CONFIGURATION);
+  }
+
+  it('scrolls to the anchor a URL fragment names', () => {
+    expect(options().anchorScrolling).toBe('enabled');
+  });
+
+  it('still restores scroll position for navigations with no fragment', () => {
+    expect(options().scrollPositionRestoration).toBe('enabled');
+  });
+});

--- a/src/app/documentation/doc-sidebar/doc-sidebar.component.html
+++ b/src/app/documentation/doc-sidebar/doc-sidebar.component.html
@@ -10,6 +10,7 @@
   <button
     type="button"
     class="sidebar-search"
+    data-cy="docs-sidebar-search"
     (click)="openSearch.emit()"
     aria-label="Search documentation"
   >

--- a/src/app/documentation/doc-sidebar/doc-sidebar.component.html
+++ b/src/app/documentation/doc-sidebar/doc-sidebar.component.html
@@ -1,3 +1,22 @@
 <div class="sidebar">
+  <!--
+    Styled as a search box but announced as a button, which is what it is: it
+    opens the palette rather than searching in place. A real <input> here would
+    move focus into a dialog the moment it was focused, which is hostile to
+    keyboard and screen-reader users and makes tabbing past it impossible.
+    Keeping one result list also means one keyboard model and one place the
+    telemetry is emitted from.
+  -->
+  <button
+    type="button"
+    class="sidebar-search"
+    (click)="openSearch.emit()"
+    aria-label="Search documentation"
+  >
+    <mat-icon aria-hidden="true">search</mat-icon>
+    <span class="sidebar-search__label">Search docs</span>
+    <kbd class="sidebar-search__key">{{ shortcutHint }}</kbd>
+  </button>
+
   <app-sidebar [navItems]="navItems"></app-sidebar>
 </div>

--- a/src/app/documentation/doc-sidebar/doc-sidebar.component.scss
+++ b/src/app/documentation/doc-sidebar/doc-sidebar.component.scss
@@ -1,3 +1,47 @@
 .sidebar {
   width: 300px;
 }
+
+// Styled as a search box, announced as a button — see the template comment.
+.sidebar-search {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: calc(100% - 1.5rem);
+  margin: 0.75rem;
+  padding: 0.45rem 0.6rem;
+  border: 1px solid rgba(127, 127, 127, 0.4);
+  border-radius: 6px;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+
+  &:hover {
+    background: rgba(127, 127, 127, 0.12);
+  }
+
+  mat-icon {
+    font-size: 1.1rem;
+    width: 1.1rem;
+    height: 1.1rem;
+    opacity: 0.7;
+  }
+}
+
+.sidebar-search__label {
+  flex: 1 1 auto;
+  font-size: 0.9rem;
+  opacity: 0.75;
+}
+
+.sidebar-search__key {
+  padding: 0.05rem 0.35rem;
+  border: 1px solid rgba(127, 127, 127, 0.4);
+  border-radius: 3px;
+  font-family: inherit;
+  font-size: 0.7rem;
+  opacity: 0.7;
+  white-space: nowrap;
+}

--- a/src/app/documentation/doc-sidebar/doc-sidebar.component.ts
+++ b/src/app/documentation/doc-sidebar/doc-sidebar.component.ts
@@ -1,6 +1,11 @@
-import { Component } from '@angular/core';
+import { Component, PLATFORM_ID, inject, output } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { INavData } from 'src/app/shared/sidebar/types';
 import { DOC_PAGES } from '../generated/docs-manifest';
+import {
+  isApplePlatform,
+  shortcutLabel,
+} from '../docs-search/keyboard-shortcut';
 
 /**
  * The docs sidebar, derived from the docs manifest: each page's `navLabel`,
@@ -16,6 +21,16 @@ import { DOC_PAGES } from '../generated/docs-manifest';
 })
 export class DocSidebarComponent {
   public navItems: INavData[] = buildNavItems();
+
+  /** Asks the shell to open the search palette; it owns the dialog ref. */
+  readonly openSearch = output<void>();
+
+  private readonly platformId = inject(PLATFORM_ID);
+
+  /** Guarded: this also runs in Node during prerendering. */
+  readonly shortcutHint = shortcutLabel(
+    isPlatformBrowser(this.platformId) && isApplePlatform(navigator.platform)
+  );
 }
 
 function buildNavItems(): INavData[] {

--- a/src/app/documentation/docs-search/docs-search-dialog.component.html
+++ b/src/app/documentation/docs-search/docs-search-dialog.component.html
@@ -28,12 +28,15 @@
   <p class="docs-search__status" aria-live="polite">
     @if (loading()) {
       Searching…
+    } @else if (failed()) {
+      Search is unavailable right now. Try again in a moment.
     } @else if (searched()) {
       {{ results().length }} {{ results().length === 1 ? 'result' : 'results' }}
     }
   </p>
 
   <ul
+    #list
     class="docs-search__results"
     id="docs-search-results"
     role="listbox"
@@ -58,7 +61,7 @@
     }
   </ul>
 
-  @if (searched() && results().length === 0 && !loading()) {
+  @if (searched() && results().length === 0 && !loading() && !failed()) {
     <p class="docs-search__empty">
       Nothing matched that. Try a different word, or
       <button type="button" class="docs-search__link" (click)="openFeedback()">

--- a/src/app/documentation/docs-search/docs-search-dialog.component.html
+++ b/src/app/documentation/docs-search/docs-search-dialog.component.html
@@ -2,6 +2,7 @@
   <input
     #input
     class="docs-search__input"
+    data-cy="docs-search-input"
     type="search"
     [formControl]="query"
     (keydown)="onKeydown($event)"
@@ -38,6 +39,7 @@
   <ul
     #list
     class="docs-search__results"
+    data-cy="docs-search-results"
     id="docs-search-results"
     role="listbox"
     aria-label="Search results"
@@ -45,6 +47,7 @@
     @for (result of results(); track result.id; let i = $index) {
       <li
         class="docs-search__result"
+        data-cy="docs-search-result"
         [class.docs-search__result--active]="i === active()"
         id="docs-search-result-{{ i }}"
         role="option"
@@ -62,7 +65,7 @@
   </ul>
 
   @if (searched() && results().length === 0 && !loading() && !failed()) {
-    <p class="docs-search__empty">
+    <p class="docs-search__empty" data-cy="docs-search-empty">
       Nothing matched that. Try a different word, or
       <button type="button" class="docs-search__link" (click)="openFeedback()">
         tell us what you were looking for</button

--- a/src/app/documentation/docs-search/docs-search-dialog.component.html
+++ b/src/app/documentation/docs-search/docs-search-dialog.component.html
@@ -1,0 +1,73 @@
+<div class="docs-search">
+  <input
+    #input
+    class="docs-search__input"
+    type="search"
+    [formControl]="query"
+    (keydown)="onKeydown($event)"
+    placeholder="Search documentation"
+    aria-label="Search documentation"
+    role="combobox"
+    aria-expanded="true"
+    aria-controls="docs-search-results"
+    [attr.aria-activedescendant]="
+      results().length ? 'docs-search-result-' + active() : null
+    "
+    autocomplete="off"
+    autocorrect="off"
+    spellcheck="false"
+    cdkFocusInitial
+  />
+
+  <!--
+    aria-live so the result count is announced without focus ever leaving the
+    input — which is where the arrow keys need it to stay. Selection is conveyed
+    by aria-activedescendant instead, so the options are not themselves
+    focusable and must not be buttons.
+  -->
+  <p class="docs-search__status" aria-live="polite">
+    @if (loading()) {
+      Searching…
+    } @else if (searched()) {
+      {{ results().length }} {{ results().length === 1 ? 'result' : 'results' }}
+    }
+  </p>
+
+  <ul
+    class="docs-search__results"
+    id="docs-search-results"
+    role="listbox"
+    aria-label="Search results"
+  >
+    @for (result of results(); track result.id; let i = $index) {
+      <li
+        class="docs-search__result"
+        [class.docs-search__result--active]="i === active()"
+        id="docs-search-result-{{ i }}"
+        role="option"
+        [attr.aria-selected]="i === active()"
+        (click)="open(result, i)"
+        (mouseenter)="active.set(i)"
+      >
+        <span class="docs-search__result-title">{{ result.title }}</span>
+        <span class="docs-search__result-page">{{ result.page }}</span>
+        @if (result.excerpt) {
+          <span class="docs-search__result-excerpt">{{ result.excerpt }}</span>
+        }
+      </li>
+    }
+  </ul>
+
+  @if (searched() && results().length === 0 && !loading()) {
+    <p class="docs-search__empty">
+      Nothing matched that. Try a different word, or
+      <button type="button" class="docs-search__link" (click)="openFeedback()">
+        tell us what you were looking for</button
+      >.
+    </p>
+  }
+
+  <p class="docs-search__hints">
+    <kbd>↑</kbd><kbd>↓</kbd> navigate <kbd>↵</kbd> open <kbd>esc</kbd> close
+  </p>
+</div>

--- a/src/app/documentation/docs-search/docs-search-dialog.component.scss
+++ b/src/app/documentation/docs-search/docs-search-dialog.component.scss
@@ -15,8 +15,14 @@
   font: inherit;
   font-size: 1.05rem;
 
+  // The default ring is dropped because it traces the full-width box and reads
+  // as a rendering artefact against the panel edge — but focus still has to be
+  // visible, so the rule under it thickens instead.
   &:focus {
     outline: none;
+    border-bottom-color: currentColor;
+    border-bottom-width: 2px;
+    padding-bottom: calc(0.9rem - 1px);
   }
 
   // The type="search" clear affordance is a different size in every browser and

--- a/src/app/documentation/docs-search/docs-search-dialog.component.scss
+++ b/src/app/documentation/docs-search/docs-search-dialog.component.scss
@@ -1,0 +1,117 @@
+.docs-search {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.docs-search__input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.9rem 1rem;
+  border: none;
+  border-bottom: 1px solid rgba(127, 127, 127, 0.3);
+  background: none;
+  color: inherit;
+  font: inherit;
+  font-size: 1.05rem;
+
+  &:focus {
+    outline: none;
+  }
+
+  // The type="search" clear affordance is a different size in every browser and
+  // sits on top of the rounded corner in WebKit.
+  &::-webkit-search-cancel-button {
+    appearance: none;
+  }
+}
+
+.docs-search__status {
+  margin: 0;
+  padding: 0.4rem 1rem 0;
+  font-size: 0.78rem;
+  opacity: 0.65;
+  // Reserves the line so results do not jump by one row when the count appears.
+  min-height: 1.4em;
+}
+
+.docs-search__results {
+  list-style: none;
+  margin: 0;
+  padding: 0.25rem 0;
+  overflow-y: auto;
+  // The dialog is capped in height; this is the part that scrolls.
+  max-height: min(60vh, 28rem);
+}
+
+.docs-search__result {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0 0.75rem;
+  padding: 0.55rem 1rem;
+  cursor: pointer;
+
+  // Selection is conveyed to assistive tech by aria-activedescendant, so this
+  // is the visible half of the same state and must not rely on :focus.
+  &--active {
+    background: rgba(127, 127, 127, 0.16);
+  }
+}
+
+.docs-search__result-title {
+  font-weight: 600;
+}
+
+.docs-search__result-page {
+  justify-self: end;
+  font-size: 0.75rem;
+  opacity: 0.6;
+  white-space: nowrap;
+}
+
+.docs-search__result-excerpt {
+  grid-column: 1 / -1;
+  font-size: 0.82rem;
+  opacity: 0.75;
+  // Two lines of context, then ellipsis: enough to judge a hit, not enough for
+  // one long section to push the rest of the results off screen.
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.docs-search__empty {
+  margin: 0;
+  padding: 0.5rem 1rem 1rem;
+  font-size: 0.9rem;
+}
+
+.docs-search__link {
+  padding: 0;
+  border: none;
+  background: none;
+  font: inherit;
+  color: inherit;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.docs-search__hints {
+  margin: 0;
+  padding: 0.5rem 1rem;
+  border-top: 1px solid rgba(127, 127, 127, 0.3);
+  font-size: 0.72rem;
+  opacity: 0.6;
+
+  kbd {
+    display: inline-block;
+    min-width: 1.1em;
+    margin: 0 0.15rem;
+    padding: 0.05rem 0.3rem;
+    border: 1px solid rgba(127, 127, 127, 0.4);
+    border-radius: 3px;
+    font-family: inherit;
+    text-align: center;
+  }
+}

--- a/src/app/documentation/docs-search/docs-search-dialog.component.spec.ts
+++ b/src/app/documentation/docs-search/docs-search-dialog.component.spec.ts
@@ -4,6 +4,7 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { Subject } from 'rxjs';
 
+import { LoggingService } from 'src/app/core/services/logging.service';
 import { DocsTelemetryService } from '../docs-telemetry.service';
 import { DocsSearchDialogComponent } from './docs-search-dialog.component';
 import { DocSearchResult, DocsSearchService } from './docs-search.service';
@@ -235,6 +236,144 @@ describe('DocsSearchDialogComponent', () => {
 
     expect(dialogRef.close).toHaveBeenCalled();
     expect(router.navigateByUrl).toHaveBeenCalledWith('/feedback');
+  }));
+
+  it('says so when the search itself fails, rather than going quiet', waitForAsync(async () => {
+    // The engine and the index are fetched, so this is a network failure, not a
+    // theoretical one. Reporting it as "0 results" would be a lie.
+    await setup();
+    search.search.and.resolveTo([result()]);
+    await type('material');
+
+    search.search.and.callFake(() =>
+      Promise.reject(new Error('chunk load failed'))
+    );
+    await type('materials');
+
+    expect(component.failed()).toBe(true);
+    expect(component.results()).toEqual([]);
+    expect(component.searched()).toBe(false);
+    expect(telemetry.trackSearch).toHaveBeenCalledTimes(1);
+  }));
+
+  it('logs a failed search', waitForAsync(async () => {
+    await setup();
+    const logging = TestBed.inject(LoggingService);
+    const logException = spyOn(logging, 'logException');
+    search.search.and.callFake(() =>
+      Promise.reject(new Error('chunk load failed'))
+    );
+
+    await type('material');
+
+    expect(logException).toHaveBeenCalled();
+  }));
+
+  it('clears the failure once a later search succeeds', waitForAsync(async () => {
+    await setup();
+    search.search.and.callFake(() =>
+      Promise.reject(new Error('chunk load failed'))
+    );
+    await type('material');
+
+    search.search.and.resolveTo([result()]);
+    await type('materials');
+
+    expect(component.failed()).toBe(false);
+    expect(component.results().length).toBe(1);
+  }));
+
+  it('ends the wait when the box is emptied mid-search', waitForAsync(async () => {
+    // Otherwise "Searching…" describes a query that is no longer there, and it
+    // stays up until a search nobody is waiting for finally settles.
+    await setup();
+    let releaseFirst: (value: DocSearchResult[]) => void = () => undefined;
+    search.search.and.returnValue(
+      new Promise<DocSearchResult[]>((resolve) => {
+        releaseFirst = resolve;
+      })
+    );
+
+    component.query.setValue('material');
+    // The debounce, and then the placeholder's own 200ms reveal delay.
+    await new Promise((resolve) =>
+      setTimeout(resolve, AFTER_DEBOUNCE_MS + 300)
+    );
+    expect(component.loading()).toBe(true);
+
+    await type('');
+    // Past the placeholder's minimum dwell, which outlives the release itself.
+    await new Promise((resolve) => setTimeout(resolve, 500));
+
+    expect(component.loading()).toBe(false);
+
+    releaseFirst([result()]);
+    await fixture.whenStable();
+    expect(component.results()).toEqual([]);
+  }));
+
+  it('keeps the wait up for a newer search when an abandoned one settles', waitForAsync(async () => {
+    // A -> clear -> B -> A settles. A shared loader count would let A's late
+    // settle hand back the placeholder B is still holding.
+    await setup();
+    const pending: Array<(value: DocSearchResult[]) => void> = [];
+    search.search.and.callFake(
+      () => new Promise<DocSearchResult[]>((resolve) => pending.push(resolve))
+    );
+
+    await type('material');
+    await type('');
+    component.query.setValue('spool');
+    await new Promise((resolve) =>
+      setTimeout(resolve, AFTER_DEBOUNCE_MS + 300)
+    );
+    expect(component.loading()).toBe(true);
+
+    // The abandoned first search finally answers.
+    pending[0]([result({ id: 'stale' })]);
+    await fixture.whenStable();
+
+    expect(component.loading()).toBe(true);
+    expect(component.results()).toEqual([]);
+  }));
+
+  it('navigates once when the reader activates a result twice', waitForAsync(async () => {
+    // `close()` only starts the animation, so a held Enter gets a second pass in
+    // before the first navigation runs.
+    await setup();
+    search.search.and.resolveTo([result()]);
+    await type('material');
+
+    component.open(component.results()[0], 0);
+    component.open(component.results()[0], 0);
+
+    expect(router.navigateByUrl).toHaveBeenCalledTimes(1);
+  }));
+
+  it('ignores a slow response for a query the box has since returned to', waitForAsync(async () => {
+    // mat -> material -> mat: the first response arrives when the box reads
+    // "mat" again, so a text comparison would let it commit and re-report.
+    await setup();
+
+    let releaseFirst: (value: DocSearchResult[]) => void = () => undefined;
+    search.search.and.returnValues(
+      new Promise<DocSearchResult[]>((resolve) => {
+        releaseFirst = resolve;
+      }),
+      Promise.resolve([result({ id: 'second' })]),
+      Promise.resolve([result({ id: 'third' })])
+    );
+
+    component.query.setValue('mat');
+    await new Promise((resolve) => setTimeout(resolve, AFTER_DEBOUNCE_MS));
+    await type('material');
+    await type('mat');
+
+    releaseFirst([result({ id: 'first' })]);
+    await fixture.whenStable();
+
+    expect(component.results().map((r) => r.id)).toEqual(['third']);
+    expect(telemetry.trackSearch).toHaveBeenCalledTimes(2);
   }));
 
   it('ignores a slow response for a query that has since changed', waitForAsync(async () => {

--- a/src/app/documentation/docs-search/docs-search-dialog.component.spec.ts
+++ b/src/app/documentation/docs-search/docs-search-dialog.component.spec.ts
@@ -337,6 +337,45 @@ describe('DocsSearchDialogComponent', () => {
     expect(component.results()).toEqual([]);
   }));
 
+  it('withholds an answer to a query the reader has already moved on from', waitForAsync(async () => {
+    // The generation alone cannot see this: while the reader types the next
+    // query its run has not started, so nothing has advanced the generation and
+    // the older answer would publish under the text now in the box.
+    await setup();
+
+    let releaseFirst: (value: DocSearchResult[]) => void = () => undefined;
+    search.search.and.returnValues(
+      new Promise<DocSearchResult[]>((resolve) => {
+        releaseFirst = resolve;
+      }),
+      Promise.resolve([result({ id: 'second' })])
+    );
+
+    await type('mat');
+    // Typed, but its debounce has not fired: no second run yet.
+    component.query.setValue('material');
+
+    releaseFirst([result({ id: 'first' })]);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(component.results()).toEqual([]);
+    expect(telemetry.trackSearch).not.toHaveBeenCalledWith('mat', 1);
+  }));
+
+  it('reports one click when the reader activates a result twice', waitForAsync(async () => {
+    // search-quality.kql averages the rank of a click, so counting a held
+    // Enter twice quietly skews it.
+    await setup();
+    search.search.and.resolveTo([result()]);
+    await type('material');
+
+    component.open(component.results()[0], 0);
+    component.open(component.results()[0], 0);
+
+    expect(telemetry.trackSearchResultClick).toHaveBeenCalledTimes(1);
+  }));
+
   it('navigates once when the reader activates a result twice', waitForAsync(async () => {
     // `close()` only starts the animation, so a held Enter gets a second pass in
     // before the first navigation runs.

--- a/src/app/documentation/docs-search/docs-search-dialog.component.spec.ts
+++ b/src/app/documentation/docs-search/docs-search-dialog.component.spec.ts
@@ -1,0 +1,261 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Router } from '@angular/router';
+import { Subject } from 'rxjs';
+
+import { DocsTelemetryService } from '../docs-telemetry.service';
+import { DocsSearchDialogComponent } from './docs-search-dialog.component';
+import { DocSearchResult, DocsSearchService } from './docs-search.service';
+
+/** Longer than DEBOUNCE_MS, so a typed query has definitely settled. */
+const AFTER_DEBOUNCE_MS = 300;
+
+const result = (over: Partial<DocSearchResult> = {}): DocSearchResult => ({
+  id: 'docs/materials::3',
+  title: 'Adding a Material',
+  page: 'Materials',
+  url: '/docs/materials#adding',
+  path: 'docs/materials',
+  excerpt: 'Add a material from the list.',
+  ...over,
+});
+
+describe('DocsSearchDialogComponent', () => {
+  let fixture: ComponentFixture<DocsSearchDialogComponent>;
+  let component: DocsSearchDialogComponent;
+  let search: jasmine.SpyObj<DocsSearchService>;
+  let telemetry: jasmine.SpyObj<DocsTelemetryService>;
+  let dialogRef: jasmine.SpyObj<MatDialogRef<DocsSearchDialogComponent>>;
+  let router: jasmine.SpyObj<Router>;
+  let closed: Subject<unknown>;
+
+  async function setup(data: { query?: string } | null = null) {
+    search = jasmine.createSpyObj<DocsSearchService>('DocsSearchService', [
+      'search',
+      'preload',
+    ]);
+    search.search.and.resolveTo([]);
+
+    telemetry = jasmine.createSpyObj<DocsTelemetryService>(
+      'DocsTelemetryService',
+      ['trackSearch', 'trackSearchResultClick']
+    );
+    dialogRef = jasmine.createSpyObj<MatDialogRef<DocsSearchDialogComponent>>(
+      'MatDialogRef',
+      ['close', 'afterClosed']
+    );
+    // The component navigates only once the dialog has finished closing, so the
+    // stub has to actually complete rather than just record the call.
+    closed = new Subject<unknown>();
+    dialogRef.afterClosed.and.returnValue(closed.asObservable() as never);
+    dialogRef.close.and.callFake(() => {
+      closed.next(undefined);
+      closed.complete();
+    });
+    router = jasmine.createSpyObj<Router>('Router', ['navigateByUrl']);
+
+    await TestBed.configureTestingModule({
+      imports: [DocsSearchDialogComponent],
+      providers: [
+        { provide: DocsSearchService, useValue: search },
+        { provide: DocsTelemetryService, useValue: telemetry },
+        { provide: MatDialogRef, useValue: dialogRef },
+        { provide: Router, useValue: router },
+        { provide: MAT_DIALOG_DATA, useValue: data },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DocsSearchDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  /** Types a query and lets the debounce and the search promise settle. */
+  async function type(query: string) {
+    component.query.setValue(query);
+    await new Promise((resolve) => setTimeout(resolve, AFTER_DEBOUNCE_MS));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  it('starts the import before the first keystroke', waitForAsync(async () => {
+    await setup();
+
+    // ~55 KB of engine and index; waiting for the first keystroke to start it
+    // puts the whole download in front of the first result.
+    expect(search.preload).toHaveBeenCalled();
+  }));
+
+  it('searches once typing settles', waitForAsync(async () => {
+    await setup();
+    search.search.and.resolveTo([result()]);
+
+    await type('material');
+
+    expect(search.search).toHaveBeenCalledWith('material');
+    expect(component.results().length).toBe(1);
+  }));
+
+  it('reports the search with its result count', waitForAsync(async () => {
+    await setup();
+    search.search.and.resolveTo([result(), result({ id: 'b' })]);
+
+    await type('material');
+
+    expect(telemetry.trackSearch).toHaveBeenCalledWith('material', 2);
+  }));
+
+  it('reports a search that found nothing', waitForAsync(async () => {
+    // zero-result-searches.kql is the most actionable query in the analytics
+    // set and it is fed entirely by these.
+    await setup();
+    search.search.and.resolveTo([]);
+
+    await type('kryptonite');
+
+    expect(telemetry.trackSearch).toHaveBeenCalledWith('kryptonite', 0);
+  }));
+
+  it('does not search or report a query too short to mean anything', waitForAsync(async () => {
+    await setup();
+
+    await type('m');
+
+    expect(search.search).not.toHaveBeenCalled();
+    expect(telemetry.trackSearch).not.toHaveBeenCalled();
+    expect(component.searched()).toBe(false);
+  }));
+
+  it('trims the query before searching and reporting', waitForAsync(async () => {
+    await setup();
+
+    await type('  material  ');
+
+    expect(search.search).toHaveBeenCalledWith('material');
+    expect(telemetry.trackSearch).toHaveBeenCalledWith('material', 0);
+  }));
+
+  it('reports a clicked result with its query, page and rank', waitForAsync(async () => {
+    await setup();
+    search.search.and.resolveTo([result(), result({ id: 'b' })]);
+    await type('material');
+
+    component.open(component.results()[1], 1);
+
+    expect(telemetry.trackSearchResultClick).toHaveBeenCalledWith(
+      'material',
+      'docs/materials',
+      1
+    );
+  }));
+
+  it('closes and navigates to the section a result names', waitForAsync(async () => {
+    await setup();
+    search.search.and.resolveTo([result()]);
+    await type('material');
+
+    component.open(component.results()[0], 0);
+
+    expect(dialogRef.close).toHaveBeenCalled();
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/docs/materials#adding');
+  }));
+
+  describe('keyboard', () => {
+    const key = (k: string) =>
+      new KeyboardEvent('keydown', { key: k, cancelable: true });
+
+    beforeEach(waitForAsync(async () => {
+      await setup();
+      search.search.and.resolveTo([
+        result({ id: 'a' }),
+        result({ id: 'b' }),
+        result({ id: 'c' }),
+      ]);
+      await type('material');
+    }));
+
+    it('moves the highlight down and up', () => {
+      component.onKeydown(key('ArrowDown'));
+      expect(component.active()).toBe(1);
+
+      component.onKeydown(key('ArrowUp'));
+      expect(component.active()).toBe(0);
+    });
+
+    it('wraps from the first result to the last', () => {
+      component.onKeydown(key('ArrowUp'));
+
+      expect(component.active()).toBe(2);
+    });
+
+    it('opens the highlighted result on Enter', () => {
+      component.onKeydown(key('ArrowDown'));
+      component.onKeydown(key('Enter'));
+
+      expect(telemetry.trackSearchResultClick).toHaveBeenCalledWith(
+        'material',
+        'docs/materials',
+        1
+      );
+    });
+
+    it('takes the arrow keys from the input, which would move the caret', () => {
+      const event = key('ArrowDown');
+      component.onKeydown(event);
+
+      expect(event.defaultPrevented).toBe(true);
+    });
+  });
+
+  it('does nothing on Enter with no results', waitForAsync(async () => {
+    // Its own setup, not the keyboard block's: that one seeds three results.
+    await setup();
+    await type('kryptonite');
+
+    component.onKeydown(
+      new KeyboardEvent('keydown', { key: 'Enter', cancelable: true })
+    );
+
+    expect(dialogRef.close).not.toHaveBeenCalled();
+  }));
+
+  it('carries a query typed elsewhere into the box', waitForAsync(async () => {
+    await setup({ query: 'spool' });
+
+    expect(component.query.value).toBe('spool');
+  }));
+
+  it('sends a reader who found nothing to feedback', waitForAsync(async () => {
+    await setup();
+
+    component.openFeedback();
+
+    expect(dialogRef.close).toHaveBeenCalled();
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/feedback');
+  }));
+
+  it('ignores a slow response for a query that has since changed', waitForAsync(async () => {
+    await setup();
+
+    // The first search resolves after the second has already been typed.
+    let releaseFirst: (value: DocSearchResult[]) => void = () => undefined;
+    search.search.and.returnValues(
+      new Promise<DocSearchResult[]>((resolve) => {
+        releaseFirst = resolve;
+      }),
+      Promise.resolve([result({ id: 'second' })])
+    );
+
+    component.query.setValue('mat');
+    await new Promise((resolve) => setTimeout(resolve, AFTER_DEBOUNCE_MS));
+    await type('material');
+
+    releaseFirst([result({ id: 'first' })]);
+    await fixture.whenStable();
+
+    expect(component.results().map((r) => r.id)).toEqual(['second']);
+  }));
+});

--- a/src/app/documentation/docs-search/docs-search-dialog.component.ts
+++ b/src/app/documentation/docs-search/docs-search-dialog.component.ts
@@ -111,8 +111,12 @@ export class DocsSearchDialogComponent {
   }
 
   open(result: DocSearchResult, rank: number): void {
-    this.telemetry.trackSearchResultClick(this.lastQuery, result.path, rank);
-    this.closeThenNavigate(result.url);
+    // Only the activation that actually takes the dialog down is reported. A
+    // held Enter reaches this twice, and search-quality.kql averages the rank
+    // of a click — counting the same one twice quietly skews that average.
+    if (this.closeThenNavigate(result.url)) {
+      this.telemetry.trackSearchResultClick(this.lastQuery, result.path, rank);
+    }
   }
 
   /** Arrow keys move the highlight, Enter opens it. Escape is MatDialog's. */
@@ -168,13 +172,14 @@ export class DocsSearchDialogComponent {
    * silently undone — the reader lands at the top of the page they searched
    * for, which is the one thing section-level results exist to avoid.
    */
-  private closeThenNavigate(url: string): void {
+  /** @returns whether this call is the one that owns the close */
+  private closeThenNavigate(url: string): boolean {
     // `close()` only starts the animation, so a held Enter or a double click
     // gets here again while the first navigation is still waiting on it. Each
     // pass would subscribe again and every subscription would fire on the one
     // close, navigating two or three times.
     if (this.navigating) {
-      return;
+      return false;
     }
     this.navigating = true;
 
@@ -183,6 +188,7 @@ export class DocsSearchDialogComponent {
       .pipe(take(1))
       .subscribe(() => void this.router.navigateByUrl(url));
     this.dialogRef.close();
+    return true;
   }
 
   /**
@@ -212,8 +218,14 @@ export class DocsSearchDialogComponent {
     try {
       const results = await this.search.search(query);
 
-      // A slower earlier search must not overwrite a newer one's results.
-      if (generation !== this.generation) {
+      // BOTH guards are load-bearing. The generation stops an older invocation
+      // committing once a newer one exists — `mat -> material -> mat` would
+      // otherwise let the first `mat` re-report. The input comparison covers
+      // the window the generation cannot see: while the reader types the next
+      // query its run has not started yet, so nothing has advanced the
+      // generation, and an answer to the query they have already left would
+      // publish under the text now in the box.
+      if (generation !== this.generation || this.query.value.trim() !== query) {
         return;
       }
 
@@ -225,7 +237,7 @@ export class DocsSearchDialogComponent {
       this.telemetry.trackSearch(query, results.length);
     } catch (error) {
       this.logging.logException(error);
-      if (generation !== this.generation) {
+      if (generation !== this.generation || this.query.value.trim() !== query) {
         return;
       }
 

--- a/src/app/documentation/docs-search/docs-search-dialog.component.ts
+++ b/src/app/documentation/docs-search/docs-search-dialog.component.ts
@@ -13,6 +13,7 @@ import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 import { Router } from '@angular/router';
 import { debounceTime, distinctUntilChanged, take } from 'rxjs/operators';
 
+import { LoggingService } from 'src/app/core/services/logging.service';
 import { DeferredSkeletonController } from 'src/app/shared/skeleton/deferred-skeleton';
 import { DocsTelemetryService } from '../docs-telemetry.service';
 import { DocSearchResult, DocsSearchService } from './docs-search.service';
@@ -38,6 +39,12 @@ export class DocsSearchDialogComponent {
   readonly active = signal(0);
   /** True once a search has run, so "no results" is not shown at rest. */
   readonly searched = signal(false);
+  /**
+   * True when the last owned search threw. The engine and the index arrive over
+   * the network, so a search CAN fail — and a palette that silently goes quiet
+   * looks like a query that matched nothing.
+   */
+  readonly failed = signal(false);
 
   private readonly skeleton = new DeferredSkeletonController();
   readonly loading = this.skeleton.visible;
@@ -45,9 +52,13 @@ export class DocsSearchDialogComponent {
   @ViewChild('input', { static: true })
   private readonly input?: ElementRef<HTMLInputElement>;
 
+  @ViewChild('list', { static: true })
+  private readonly list?: ElementRef<HTMLElement>;
+
   private readonly search = inject(DocsSearchService);
   private readonly telemetry = inject(DocsTelemetryService);
   private readonly router = inject(Router);
+  private readonly logging = inject(LoggingService);
   private readonly dialogRef = inject(MatDialogRef<DocsSearchDialogComponent>);
   private readonly data = inject<{ query?: string } | null>(MAT_DIALOG_DATA, {
     optional: true,
@@ -55,6 +66,28 @@ export class DocsSearchDialogComponent {
 
   /** The query the current results answer; reported with a result click. */
   private lastQuery = '';
+
+  /**
+   * Which invocation of `run` owns the displayed state.
+   *
+   * Comparing the query text instead would let an older `foo` commit after the
+   * box has gone `foo -> bar -> foo`, re-reporting the search and resetting the
+   * highlight under the reader. Only the newest invocation may publish.
+   */
+  private generation = 0;
+
+  /**
+   * One release per loader start that has not been handed back yet.
+   *
+   * A shared count is NOT enough: after `A -> clear -> B`, a late `stop()` from
+   * A would decrement the count B is holding and hide B's placeholder while B
+   * is still running. Each invocation gets its own idempotent release instead,
+   * so settling late is a no-op once that start has already been given back.
+   */
+  private readonly releases = new Set<() => void>();
+
+  /** Set once the dialog is closing to navigate; a second Enter must not add another. */
+  private navigating = false;
 
   constructor() {
     // The engine and index are ~55 KB and the reader is about to type into this
@@ -94,6 +127,9 @@ export class DocsSearchDialogComponent {
       this.active.set(
         (this.active() + delta + results.length) % results.length
       );
+      // The list scrolls at 12 results; without this the highlight walks off
+      // the bottom while focus — and so the viewport — stays on the input.
+      this.scrollActiveIntoView();
       return;
     }
 
@@ -106,6 +142,12 @@ export class DocsSearchDialogComponent {
 
   focusInput(): void {
     this.input?.nativeElement.focus();
+  }
+
+  /** Keeps the aria-activedescendant option inside the scrolling result list. */
+  private scrollActiveIntoView(): void {
+    const option = this.list?.nativeElement.children[this.active()];
+    option?.scrollIntoView?.({ block: 'nearest' });
   }
 
   /**
@@ -127,6 +169,15 @@ export class DocsSearchDialogComponent {
    * for, which is the one thing section-level results exist to avoid.
    */
   private closeThenNavigate(url: string): void {
+    // `close()` only starts the animation, so a held Enter or a double click
+    // gets here again while the first navigation is still waiting on it. Each
+    // pass would subscribe again and every subscription would fire on the one
+    // close, navigating two or three times.
+    if (this.navigating) {
+      return;
+    }
+    this.navigating = true;
+
     this.dialogRef
       .afterClosed()
       .pipe(take(1))
@@ -144,19 +195,25 @@ export class DocsSearchDialogComponent {
   private async run(raw: string): Promise<void> {
     const query = raw.trim();
 
+    const generation = ++this.generation;
+
     if (query.length < MIN_QUERY_LENGTH) {
       this.results.set([]);
       this.searched.set(false);
+      this.failed.set(false);
       this.lastQuery = '';
+      // Emptying the box ends the wait it described: leaving the placeholder up
+      // until a superseded search settles reads as a query that is still running.
+      this.releaseLoaders();
       return;
     }
 
-    this.skeleton.start();
+    const release = this.startLoader();
     try {
       const results = await this.search.search(query);
 
       // A slower earlier search must not overwrite a newer one's results.
-      if (this.query.value.trim() !== query) {
+      if (generation !== this.generation) {
         return;
       }
 
@@ -164,9 +221,46 @@ export class DocsSearchDialogComponent {
       this.results.set(results);
       this.active.set(0);
       this.searched.set(true);
+      this.failed.set(false);
       this.telemetry.trackSearch(query, results.length);
+    } catch (error) {
+      this.logging.logException(error);
+      if (generation !== this.generation) {
+        return;
+      }
+
+      // The old results answered a query that is no longer in the box, so they
+      // are cleared rather than left looking like an answer to this one.
+      this.results.set([]);
+      this.lastQuery = '';
+      this.searched.set(false);
+      this.failed.set(true);
     } finally {
+      release();
+    }
+  }
+
+  /** @returns the one release for this start; safe to call more than once */
+  private startLoader(): () => void {
+    this.skeleton.start();
+
+    let released = false;
+    const release = () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      this.releases.delete(release);
       this.skeleton.stop();
+    };
+
+    this.releases.add(release);
+    return release;
+  }
+
+  private releaseLoaders(): void {
+    for (const release of [...this.releases]) {
+      release();
     }
   }
 }

--- a/src/app/documentation/docs-search/docs-search-dialog.component.ts
+++ b/src/app/documentation/docs-search/docs-search-dialog.component.ts
@@ -1,0 +1,172 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  ElementRef,
+  ViewChild,
+  inject,
+  signal,
+} from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { Router } from '@angular/router';
+import { debounceTime, distinctUntilChanged, take } from 'rxjs/operators';
+
+import { DeferredSkeletonController } from 'src/app/shared/skeleton/deferred-skeleton';
+import { DocsTelemetryService } from '../docs-telemetry.service';
+import { DocSearchResult, DocsSearchService } from './docs-search.service';
+
+/** How long typing settles before a search runs, and a Docs_Search is logged. */
+const DEBOUNCE_MS = 250;
+
+/** Below this a query matches most of the corpus and means nothing. */
+const MIN_QUERY_LENGTH = 2;
+
+@Component({
+  selector: 'app-docs-search-dialog',
+  templateUrl: './docs-search-dialog.component.html',
+  styleUrls: ['./docs-search-dialog.component.scss'],
+  imports: [ReactiveFormsModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DocsSearchDialogComponent {
+  readonly query = new FormControl('', { nonNullable: true });
+
+  readonly results = signal<readonly DocSearchResult[]>([]);
+  /** Index of the keyboard-highlighted result. */
+  readonly active = signal(0);
+  /** True once a search has run, so "no results" is not shown at rest. */
+  readonly searched = signal(false);
+
+  private readonly skeleton = new DeferredSkeletonController();
+  readonly loading = this.skeleton.visible;
+
+  @ViewChild('input', { static: true })
+  private readonly input?: ElementRef<HTMLInputElement>;
+
+  private readonly search = inject(DocsSearchService);
+  private readonly telemetry = inject(DocsTelemetryService);
+  private readonly router = inject(Router);
+  private readonly dialogRef = inject(MatDialogRef<DocsSearchDialogComponent>);
+  private readonly data = inject<{ query?: string } | null>(MAT_DIALOG_DATA, {
+    optional: true,
+  });
+
+  /** The query the current results answer; reported with a result click. */
+  private lastQuery = '';
+
+  constructor() {
+    // The engine and index are ~55 KB and the reader is about to type into this
+    // box, so the import starts now rather than on the first keystroke.
+    this.search.preload();
+
+    this.query.valueChanges
+      .pipe(
+        debounceTime(DEBOUNCE_MS),
+        distinctUntilChanged(),
+        takeUntilDestroyed()
+      )
+      .subscribe((value) => void this.run(value));
+
+    inject(DestroyRef).onDestroy(() => this.skeleton.destroy());
+
+    // Opened from the sidebar box, which may already have something typed in it.
+    if (this.data?.query) {
+      this.query.setValue(this.data.query);
+    }
+  }
+
+  open(result: DocSearchResult, rank: number): void {
+    this.telemetry.trackSearchResultClick(this.lastQuery, result.path, rank);
+    this.closeThenNavigate(result.url);
+  }
+
+  /** Arrow keys move the highlight, Enter opens it. Escape is MatDialog's. */
+  onKeydown(event: KeyboardEvent): void {
+    const results = this.results();
+
+    if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+      event.preventDefault();
+      if (results.length === 0) return;
+      const delta = event.key === 'ArrowDown' ? 1 : -1;
+      // Wraps, so Up from the first result reaches the last one.
+      this.active.set(
+        (this.active() + delta + results.length) % results.length
+      );
+      return;
+    }
+
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      const result = results[this.active()];
+      if (result) this.open(result, this.active());
+    }
+  }
+
+  focusInput(): void {
+    this.input?.nativeElement.focus();
+  }
+
+  /**
+   * The zero-result path. A search that found nothing is the moment the reader
+   * knows exactly what they wanted and we do not have it, so it is the best
+   * place in the whole product to ask for that in their own words.
+   */
+  openFeedback(): void {
+    this.closeThenNavigate('/feedback');
+  }
+
+  /**
+   * Navigates only once the dialog has finished closing.
+   *
+   * MatDialog blocks scrolling while it is open by pinning `html` in place, and
+   * releasing that block RESTORES the scroll position the reader was at. A
+   * navigation to `#anchor` issued before then is scrolled correctly and then
+   * silently undone — the reader lands at the top of the page they searched
+   * for, which is the one thing section-level results exist to avoid.
+   */
+  private closeThenNavigate(url: string): void {
+    this.dialogRef
+      .afterClosed()
+      .pipe(take(1))
+      .subscribe(() => void this.router.navigateByUrl(url));
+    this.dialogRef.close();
+  }
+
+  /**
+   * Runs a search and reports it.
+   *
+   * `Docs_Search` is emitted for every settled query INCLUDING the ones that
+   * found nothing — a zero-result search is the most actionable row in the whole
+   * analytics set, since each one is something a real person expected to exist.
+   */
+  private async run(raw: string): Promise<void> {
+    const query = raw.trim();
+
+    if (query.length < MIN_QUERY_LENGTH) {
+      this.results.set([]);
+      this.searched.set(false);
+      this.lastQuery = '';
+      return;
+    }
+
+    this.skeleton.start();
+    try {
+      const results = await this.search.search(query);
+
+      // A slower earlier search must not overwrite a newer one's results.
+      if (this.query.value.trim() !== query) {
+        return;
+      }
+
+      this.lastQuery = query;
+      this.results.set(results);
+      this.active.set(0);
+      this.searched.set(true);
+      this.telemetry.trackSearch(query, results.length);
+    } finally {
+      this.skeleton.stop();
+    }
+  }
+}

--- a/src/app/documentation/docs-search/docs-search.opener.spec.ts
+++ b/src/app/documentation/docs-search/docs-search.opener.spec.ts
@@ -1,0 +1,94 @@
+import { TestBed } from '@angular/core/testing';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { Subject } from 'rxjs';
+
+import { DocsSearchDialogComponent } from './docs-search-dialog.component';
+import { DocsSearchOpener } from './docs-search.opener';
+
+describe('DocsSearchOpener', () => {
+  let opener: DocsSearchOpener;
+  let dialog: jasmine.SpyObj<MatDialog>;
+  let closed: Subject<unknown>;
+  let componentInstance: jasmine.SpyObj<DocsSearchDialogComponent>;
+
+  beforeEach(() => {
+    closed = new Subject();
+    componentInstance = jasmine.createSpyObj<DocsSearchDialogComponent>(
+      'DocsSearchDialogComponent',
+      ['focusInput']
+    );
+
+    const ref = {
+      afterClosed: () => closed.asObservable(),
+      componentInstance,
+    } as unknown as MatDialogRef<DocsSearchDialogComponent>;
+
+    dialog = jasmine.createSpyObj<MatDialog>('MatDialog', ['open']);
+    dialog.open.and.returnValue(ref as never);
+
+    TestBed.configureTestingModule({
+      providers: [DocsSearchOpener, { provide: MatDialog, useValue: dialog }],
+    });
+    opener = TestBed.inject(DocsSearchOpener);
+  });
+
+  it('opens the search dialog', () => {
+    opener.open();
+
+    expect(dialog.open).toHaveBeenCalledWith(
+      DocsSearchDialogComponent,
+      jasmine.any(Object)
+    );
+    expect(opener.isOpen).toBe(true);
+  });
+
+  it('does not stack a second dialog on the first', () => {
+    // Three entry points can fire — toolbar, sidebar, Ctrl+K — and the shortcut
+    // still works while the palette has focus.
+    opener.open();
+    opener.open();
+
+    expect(dialog.open).toHaveBeenCalledTimes(1);
+  });
+
+  it('puts the caret back in the box when asked again while open', () => {
+    opener.open();
+    opener.open();
+
+    expect(componentInstance.focusInput).toHaveBeenCalled();
+  });
+
+  it('can be reopened once closed', () => {
+    opener.open();
+    closed.next(undefined);
+
+    expect(opener.isOpen).toBe(false);
+
+    opener.open();
+    expect(dialog.open).toHaveBeenCalledTimes(2);
+  });
+
+  it('carries a query into the dialog', () => {
+    opener.open('spool');
+
+    expect(dialog.open.calls.mostRecent().args[1]?.data).toEqual({
+      query: 'spool',
+    });
+  });
+
+  it('passes no data when opened with nothing typed', () => {
+    opener.open();
+
+    expect(dialog.open.calls.mostRecent().args[1]?.data).toBeNull();
+  });
+
+  it('does not steal focus from the input on open', () => {
+    // The dialog focuses its own box via cdkFocusInitial; letting MatDialog
+    // autofocus the panel instead would put the caret nowhere.
+    expect(dialog.open).not.toHaveBeenCalled();
+
+    opener.open();
+
+    expect(dialog.open.calls.mostRecent().args[1]?.autoFocus).toBe(false);
+  });
+});

--- a/src/app/documentation/docs-search/docs-search.opener.spec.ts
+++ b/src/app/documentation/docs-search/docs-search.opener.spec.ts
@@ -82,13 +82,14 @@ describe('DocsSearchOpener', () => {
     expect(dialog.open.calls.mostRecent().args[1]?.data).toBeNull();
   });
 
-  it('does not steal focus from the input on open', () => {
-    // The dialog focuses its own box via cdkFocusInitial; letting MatDialog
-    // autofocus the panel instead would put the caret nowhere.
-    expect(dialog.open).not.toHaveBeenCalled();
-
+  it('puts the caret in the input on open', () => {
+    // `cdkFocusInitial` on the input is only consulted on the first-tabbable
+    // path; `autoFocus: false` focuses the panel element instead and leaves a
+    // palette opened with Ctrl+K with nowhere to type.
     opener.open();
 
-    expect(dialog.open.calls.mostRecent().args[1]?.autoFocus).toBe(false);
+    expect(dialog.open.calls.mostRecent().args[1]?.autoFocus).toBe(
+      'first-tabbable'
+    );
   });
 });

--- a/src/app/documentation/docs-search/docs-search.opener.ts
+++ b/src/app/documentation/docs-search/docs-search.opener.ts
@@ -1,0 +1,50 @@
+import { Injectable, inject } from '@angular/core';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+
+import { DocsSearchDialogComponent } from './docs-search-dialog.component';
+
+/**
+ * Opens the search palette, from wherever asked.
+ *
+ * There are three entry points — the toolbar button, the sidebar box, and the
+ * keyboard shortcut — and they must not be able to stack three dialogs on top of
+ * each other. The single open ref lives here rather than in any one of them.
+ */
+@Injectable()
+export class DocsSearchOpener {
+  private readonly dialog = inject(MatDialog);
+  private ref: MatDialogRef<DocsSearchDialogComponent> | null = null;
+
+  /**
+   * @param query text already typed elsewhere, carried into the palette so the
+   *   reader never types the same word twice
+   */
+  open(query?: string): void {
+    if (this.ref) {
+      // Already open: give it what was typed and put the caret back in it.
+      this.ref.componentInstance?.focusInput();
+      return;
+    }
+
+    this.ref = this.dialog.open(DocsSearchDialogComponent, {
+      data: query ? { query } : null,
+      width: 'min(40rem, 100vw - 2rem)',
+      maxWidth: '100vw',
+      // Top-anchored, the way every command palette is: centring it makes the
+      // results list move up the screen as it grows.
+      position: { top: '10vh' },
+      panelClass: 'docs-search-panel',
+      autoFocus: false,
+      restoreFocus: true,
+      ariaLabel: 'Search documentation',
+    });
+
+    this.ref.afterClosed().subscribe(() => {
+      this.ref = null;
+    });
+  }
+
+  get isOpen(): boolean {
+    return this.ref !== null;
+  }
+}

--- a/src/app/documentation/docs-search/docs-search.opener.ts
+++ b/src/app/documentation/docs-search/docs-search.opener.ts
@@ -22,7 +22,11 @@ export class DocsSearchOpener {
   open(query?: string): void {
     if (this.ref) {
       // Already open: give it what was typed and put the caret back in it.
-      this.ref.componentInstance?.focusInput();
+      const instance = this.ref.componentInstance;
+      if (query) {
+        instance?.query.setValue(query);
+      }
+      instance?.focusInput();
       return;
     }
 
@@ -34,7 +38,10 @@ export class DocsSearchOpener {
       // results list move up the screen as it grows.
       position: { top: '10vh' },
       panelClass: 'docs-search-panel',
-      autoFocus: false,
+      // Honours the input's `cdkFocusInitial`. `false` does NOT mean "leave
+      // focus alone": MatDialog then focuses the panel element itself, and a
+      // palette opened with Ctrl+K would put the caret nowhere.
+      autoFocus: 'first-tabbable',
       restoreFocus: true,
       ariaLabel: 'Search documentation',
     });

--- a/src/app/documentation/docs-search/docs-search.service.spec.ts
+++ b/src/app/documentation/docs-search/docs-search.service.spec.ts
@@ -1,0 +1,105 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DocsSearchService } from './docs-search.service';
+
+/**
+ * Run against the REAL generated index, not a fixture.
+ *
+ * The thing most likely to break here is not the wiring but the corpus: a
+ * retitled page or a reworded section can quietly stop answering a query people
+ * actually type. A fixture would keep passing through all of that.
+ *
+ * It also exercises the two dynamic imports, which is the part that only fails
+ * in a real bundle.
+ */
+describe('DocsSearchService', () => {
+  let service: DocsSearchService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [DocsSearchService] });
+    service = TestBed.inject(DocsSearchService);
+  });
+
+  it('finds a page by a word from its title', async () => {
+    const results = await service.search('materials');
+
+    expect(results.length).toBeGreaterThan(0);
+    expect(results.some((r) => r.path === 'docs/materials')).toBe(true);
+  });
+
+  it('finds a release note by its subject, not just its version', async () => {
+    // The reason the index is cut into sections: this text lives 78 KB down a
+    // single page, under one of 155 headings.
+    const results = await service.search('spool photos');
+
+    expect(results.some((r) => r.url.includes('#v1.48.0'))).toBe(true);
+  });
+
+  it('deep-links to the section it matched', async () => {
+    const results = await service.search('spool photos');
+    const hit = results.find((r) => r.url.includes('#v1.48.0'))!;
+
+    expect(hit.url).toBe('/docs/release-notes#v1.48.0');
+    expect(hit.page).toBe('Release Notes');
+  });
+
+  it('returns an excerpt that contains what was searched for', async () => {
+    const results = await service.search('spool photos');
+    const hit = results.find((r) => r.url.includes('#v1.48.0'))!;
+
+    expect(hit.excerpt.toLowerCase()).toContain('photo');
+  });
+
+  it('tolerates a typo in a word long enough to be sure about', async () => {
+    const results = await service.search('matreials');
+
+    expect(results.length).toBeGreaterThan(0);
+  });
+
+  it('matches on a prefix, so results appear while still typing', async () => {
+    const results = await service.search('printe');
+
+    expect(results.length).toBeGreaterThan(0);
+  });
+
+  it('requires every term, so adding a word narrows rather than widens', async () => {
+    const broad = await service.search('material');
+    const narrow = await service.search('material qr code');
+
+    expect(narrow.length).toBeLessThan(broad.length);
+  });
+
+  it('returns nothing for a query too short to mean anything', async () => {
+    expect(await service.search('a')).toEqual([]);
+    expect(await service.search(' ')).toEqual([]);
+  });
+
+  it('returns nothing rather than throwing for a query that matches nothing', async () => {
+    // This is the zero-result path the analytics care most about, so it has to
+    // be an ordinary empty list, not an error.
+    expect(await service.search('zzzzqqqxyzzy')).toEqual([]);
+  });
+
+  it('caps the result list', async () => {
+    const results = await service.search('the');
+
+    expect(results.length).toBeLessThanOrEqual(12);
+  });
+
+  it('gives every result a unique id, so the list can track by it', async () => {
+    const results = await service.search('print');
+
+    expect(new Set(results.map((r) => r.id)).size).toBe(results.length);
+  });
+
+  it('builds the engine once across concurrent first searches', async () => {
+    // Two keystrokes can race the very first import; starting two builds would
+    // parse and index the whole corpus twice.
+    const [a, b] = await Promise.all([
+      service.search('materials'),
+      service.search('materials'),
+    ]);
+
+    expect(a).toEqual(b);
+  });
+});

--- a/src/app/documentation/docs-search/docs-search.service.ts
+++ b/src/app/documentation/docs-search/docs-search.service.ts
@@ -1,0 +1,115 @@
+import { Injectable } from '@angular/core';
+
+import type { DocSearchSection } from './docs-search.types';
+import { excerptFor } from './docs-search.types';
+
+/** What the UI renders for one hit. */
+export interface DocSearchResult {
+  readonly id: string;
+  readonly title: string;
+  readonly page: string;
+  readonly url: string;
+  readonly path: string;
+  /** A window of the section's text around the match, for display only. */
+  readonly excerpt: string;
+}
+
+/** Nothing below this scores as a real match; MiniSearch will rank noise. */
+const MAX_RESULTS = 12;
+
+/**
+ * Client-side search over the generated section index.
+ *
+ * Both the engine and the index are pulled in by `import()` on the first
+ * search, never at construction. Together they are ~55 KB gzipped, and the
+ * overwhelming majority of docs visitors never search — putting either in the
+ * eager bundle would undo the bundle-splitting work this app already did.
+ *
+ * Not provided in root: it belongs to DocumentationModule, so the class itself
+ * is in the lazy docs chunk rather than the main one.
+ */
+@Injectable()
+export class DocsSearchService {
+  /**
+   * The load, kept as the promise rather than the result. Two searches racing
+   * on the first keystrokes must await one import, not start two.
+   */
+  private engine: Promise<SearchEngine> | null = null;
+
+  /**
+   * @returns ranked results, best first; empty when the query is too short to
+   *   mean anything or nothing matched
+   */
+  async search(query: string): Promise<DocSearchResult[]> {
+    const trimmed = query.trim();
+    if (trimmed.length < 2) {
+      return [];
+    }
+
+    const engine = await this.load();
+    return engine.search(trimmed);
+  }
+
+  /**
+   * Warms the engine without searching. Called when the palette opens so the
+   * chunk is usually in flight before the first keystroke lands.
+   */
+  preload(): void {
+    void this.load().catch(() => undefined);
+  }
+
+  private load(): Promise<SearchEngine> {
+    // A failed import must not be cached as a permanently broken engine, so the
+    // slot is cleared on rejection and the next search retries.
+    this.engine ??= buildEngine().catch((error) => {
+      this.engine = null;
+      throw error;
+    });
+    return this.engine;
+  }
+}
+
+interface SearchEngine {
+  search(query: string): DocSearchResult[];
+}
+
+async function buildEngine(): Promise<SearchEngine> {
+  const [{ default: MiniSearch }, { default: sections }] = await Promise.all([
+    import('minisearch'),
+    import('../generated/docs-search-index.json'),
+  ]);
+
+  const corpus = sections as DocSearchSection[];
+
+  const index = new MiniSearch<DocSearchSection>({
+    fields: ['title', 'page', 'text'],
+    storeFields: ['title', 'page', 'url', 'path', 'text'],
+    searchOptions: {
+      // A heading is a far stronger signal than a mention buried in prose, and
+      // the page name lets "materials qr" find a section of the materials page.
+      boost: { title: 4, page: 2 },
+      prefix: true,
+      // Typo tolerance that scales with the word: too aggressive on short words
+      // turns "qr" into a match for everything.
+      fuzzy: (term) => (term.length > 4 ? 0.2 : 0),
+      combineWith: 'AND',
+    },
+  });
+
+  index.addAll(corpus);
+
+  return {
+    search(query: string): DocSearchResult[] {
+      const hits = index.search(query).slice(0, MAX_RESULTS);
+
+      return hits.map((hit) => ({
+        id: String(hit.id),
+        title: hit['title'] as string,
+        page: hit['page'] as string,
+        url: hit['url'] as string,
+        path: hit['path'] as string,
+        excerpt: excerptFor(hit['text'] as string, query),
+      }));
+    },
+  };
+}

--- a/src/app/documentation/docs-search/docs-search.types.spec.ts
+++ b/src/app/documentation/docs-search/docs-search.types.spec.ts
@@ -1,0 +1,59 @@
+import { excerptFor } from './docs-search.types';
+
+describe('excerptFor', () => {
+  const long = (filler: string, word: string) =>
+    `${filler.repeat(40)} ${word} ${filler.repeat(40)}`;
+
+  it('returns a short section unchanged', () => {
+    expect(excerptFor('Log a print.', 'print')).toBe('Log a print.');
+  });
+
+  it('returns nothing for a section with no text', () => {
+    // A heading immediately followed by a subheading indexes with empty text.
+    expect(excerptFor('', 'print')).toBe('');
+  });
+
+  it('centres the window on the match, not on the start of the section', () => {
+    // The whole point: on a 5,000-character release note the searched words can
+    // be paragraphs down, and an excerpt without them reads as a bad result.
+    const excerpt = excerptFor(long('filler ', 'kryptonite'), 'kryptonite');
+
+    expect(excerpt).toContain('kryptonite');
+  });
+
+  it('marks both ends of a window taken from the middle', () => {
+    const excerpt = excerptFor(long('filler ', 'kryptonite'), 'kryptonite');
+
+    expect(excerpt.startsWith('…')).toBe(true);
+    expect(excerpt.endsWith('…')).toBe(true);
+  });
+
+  it('falls back to the opening when no term appears in the text', () => {
+    // MiniSearch matches stems and prefixes, so a hit can have no literal
+    // occurrence of what was typed.
+    const excerpt = excerptFor(long('filler ', 'kryptonite'), 'zzz');
+
+    expect(excerpt.startsWith('…')).toBe(false);
+    expect(excerpt.endsWith('…')).toBe(true);
+  });
+
+  it('uses the earliest of several query terms', () => {
+    const text = `alpha ${'pad '.repeat(80)} omega ${'pad '.repeat(80)}`;
+    const excerpt = excerptFor(text, 'omega alpha');
+
+    expect(excerpt).toContain('alpha');
+  });
+
+  it('matches case-insensitively', () => {
+    const excerpt = excerptFor(long('filler ', 'Kryptonite'), 'KRYPTONITE');
+
+    expect(excerpt).toContain('Kryptonite');
+  });
+
+  it('does not open mid-word', () => {
+    const excerpt = excerptFor(long('filler ', 'kryptonite'), 'kryptonite');
+    const firstWord = excerpt.replace(/^…/, '').split(' ')[0];
+
+    expect(['filler', 'kryptonite']).toContain(firstWord);
+  });
+});

--- a/src/app/documentation/docs-search/docs-search.types.ts
+++ b/src/app/documentation/docs-search/docs-search.types.ts
@@ -1,0 +1,70 @@
+/**
+ * One entry of `generated/docs-search-index.json` — a heading section, not a
+ * page. Shape is fixed by `sectionsOf` in scripts/docs-emit.mjs.
+ */
+export interface DocSearchSection {
+  readonly id: string;
+  readonly path: string;
+  /** Route plus the section's anchor, when its heading declares one. */
+  readonly url: string;
+  readonly title: string;
+  /** The nav label of the page this section belongs to. */
+  readonly page: string;
+  readonly group: string;
+  readonly text: string;
+}
+
+/** Characters of context shown around a match. */
+const EXCERPT_LENGTH = 160;
+
+/**
+ * A window of `text` around the first query term that appears in it.
+ *
+ * The opening sentence is usually the wrong thing to show: on a 5,000-character
+ * release note the words the reader searched for can be paragraphs down, and an
+ * excerpt that does not contain them reads as an irrelevant result.
+ */
+export function excerptFor(text: string, query: string): string {
+  if (!text) {
+    return '';
+  }
+  if (text.length <= EXCERPT_LENGTH) {
+    return text;
+  }
+
+  const at = firstTermIndex(text, query);
+  if (at < 0) {
+    return `${cut(text, 0, EXCERPT_LENGTH)}…`;
+  }
+
+  // Centre the window on the match, then pull back to a word boundary so the
+  // excerpt does not open mid-word.
+  const start = Math.max(0, at - Math.floor(EXCERPT_LENGTH / 3));
+  const from = start === 0 ? 0 : wordBoundaryAfter(text, start);
+  const body = cut(text, from, EXCERPT_LENGTH);
+
+  return `${from > 0 ? '…' : ''}${body}${from + body.length < text.length ? '…' : ''}`;
+}
+
+/** Where the earliest query term occurs, or -1. */
+function firstTermIndex(text: string, query: string): number {
+  const haystack = text.toLowerCase();
+  let earliest = -1;
+
+  for (const term of query.toLowerCase().split(/\s+/).filter(Boolean)) {
+    const at = haystack.indexOf(term);
+    if (at >= 0 && (earliest < 0 || at < earliest)) {
+      earliest = at;
+    }
+  }
+  return earliest;
+}
+
+function wordBoundaryAfter(text: string, from: number): number {
+  const space = text.indexOf(' ', from);
+  return space < 0 || space - from > 20 ? from : space + 1;
+}
+
+function cut(text: string, from: number, length: number): string {
+  return text.slice(from, from + length).trim();
+}

--- a/src/app/documentation/docs-search/keyboard-shortcut.spec.ts
+++ b/src/app/documentation/docs-search/keyboard-shortcut.spec.ts
@@ -1,0 +1,70 @@
+import {
+  isApplePlatform,
+  isSearchShortcut,
+  shortcutLabel,
+} from './keyboard-shortcut';
+
+describe('docs search keyboard shortcut', () => {
+  const chord = (over: Partial<KeyboardEvent> = {}) => ({
+    key: 'k',
+    metaKey: false,
+    ctrlKey: true,
+    shiftKey: false,
+    altKey: false,
+    ...over,
+  });
+
+  describe('isApplePlatform', () => {
+    it('recognizes the platforms that expect Cmd', () => {
+      for (const platform of ['MacIntel', 'iPhone', 'iPad', 'iPod touch']) {
+        expect(isApplePlatform(platform)).withContext(platform).toBe(true);
+      }
+    });
+
+    it('treats everything else as a Ctrl platform', () => {
+      for (const platform of ['Win32', 'Linux x86_64', '']) {
+        expect(isApplePlatform(platform)).withContext(platform).toBe(false);
+      }
+    });
+
+    it('handles an absent platform string', () => {
+      // navigator.platform is deprecated and may be missing entirely.
+      expect(isApplePlatform(undefined)).toBe(false);
+    });
+  });
+
+  describe('shortcutLabel', () => {
+    it('uses the modifier the reader expects', () => {
+      expect(shortcutLabel(true)).toBe('⌘K');
+      expect(shortcutLabel(false)).toBe('Ctrl K');
+    });
+  });
+
+  describe('isSearchShortcut', () => {
+    it('accepts Ctrl+K and Cmd+K', () => {
+      expect(isSearchShortcut(chord())).toBe(true);
+      expect(isSearchShortcut(chord({ ctrlKey: false, metaKey: true }))).toBe(
+        true
+      );
+    });
+
+    it('accepts a capital K, as Caps Lock produces', () => {
+      expect(isSearchShortcut(chord({ key: 'K' }))).toBe(true);
+    });
+
+    it('ignores K with no modifier, which is just typing', () => {
+      expect(isSearchShortcut(chord({ ctrlKey: false }))).toBe(false);
+    });
+
+    it('leaves the browser its own Ctrl+Shift+K and Alt+K', () => {
+      expect(isSearchShortcut(chord({ shiftKey: true }))).toBe(false);
+      expect(isSearchShortcut(chord({ altKey: true }))).toBe(false);
+    });
+
+    it('does not bind slash', () => {
+      // Readers type slashes into the search box and into the code samples on
+      // the integration pages.
+      expect(isSearchShortcut(chord({ key: '/', ctrlKey: false }))).toBe(false);
+    });
+  });
+});

--- a/src/app/documentation/docs-search/keyboard-shortcut.ts
+++ b/src/app/documentation/docs-search/keyboard-shortcut.ts
@@ -1,0 +1,38 @@
+/**
+ * True for the platforms whose users expect Cmd rather than Ctrl.
+ *
+ * Takes the platform string rather than reading `navigator` itself, so it stays
+ * pure and every caller owns its own SSR guard — `/docs` is prerendered in Node,
+ * where there is no navigator to ask.
+ */
+export function isApplePlatform(platform: string | undefined): boolean {
+  return /Mac|iPhone|iPad|iPod/i.test(platform ?? '');
+}
+
+/** `⌘K` or `Ctrl K`, for a label the reader has to recognise at a glance. */
+export function shortcutLabel(isApple: boolean): string {
+  return isApple ? '⌘K' : 'Ctrl K';
+}
+
+/**
+ * Whether a keydown is the "open search" chord.
+ *
+ * `/` is deliberately not accepted: readers type slashes into the search box
+ * and into the code samples on the integration pages, and stealing it from a
+ * text field is the classic version of this bug. Shift and Alt are excluded so
+ * the browser keeps its own Ctrl+Shift+K and Alt+K bindings.
+ */
+export function isSearchShortcut(event: {
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+}): boolean {
+  return (
+    (event.key === 'k' || event.key === 'K') &&
+    (event.metaKey || event.ctrlKey) &&
+    !event.shiftKey &&
+    !event.altKey
+  );
+}

--- a/src/app/documentation/docs-telemetry.service.spec.ts
+++ b/src/app/documentation/docs-telemetry.service.spec.ts
@@ -305,4 +305,94 @@ describe('DocsTelemetryService', () => {
       expect((props['comment'] as string).length).toBe(1000);
     });
   });
+
+  describe('trackSearch', () => {
+    it('reports the query and how many results it found', () => {
+      const service = configure();
+
+      service.trackSearch('spool photos', 4);
+
+      expect(logging.logEvent).toHaveBeenCalledWith('Docs_Search', {
+        query: 'spool photos',
+        resultCount: 4,
+      });
+    });
+
+    it('reports a search that found nothing', () => {
+      // This is the row zero-result-searches.kql exists to surface: something a
+      // real person expected to find and could not.
+      const service = configure();
+
+      service.trackSearch('kryptonite', 0);
+
+      expect(logging.logEvent).toHaveBeenCalledWith('Docs_Search', {
+        query: 'kryptonite',
+        resultCount: 0,
+      });
+    });
+
+    it('trims the query, so the same search groups as one row', () => {
+      const service = configure();
+
+      service.trackSearch('  spool  ', 1);
+
+      expect(propsOf(0)['query']).toBe('spool');
+    });
+
+    it('reports nothing for an empty query', () => {
+      const service = configure();
+
+      service.trackSearch('   ', 0);
+
+      expect(logging.logEvent).not.toHaveBeenCalled();
+    });
+
+    it('caps a pasted query', () => {
+      const service = configure();
+
+      service.trackSearch('x'.repeat(5000), 0);
+
+      expect((propsOf(0)['query'] as string).length).toBe(200);
+    });
+  });
+
+  describe('trackSearchResultClick', () => {
+    it('reports the query, the page opened, and its rank', () => {
+      const service = configure();
+
+      service.trackSearchResultClick('spool photos', 'docs/release-notes', 2);
+
+      expect(logging.logEvent).toHaveBeenCalledWith('Docs_SearchResultClick', {
+        query: 'spool photos',
+        slug: 'release-notes',
+        rank: 2,
+      });
+    });
+
+    it('reports the top result as rank 0', () => {
+      const service = configure();
+
+      service.trackSearchResultClick('materials', 'docs/materials', 0);
+
+      expect(propsOf(0)['rank']).toBe(0);
+    });
+
+    it('reduces the path to the slug the other docs events use', () => {
+      // Every other Docs_* event keys on the slug; a full path here would not
+      // join against them.
+      const service = configure();
+
+      service.trackSearchResultClick('a', 'docs/materials', 0);
+
+      expect(propsOf(0)['slug']).toBe('materials');
+    });
+
+    it('caps a pasted query', () => {
+      const service = configure();
+
+      service.trackSearchResultClick('x'.repeat(5000), 'docs/materials', 0);
+
+      expect((propsOf(0)['query'] as string).length).toBe(200);
+    });
+  });
 });

--- a/src/app/documentation/docs-telemetry.service.spec.ts
+++ b/src/app/documentation/docs-telemetry.service.spec.ts
@@ -434,6 +434,11 @@ describe('isReportableQuery', () => {
       'api/Moonraker/notifier',
       'OctoPrint-Webhook',
       '3d_print_log',
+      // Ordinary phrasing: a trailing mark is punctuation, not evidence.
+      "why won't my print stick?",
+      'C++',
+      'error: missing_refresh_token',
+      'how do I connect my klipper printer to the print log app',
     ]) {
       expect(isReportableQuery(query)).withContext(query).toBe(true);
     }
@@ -453,8 +458,13 @@ describe('isReportableQuery', () => {
       '--client-id uzxvtpefYIrWoYbaJteoRzZtIYw4wP7j',
       // Short enough to pass the length cap, still shaped like a key.
       'aB3xK9mQ2pL7wR4t',
-      // Ten words is a command; more than that is prose.
-      'how do I connect my klipper printer to the print log app',
+      // An assignment is the only thing marking these as secret: sixteen
+      // lowercase characters clear both the length cap and the token test.
+      'password=hunter2',
+      'api_key=abcdef123456',
+      // A URL keeps its colon mid-word, so trimming trailing marks cannot
+      // rescue it.
+      'https://api.3dprintlog.com/mcp?token=abc',
     ]) {
       expect(isReportableQuery(query))
         .withContext(JSON.stringify(query.slice(0, 40)))

--- a/src/app/documentation/docs-telemetry.service.spec.ts
+++ b/src/app/documentation/docs-telemetry.service.spec.ts
@@ -3,6 +3,8 @@ import { TestBed } from '@angular/core/testing';
 import { LoggingService } from 'src/app/core/services/logging.service';
 import {
   DocsTelemetryService,
+  REDACTED_QUERY,
+  isReportableQuery,
   scrollPercentOf,
 } from './docs-telemetry.service';
 
@@ -347,12 +349,23 @@ describe('DocsTelemetryService', () => {
       expect(logging.logEvent).not.toHaveBeenCalled();
     });
 
-    it('caps a pasted query', () => {
+    it('redacts a pasted query but still counts the search', () => {
       const service = configure();
 
       service.trackSearch('x'.repeat(5000), 0);
 
-      expect((propsOf(0)['query'] as string).length).toBe(200);
+      expect(propsOf(0)['query']).toBe(REDACTED_QUERY);
+      // The row still has to reach zero-result-searches.kql: a search that
+      // found nothing counts even when its text cannot be reported.
+      expect(propsOf(0)['resultCount']).toBe(0);
+    });
+
+    it('redacts something that looks like a credential', () => {
+      const service = configure();
+
+      service.trackSearch('uzxvtpefYIrWoYbaJteoRzZtIYw4wP7j', 0);
+
+      expect(propsOf(0)['query']).toBe(REDACTED_QUERY);
     });
   });
 
@@ -387,12 +400,65 @@ describe('DocsTelemetryService', () => {
       expect(propsOf(0)['slug']).toBe('materials');
     });
 
-    it('caps a pasted query', () => {
+    it('redacts a pasted query', () => {
       const service = configure();
 
       service.trackSearchResultClick('x'.repeat(5000), 'docs/materials', 0);
 
-      expect((propsOf(0)['query'] as string).length).toBe(200);
+      expect(propsOf(0)['query']).toBe(REDACTED_QUERY);
     });
+  });
+});
+
+describe('isReportableQuery', () => {
+  // The docs cover auth setup and the MCP page ships a real client ID, so the
+  // palette is one keystroke away from a reader holding a credential. This
+  // allows ordinary words rather than blocking known secret shapes, so an
+  // unfamiliar format fails closed instead of passing through.
+  it('reports the queries worth reading', () => {
+    for (const query of [
+      'qr code',
+      'filament cost',
+      'klipper macro',
+      "printer's nozzle",
+      'multi-material',
+      'G-code',
+      'Fehlerbehebung',
+      // Command shapes: the reader who searches a flag is the reader the
+      // integration pages are written for, and an empty analytics row for
+      // them is the blind spot this list exists to avoid.
+      '--callback-port',
+      '--callback-port 8400',
+      'claude mcp add --transport http printlog',
+      'X-Api-Key',
+      'api/Moonraker/notifier',
+      'OctoPrint-Webhook',
+      '3d_print_log',
+    ]) {
+      expect(isReportableQuery(query)).withContext(query).toBe(true);
+    }
+  });
+
+  it('withholds anything that does not read as typed words', () => {
+    for (const query of [
+      'uzxvtpefYIrWoYbaJteoRzZtIYw4wP7j',
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIn0',
+      'csh.hoffman@gmail.com',
+      'https://api.3dprintlog.com/mcp',
+      'x'.repeat(5000),
+      '',
+      '   ',
+      // A flag carrying a real credential is still withheld: widening the
+      // character class for commands must not widen it for what follows one.
+      '--client-id uzxvtpefYIrWoYbaJteoRzZtIYw4wP7j',
+      // Short enough to pass the length cap, still shaped like a key.
+      'aB3xK9mQ2pL7wR4t',
+      // Ten words is a command; more than that is prose.
+      'how do I connect my klipper printer to the print log app',
+    ]) {
+      expect(isReportableQuery(query))
+        .withContext(JSON.stringify(query.slice(0, 40)))
+        .toBe(false);
+    }
   });
 });

--- a/src/app/documentation/docs-telemetry.service.ts
+++ b/src/app/documentation/docs-telemetry.service.ts
@@ -48,6 +48,13 @@ const DEPTH_BUCKETS = [25, 50, 75, 100] as const;
 const MAX_COMMENT_LENGTH = 1000;
 
 /**
+ * Cap on a reported search query. Real queries are a few words; anything longer
+ * is a paste, and `zero-result-searches.kql` groups on this value so an
+ * unbounded one would also make its own row forever.
+ */
+const MAX_QUERY_LENGTH = 200;
+
+/**
  * Emits the Phase 0 documentation telemetry events.
  *
  * Everything goes through `LoggingService`, which already no-ops without a
@@ -126,6 +133,40 @@ export class DocsTelemetryService {
       slug: slug || (this.currentSlug ?? 'unknown'),
       helpful,
       ...(trimmed ? { comment: trimmed.slice(0, MAX_COMMENT_LENGTH) } : {}),
+    });
+  }
+
+  /**
+   * A settled search. Emitted for zero-result queries too — `zero-result-searches.kql`
+   * is the most actionable query in the whole analytics set, and it is fed
+   * entirely by the searches that found nothing.
+   *
+   * The query is truncated like feedback is: an accidental paste must not
+   * become the telemetry payload.
+   */
+  trackSearch(query: string, resultCount: number): void {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    this.logging.logEvent('Docs_Search', {
+      query: trimmed.slice(0, MAX_QUERY_LENGTH),
+      resultCount,
+    });
+  }
+
+  /**
+   * A result the reader actually opened.
+   *
+   * `rank` is 0-based, matching the position in the rendered list.
+   * `search-quality.kql` averages it to see how far down the useful answer sits.
+   */
+  trackSearchResultClick(query: string, slug: string, rank: number): void {
+    this.logging.logEvent('Docs_SearchResultClick', {
+      query: query.trim().slice(0, MAX_QUERY_LENGTH),
+      slug: slugFromDocsUrl(slug),
+      rank,
     });
   }
 

--- a/src/app/documentation/docs-telemetry.service.ts
+++ b/src/app/documentation/docs-telemetry.service.ts
@@ -60,9 +60,11 @@ export const REDACTED_QUERY = '[redacted]';
 /**
  * Longest reported query, in words. Real ones are two or three; a command
  * fragment such as `claude mcp add --transport http printlog` runs longer, and
- * those are worth seeing. Past this it is a paste of prose.
+ * so does a question typed out in full — "how do I connect my klipper printer
+ * to the print log app" is exactly the zero-result row worth reading. Past
+ * this it is a paste rather than a question.
  */
-const MAX_QUERY_WORDS = 10;
+const MAX_QUERY_WORDS = 16;
 
 /** Longest single word. "troubleshooting" is 15; an API key is not a word. */
 const MAX_QUERY_WORD_LENGTH = 24;
@@ -74,8 +76,13 @@ const MAX_QUERY_WORD_LENGTH = 24;
  * `:` and `@` are deliberately absent. They are what make a URL a URL and an
  * address an address, and excluding them is what keeps a pasted signed link or
  * email out of telemetry while the flags stay readable.
+ *
+ * So is `=`. `password=hunter2` is sixteen ordinary lowercase characters — it
+ * clears the length cap and it is not mixed-case enough to read as generated,
+ * so the assignment itself is the only thing marking it as a secret. Nothing
+ * a reader searches for needs one.
  */
-const REPORTABLE_WORD = /^[\p{L}\p{N}'\-_./=]+$/u;
+const REPORTABLE_WORD = /^[\p{L}\p{N}'\-_./+]+$/u;
 
 /** Shortest word that is long enough to be worth checking for key-ness. */
 const TOKEN_MIN_LENGTH = 16;
@@ -111,7 +118,7 @@ function looksLikeToken(word: string): boolean {
  * all pass it.
  */
 export function isReportableQuery(query: string): boolean {
-  const words = query.split(/\s+/).filter(Boolean);
+  const words = query.split(/\s+/).filter(Boolean).map(trimSentencePunctuation);
 
   return (
     words.length > 0 &&
@@ -123,6 +130,19 @@ export function isReportableQuery(query: string): boolean {
         !looksLikeToken(word)
     )
   );
+}
+
+/**
+ * Drops the punctuation that ends a word in a sentence, so ordinary phrasing
+ * is judged on the word itself.
+ *
+ * "why won't my print stick?" and "error: missing_refresh_token" are the shape
+ * of a real docs search, and both were being withheld over one trailing mark.
+ * Only trailing marks go: a `:` in the MIDDLE of a word is still what makes
+ * `https://…` a URL, and that has to stay disqualifying.
+ */
+function trimSentencePunctuation(word: string): string {
+  return word.replace(/[.,;:!?]+$/, '');
 }
 
 /** The query as reported: itself, or a marker that still counts as a search. */

--- a/src/app/documentation/docs-telemetry.service.ts
+++ b/src/app/documentation/docs-telemetry.service.ts
@@ -54,6 +54,84 @@ const MAX_COMMENT_LENGTH = 1000;
  */
 const MAX_QUERY_LENGTH = 200;
 
+/** Stands in for a query that did not look like something a person typed. */
+export const REDACTED_QUERY = '[redacted]';
+
+/**
+ * Longest reported query, in words. Real ones are two or three; a command
+ * fragment such as `claude mcp add --transport http printlog` runs longer, and
+ * those are worth seeing. Past this it is a paste of prose.
+ */
+const MAX_QUERY_WORDS = 10;
+
+/** Longest single word. "troubleshooting" is 15; an API key is not a word. */
+const MAX_QUERY_WORD_LENGTH = 24;
+
+/**
+ * Letters, digits, and the punctuation that appears in words, flags and paths —
+ * so `--callback-port`, `X-Api-Key` and `api/Moonraker` all report as typed.
+ *
+ * `:` and `@` are deliberately absent. They are what make a URL a URL and an
+ * address an address, and excluding them is what keeps a pasted signed link or
+ * email out of telemetry while the flags stay readable.
+ */
+const REPORTABLE_WORD = /^[\p{L}\p{N}'\-_./=]+$/u;
+
+/** Shortest word that is long enough to be worth checking for key-ness. */
+const TOKEN_MIN_LENGTH = 16;
+
+/**
+ * Whether a word reads as a generated key rather than something typed.
+ *
+ * The length cap alone stops a 32-character client ID, but not a shorter one.
+ * Mixed case AND digits AND length together is the shape of a generated
+ * secret; ordinary long words are one case (`troubleshooting`), and named
+ * things keep their case without digits (`OctoPrint-Webhook`).
+ */
+function looksLikeToken(word: string): boolean {
+  return (
+    word.length >= TOKEN_MIN_LENGTH &&
+    /\p{Ll}/u.test(word) &&
+    /\p{Lu}/u.test(word) &&
+    /\p{N}/u.test(word)
+  );
+}
+
+/**
+ * Whether a query is safe to report as written.
+ *
+ * The docs cover auth setup and the MCP page ships a real client ID, so a
+ * reader can plausibly paste a token, an email, or a signed URL into the
+ * palette — and `logEvent` would carry it straight to App Insights.
+ *
+ * This allows rather than blocks. A blocklist of things that look secret has
+ * to recognise every format a secret can take and fails open on the next one;
+ * a shape test for "a few ordinary words" fails closed instead, and the
+ * queries worth reading — `qr code`, `filament cost`, `--callback-port` —
+ * all pass it.
+ */
+export function isReportableQuery(query: string): boolean {
+  const words = query.split(/\s+/).filter(Boolean);
+
+  return (
+    words.length > 0 &&
+    words.length <= MAX_QUERY_WORDS &&
+    words.every(
+      (word) =>
+        word.length <= MAX_QUERY_WORD_LENGTH &&
+        REPORTABLE_WORD.test(word) &&
+        !looksLikeToken(word)
+    )
+  );
+}
+
+/** The query as reported: itself, or a marker that still counts as a search. */
+function reportableQuery(query: string): string {
+  return isReportableQuery(query)
+    ? query.slice(0, MAX_QUERY_LENGTH)
+    : REDACTED_QUERY;
+}
+
 /**
  * Emits the Phase 0 documentation telemetry events.
  *
@@ -141,8 +219,8 @@ export class DocsTelemetryService {
    * is the most actionable query in the whole analytics set, and it is fed
    * entirely by the searches that found nothing.
    *
-   * The query is truncated like feedback is: an accidental paste must not
-   * become the telemetry payload.
+   * The query is reported only when it looks like something a person typed;
+   * see `isReportableQuery`. An accidental paste must not become the payload.
    */
   trackSearch(query: string, resultCount: number): void {
     const trimmed = query.trim();
@@ -150,8 +228,10 @@ export class DocsTelemetryService {
       return;
     }
 
+    // Redacted rather than dropped: a search that found nothing still counts
+    // toward the zero-result rate even when its text cannot be reported.
     this.logging.logEvent('Docs_Search', {
-      query: trimmed.slice(0, MAX_QUERY_LENGTH),
+      query: reportableQuery(trimmed),
       resultCount,
     });
   }
@@ -164,7 +244,7 @@ export class DocsTelemetryService {
    */
   trackSearchResultClick(query: string, slug: string, rank: number): void {
     this.logging.logEvent('Docs_SearchResultClick', {
-      query: query.trim().slice(0, MAX_QUERY_LENGTH),
+      query: reportableQuery(query.trim()),
       slug: slugFromDocsUrl(slug),
       rank,
     });

--- a/src/app/documentation/documentation.component.html
+++ b/src/app/documentation/documentation.component.html
@@ -4,6 +4,18 @@
       <mat-icon>menu</mat-icon>
     </button>
     <h1 class="example-app-name">Documentation</h1>
+
+    <span class="toolbar-spacer"></span>
+
+    <button
+      mat-icon-button
+      class="docs-search-button"
+      (click)="openSearch()"
+      aria-label="Search documentation"
+      [matTooltip]="searchTooltip"
+    >
+      <mat-icon>search</mat-icon>
+    </button>
   </mat-toolbar>
 
   <mat-sidenav-container class="example-sidenav-container">
@@ -13,7 +25,10 @@
       [fixedInViewport]="mobileQuery.matches"
       fixedTopGap="56"
     >
-      <app-doc-sidebar (click)="handleSidebarClick()"></app-doc-sidebar>
+      <app-doc-sidebar
+        (click)="handleSidebarClick()"
+        (openSearch)="openSearch()"
+      ></app-doc-sidebar>
     </mat-sidenav>
 
     <mat-sidenav-content>

--- a/src/app/documentation/documentation.component.html
+++ b/src/app/documentation/documentation.component.html
@@ -10,6 +10,7 @@
     <button
       mat-icon-button
       class="docs-search-button"
+      data-cy="docs-search-button"
       (click)="openSearch()"
       aria-label="Search documentation"
       [matTooltip]="searchTooltip"

--- a/src/app/documentation/documentation.component.scss
+++ b/src/app/documentation/documentation.component.scss
@@ -42,3 +42,8 @@ h1.example-app-name {
     background-color: #1e1e1e;
   }
 }
+
+// Pushes the search button to the trailing edge of the toolbar.
+.toolbar-spacer {
+  flex: 1 1 auto;
+}

--- a/src/app/documentation/documentation.component.spec.ts
+++ b/src/app/documentation/documentation.component.spec.ts
@@ -5,6 +5,7 @@ import { Subject } from 'rxjs';
 import { Event as RouterEvent, NavigationEnd, Router } from '@angular/router';
 
 import { DocumentationComponent } from './documentation.component';
+import { DocsSearchOpener } from './docs-search/docs-search.opener';
 import { DocsTelemetryService } from './docs-telemetry.service';
 import { MetaTagService } from '../core/services/meta-tag.service';
 import { StructuredDataService } from '../core/services/structured-data.service';
@@ -18,6 +19,10 @@ const mobileMediaMatcher = {
     removeListener: () => {},
   }),
 };
+
+/** The shell injects the opener to run the Ctrl+K shortcut and toolbar button. */
+const searchOpener = () =>
+  jasmine.createSpyObj<DocsSearchOpener>('DocsSearchOpener', ['open']);
 
 xdescribe('DocumentationComponent', () => {
   let component: DocumentationComponent;
@@ -61,6 +66,7 @@ describe('DocumentationComponent SEO lifecycle', () => {
       declarations: [DocumentationComponent],
       providers: [
         { provide: Router, useValue: { url: '/docs/prints', events } },
+        { provide: DocsSearchOpener, useValue: searchOpener() },
         { provide: StructuredDataService, useValue: structuredData },
         { provide: MetaTagService, useValue: meta },
         { provide: MediaMatcher, useValue: mobileMediaMatcher },
@@ -140,6 +146,7 @@ describe('DocumentationComponent telemetry', () => {
       declarations: [DocumentationComponent],
       providers: [
         { provide: Router, useValue: { url: initialUrl, events } },
+        { provide: DocsSearchOpener, useValue: searchOpener() },
         {
           provide: StructuredDataService,
           useValue: jasmine.createSpyObj<StructuredDataService>(

--- a/src/app/documentation/documentation.component.ts
+++ b/src/app/documentation/documentation.component.ts
@@ -25,6 +25,12 @@ import {
   buildDocBreadcrumb,
 } from '../core/structured-data/doc-schema';
 import { getDocSeoTags } from './doc-seo.config';
+import { DocsSearchOpener } from './docs-search/docs-search.opener';
+import {
+  isApplePlatform,
+  isSearchShortcut,
+  shortcutLabel,
+} from './docs-search/keyboard-shortcut';
 import {
   DocsTelemetryService,
   scrollPercentOf,
@@ -41,6 +47,11 @@ let apiLoaded = false;
   templateUrl: './documentation.component.html',
   styleUrls: ['./documentation.component.scss'],
   standalone: false,
+  host: {
+    // Bound on the document, not the host element: the shortcut has to work
+    // wherever focus happens to be inside the docs shell.
+    '(document:keydown)': 'onDocumentKeydown($event)',
+  },
 })
 export class DocumentationComponent
   implements OnInit, OnDestroy, AfterViewInit
@@ -59,6 +70,16 @@ export class DocumentationComponent
   private readonly telemetry = inject(DocsTelemetryService);
   private readonly scrollDispatcher = inject(ScrollDispatcher);
   private readonly document = inject(DOCUMENT);
+  private readonly searchOpener = inject(DocsSearchOpener);
+
+  /**
+   * Shown on the toolbar button. The modifier differs by platform, and the
+   * check is guarded: this initializer also runs in Node during prerendering,
+   * where there is no navigator to ask.
+   */
+  readonly searchTooltip = `Search documentation (${shortcutLabel(
+    isPlatformBrowser(this.platformId) && isApplePlatform(navigator.platform)
+  )})`;
 
   @ViewChild('snav', { static: true }) snav;
 
@@ -192,6 +213,19 @@ export class DocumentationComponent
       this.title.setTitle('Documentation - 3D Print Log');
       this.structuredData.setJsonLd([]);
     }
+  }
+
+  openSearch(query?: string): void {
+    this.searchOpener.open(query);
+  }
+
+  /** Ctrl+K / Cmd+K opens search, the shortcut every docs site uses. */
+  onDocumentKeydown(event: KeyboardEvent): void {
+    if (!isSearchShortcut(event)) {
+      return;
+    }
+    event.preventDefault();
+    this.openSearch();
   }
 
   handleSidebarClick() {

--- a/src/app/documentation/documentation.module.ts
+++ b/src/app/documentation/documentation.module.ts
@@ -9,6 +9,8 @@ import { DocsGettingStartedComponent } from './docs/docs-getting-started/docs-ge
 import { DocsReleaseNotesComponent } from './docs/docs-release-notes/docs-release-notes.component';
 import { DocumentationRoutingModule } from './documentation-routing.module';
 import { DocFeedbackComponent } from './doc-feedback/doc-feedback.component';
+import { DocsSearchOpener } from './docs-search/docs-search.opener';
+import { DocsSearchService } from './docs-search/docs-search.service';
 import { DocsTelemetryService } from './docs-telemetry.service';
 import { DocumentationComponent } from './documentation.component';
 import { DOCS_PAGE_COMPONENTS } from './generated/docs-declarations';
@@ -37,6 +39,8 @@ import { DOCS_PAGE_COMPONENTS } from './generated/docs-declarations';
     YouTubePlayerModule,
     DocFeedbackComponent,
   ],
-  providers: [DocsTelemetryService],
+  // Provided here, not in root: search is only reachable from /docs, so both
+  // classes stay in the lazy docs chunk rather than the main bundle.
+  providers: [DocsTelemetryService, DocsSearchService, DocsSearchOpener],
 })
 export class DocumentationModule {}

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -597,8 +597,8 @@
 
           @if (!pushPermissionGranted) {
             <p data-testid="push-permission-warning">
-              Notifications are turned off for 3D Print Log on this device, so
-              these settings have no effect yet.
+              Notifications are turned off for 3D Print Log on this device, so these
+              settings have no effect yet.
             </p>
             <p>
               <button

--- a/src/app/settings/settings.component.html
+++ b/src/app/settings/settings.component.html
@@ -597,8 +597,8 @@
 
           @if (!pushPermissionGranted) {
             <p data-testid="push-permission-warning">
-              Notifications are turned off for 3D Print Log on this device, so these
-              settings have no effect yet.
+              Notifications are turned off for 3D Print Log on this device, so
+              these settings have no effect yet.
             </p>
             <p>
               <button

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -66,6 +66,17 @@ app-navbar {
   min-height: 70vh;
 }
 
+/**
+ * Anchored headings have to clear the two fixed bars above them: the app navbar
+ * and the Documentation toolbar. Without this, every deep link — a search
+ * result, a cross-page `#anchor`, a bookmark — scrolls the heading to y=0,
+ * which is behind that chrome, so the reader lands on the paragraph after the
+ * thing they asked for.
+ */
+.docs-markdown :is(h1, h2, h3, h4, h5, h6) {
+  scroll-margin-top: 8rem;
+}
+
 .docs-markdown ol,
 .docs-markdown p,
 .docs-markdown ul {


### PR DESCRIPTION
Closes #143.

Client-side search over `/docs`: a command palette opened from the toolbar, the sidebar box, or Ctrl/Cmd+K, searching a section-level index generated at build time.

**Stacked on #159.** The base is `feat/release-notes-per-file`, so this diff shows only the search work. Merge #159 first and GitHub will retarget this to `main`.

## How it works

`scripts/docs-emit.mjs` splits each rendered page at its h1–h3 headings and emits one index entry per section, so a result names the heading it matched and deep-links to that heading's anchor rather than dumping the reader at the top of a long page.

MiniSearch and the index are pulled in by `import()` on first use — together ~55 KB gzipped, and most docs visitors never search, so neither belongs in the eager bundle. `DocsSearchService` is provided by `DocumentationModule`, not root, so the class itself stays in the lazy docs chunk.

Code samples are indexed, which needed more than not stripping `<pre>`: the MCP command renders from a frontmatter constant that references another constant, and the Klipper Moonraker config is wrapped in an interpolated string literal so Angular doesn't parse its Jinja braces. Bindings are resolved and re-encoded as text before indexing. That also fixed prose which was storing `{{ mcpEndpoint }}` verbatim, leaving the endpoint unsearchable.

`anchorScrolling: 'enabled'` is switched on globally, without which `scrollPositionRestoration` ignores the fragment and every deep link lands at the top. Navigation waits for `afterClosed()` because MatDialog restores the scroll position as it closes, which would otherwise silently undo the scroll.

## Telemetry

`Docs_Search` reports a query only when it reads as typed words or a command flag; anything else is redacted but still counted, so `zero-result-searches.kql` keeps both its text and its denominator. The docs cover auth setup and the MCP page ships a client ID, so a pasted credential could otherwise reach App Insights. The rule allows rather than blocks — a blocklist has to recognise every format a secret can take and fails open on the next one.

## Testing

157 unit tests and 315 script tests pass. 12 Cypress specs cover what unit tests structurally cannot: real focus (the unit test can only assert the `autoFocus` value handed to MatDialog), real scrolling (no fixture models MatDialog's scroll lock), and the real index through the real engine (unit tests mock the service, so nothing there proves the generated JSON, MiniSearch and the emit pipeline agree).

Both mutation-checked: restoring `autoFocus: false` fails exactly the two focus tests, and removing `navigateByUrl` fails exactly the three navigation tests.

## Review notes

Two adversarial review passes are folded in. Worth flagging for a human reader:

- The palette's loading and result state is owned by a request generation **and** a current-input comparison. Neither alone is sufficient — the generation misses the debounce window, the text comparison misses `mat -> material -> mat` — and there's a comment saying so.
- `escapeSubstitution` in `docs-emit.mjs` is load-bearing: without it a `<your-api-key>` placeholder in a constant vanishes like a tag, and a literal `<h2 id="x">` opens a section the page doesn't have.
