### PR TITLE
fix(docs): make the contents rail stick and follow the reader

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,14 @@ When communicating with Claude about test or lint failures, use these token-effi
 
 These commands are optimized for minimal token usage while preserving actionable information about failures and warnings.
 
+**Read the last line of `test:brief`, not the exit code.** These are meant to be
+piped (`npm run test:brief | tail -20`), and a shell pipeline reports the status
+of its _last_ command — so the exit code you see belongs to `tail`, not to the
+test run. The script prints `RESULT: PASSED` or `RESULT: FAILED (ng test exited
+N)` as its final line for exactly this reason. A compile error is the case that
+bites: Karma never reaches a `TOTAL:` line, so without that verdict the output
+ends in a blank summary that looks like a clean run.
+
 ## Architecture
 
 ### Module Structure

--- a/scripts/test-brief.sh
+++ b/scripts/test-brief.sh
@@ -15,4 +15,18 @@ fi
 
 echo "$summary"
 
+# Say the verdict in the output, not only in the exit code.
+#
+# This script exists to be piped — AGENTS.md points at it as the low-token way
+# to read a test run — and a shell pipeline reports the exit status of its LAST
+# command, so `npm run test:brief | tail` throws this away and a failed run
+# reads as a success. A compile error makes that worse: Karma never reaches a
+# TOTAL line, so the summary above is empty and the output carries no verdict
+# at all. One line of stdout survives the pipe.
+if [ "$exit_code" -ne 0 ]; then
+  echo "RESULT: FAILED (ng test exited $exit_code)"
+else
+  echo "RESULT: PASSED"
+fi
+
 exit $exit_code

--- a/src/app/documentation/doc-back-to-top/doc-back-to-top.component.html
+++ b/src/app/documentation/doc-back-to-top/doc-back-to-top.component.html
@@ -1,0 +1,12 @@
+@if (visible()) {
+  <button
+    mat-fab
+    class="doc-back-to-top__button"
+    data-cy="doc-back-to-top"
+    type="button"
+    aria-label="Back to top of page"
+    (click)="scrollToTop()"
+  >
+    <mat-icon>arrow_upward</mat-icon>
+  </button>
+}

--- a/src/app/documentation/doc-back-to-top/doc-back-to-top.component.scss
+++ b/src/app/documentation/doc-back-to-top/doc-back-to-top.component.scss
@@ -1,0 +1,45 @@
+/**
+ * Only below the rail breakpoint in documentation.component.scss. Above it the
+ * sticky table of contents already gets the reader anywhere on the page, and a
+ * floating button would sit over the ad at the foot of the article.
+ */
+:host {
+  display: none;
+}
+
+@media (max-width: 1199px) {
+  :host {
+    display: block;
+  }
+}
+
+.doc-back-to-top__button {
+  position: fixed;
+  // Clear of the trailing edge, and clear of a phone's home indicator.
+  right: 16px;
+  bottom: calc(16px + env(safe-area-inset-bottom, 0px));
+  // Above the article, below Material's overlay container (1000), so the search
+  // dialog and any menu still cover it.
+  z-index: 100;
+}
+
+/**
+ * The button is added to the DOM when it becomes relevant, so without this it
+ * pops into place. Skipped for a reader who has asked for less motion.
+ */
+@media (prefers-reduced-motion: no-preference) {
+  .doc-back-to-top__button {
+    animation: doc-back-to-top-in 150ms ease-out;
+  }
+}
+
+@keyframes doc-back-to-top-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/src/app/documentation/doc-back-to-top/doc-back-to-top.component.scss
+++ b/src/app/documentation/doc-back-to-top/doc-back-to-top.component.scss
@@ -16,7 +16,7 @@
 .doc-back-to-top__button {
   position: fixed;
   // Clear of the trailing edge, and clear of a phone's home indicator.
-  right: 16px;
+  inset-inline-end: 16px;
   bottom: calc(16px + env(safe-area-inset-bottom, 0px));
   // Above the article, below Material's overlay container (1000), so the search
   // dialog and any menu still cover it.

--- a/src/app/documentation/doc-back-to-top/doc-back-to-top.component.spec.ts
+++ b/src/app/documentation/doc-back-to-top/doc-back-to-top.component.spec.ts
@@ -1,0 +1,86 @@
+import { ScrollDispatcher } from '@angular/cdk/scrolling';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Subject } from 'rxjs';
+
+import { DocBackToTopComponent } from './doc-back-to-top.component';
+import { shouldShowBackToTop } from './scroll-target';
+
+describe('shouldShowBackToTop', () => {
+  it('stays hidden within the first two screens', () => {
+    expect(shouldShowBackToTop(0, 800)).toBeFalse();
+    expect(shouldShowBackToTop(1600, 800)).toBeFalse();
+  });
+
+  it('appears past two screens', () => {
+    expect(shouldShowBackToTop(1601, 800)).toBeTrue();
+  });
+
+  it('scales with the viewport rather than a fixed pixel count', () => {
+    // The same absolute offset is deep into a short viewport and barely past
+    // the fold on a tall one.
+    expect(shouldShowBackToTop(1000, 400)).toBeTrue();
+    expect(shouldShowBackToTop(1000, 900)).toBeFalse();
+  });
+});
+
+describe('DocBackToTopComponent', () => {
+  let fixture: ComponentFixture<DocBackToTopComponent>;
+  let scrolled: Subject<void>;
+
+  const button = (): HTMLButtonElement | null =>
+    fixture.nativeElement.querySelector('[data-cy="doc-back-to-top"]');
+
+  beforeEach(async () => {
+    scrolled = new Subject<void>();
+
+    await TestBed.configureTestingModule({
+      imports: [DocBackToTopComponent],
+      providers: [
+        {
+          provide: ScrollDispatcher,
+          useValue: { scrolled: () => scrolled.asObservable() },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DocBackToTopComponent);
+    fixture.detectChanges();
+  });
+
+  it('renders no button until the reader has scrolled', () => {
+    expect(button()).toBeNull();
+  });
+
+  it('renders the button once the page is scrolled past two screens', () => {
+    const element = document.documentElement;
+    spyOnProperty(element, 'scrollTop').and.returnValue(5000);
+    spyOnProperty(element, 'clientHeight').and.returnValue(800);
+
+    scrolled.next();
+    fixture.detectChanges();
+
+    expect(button()).not.toBeNull();
+    expect(button()?.getAttribute('aria-label')).toBe('Back to top of page');
+  });
+
+  it('scrolls the page to the top and hides itself again', () => {
+    const element = document.documentElement;
+    spyOnProperty(element, 'scrollTop').and.returnValue(5000);
+    spyOnProperty(element, 'clientHeight').and.returnValue(800);
+    // Typed as the two-argument scrollTo(x, y) overload, so the options-object
+    // call has to be read back off the spy rather than matched inline.
+    const scrollTo = spyOn(element, 'scrollTo');
+    scrolled.next();
+    fixture.detectChanges();
+
+    button()?.click();
+    fixture.detectChanges();
+
+    expect(scrollTo).toHaveBeenCalled();
+    expect(scrollTo.calls.mostRecent().args[0]).toEqual(
+      jasmine.objectContaining({ top: 0 })
+    );
+    expect(fixture.componentInstance.visible()).toBeFalse();
+    expect(button()).toBeNull();
+  });
+});

--- a/src/app/documentation/doc-back-to-top/doc-back-to-top.component.ts
+++ b/src/app/documentation/doc-back-to-top/doc-back-to-top.component.ts
@@ -1,0 +1,115 @@
+import { ScrollDispatcher } from '@angular/cdk/scrolling';
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  DestroyRef,
+  inject,
+  OnInit,
+  PLATFORM_ID,
+  signal,
+} from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { shouldShowBackToTop } from './scroll-target';
+
+/** How often scroll position is sampled, in ms. Matches the docs shell. */
+const SCROLL_SAMPLE_MS = 200;
+
+/**
+ * "Back to top", for the widths that have no table of contents rail.
+ *
+ * Deliberately not shown on a wide screen: there the TOC is a sticky rail that
+ * will take the reader to any section, top included, so a floating button would
+ * be a second way to do the same thing — and it would land on top of the ad
+ * slot at the foot of the article. Below the rail breakpoint the TOC is a card
+ * stranded at the top of the page, which is exactly the case this covers. The
+ * width gate is in the stylesheet, so a hidden button is out of the
+ * accessibility tree as well as out of sight.
+ */
+@Component({
+  selector: 'app-doc-back-to-top',
+  templateUrl: './doc-back-to-top.component.html',
+  styleUrls: ['./doc-back-to-top.component.scss'],
+  imports: [MatButtonModule, MatIconModule],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class DocBackToTopComponent implements OnInit {
+  readonly visible = signal(false);
+
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly document = inject(DOCUMENT);
+  private readonly scrollDispatcher = inject(ScrollDispatcher);
+  private readonly destroyRef = inject(DestroyRef);
+
+  ngOnInit(): void {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+    this.scrollDispatcher
+      .scrolled(SCROLL_SAMPLE_MS)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.sample());
+  }
+
+  scrollToTop(): void {
+    const element = this.scrollElement();
+    element.scrollTo({
+      top: 0,
+      behavior: this.prefersReducedMotion() ? 'auto' : 'smooth',
+    });
+    this.visible.set(false);
+    this.moveFocusToTop();
+  }
+
+  private sample(): void {
+    const element = this.scrollElement();
+    this.visible.set(
+      shouldShowBackToTop(element.scrollTop, element.clientHeight)
+    );
+  }
+
+  /**
+   * The element that actually scrolls. Which one it is depends on the layout:
+   * `mat-sidenav-content` scrolls once the sidenav is docked, the document
+   * scrolls on a phone where it is fixed over the page. Asking which of them
+   * overflows is more robust than re-deriving the shell's breakpoint here.
+   */
+  private scrollElement(): HTMLElement {
+    const content = this.document.querySelector<HTMLElement>(
+      'mat-sidenav-content'
+    );
+    if (content && content.scrollHeight > content.clientHeight) {
+      return content;
+    }
+    return this.document.documentElement;
+  }
+
+  /**
+   * Sending the page to the top without sending focus there leaves a keyboard
+   * or screen reader user's focus stranded on a button that is about to be
+   * hidden — the next Tab would resume from the bottom of a page they just
+   * left. Focus follows the scroll to the article's heading.
+   */
+  private moveFocusToTop(): void {
+    const heading = this.document.querySelector<HTMLElement>(
+      '.docs-layout__main h1, .docs-layout__main'
+    );
+    if (!heading) {
+      return;
+    }
+    if (!heading.hasAttribute('tabindex')) {
+      heading.setAttribute('tabindex', '-1');
+    }
+    heading.focus({ preventScroll: true });
+  }
+
+  private prefersReducedMotion(): boolean {
+    return (
+      this.document.defaultView?.matchMedia?.(
+        '(prefers-reduced-motion: reduce)'
+      ).matches ?? false
+    );
+  }
+}

--- a/src/app/documentation/doc-back-to-top/doc-back-to-top.component.ts
+++ b/src/app/documentation/doc-back-to-top/doc-back-to-top.component.ts
@@ -12,6 +12,7 @@ import {
 } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
+import { resolveScrollContainer } from '../docs-scroll-container';
 import { shouldShowBackToTop } from './scroll-target';
 
 /** How often scroll position is sampled, in ms. Matches the docs shell. */
@@ -70,20 +71,9 @@ export class DocBackToTopComponent implements OnInit {
     );
   }
 
-  /**
-   * The element that actually scrolls. Which one it is depends on the layout:
-   * `mat-sidenav-content` scrolls once the sidenav is docked, the document
-   * scrolls on a phone where it is fixed over the page. Asking which of them
-   * overflows is more robust than re-deriving the shell's breakpoint here.
-   */
+  /** Shared with the shell's scroll-depth telemetry, which needs the same answer. */
   private scrollElement(): HTMLElement {
-    const content = this.document.querySelector<HTMLElement>(
-      'mat-sidenav-content'
-    );
-    if (content && content.scrollHeight > content.clientHeight) {
-      return content;
-    }
-    return this.document.documentElement;
+    return resolveScrollContainer(this.document);
   }
 
   /**

--- a/src/app/documentation/doc-back-to-top/doc-back-to-top.component.ts
+++ b/src/app/documentation/doc-back-to-top/doc-back-to-top.component.ts
@@ -89,9 +89,22 @@ export class DocBackToTopComponent implements OnInit {
     if (!heading) {
       return;
     }
-    if (!heading.hasAttribute('tabindex')) {
-      heading.setAttribute('tabindex', '-1');
+
+    // The target belongs to the routed page, or to the shell — not to this
+    // component. A programmatic focus needs it to be focusable, but leaving the
+    // attribute behind would permanently change the focus semantics of markup
+    // this component does not own, and the shell fallback persists across every
+    // navigation. Borrow it for the duration of the focus and hand it back.
+    if (heading.hasAttribute('tabindex')) {
+      heading.focus({ preventScroll: true });
+      return;
     }
+    heading.setAttribute('tabindex', '-1');
+    heading.addEventListener(
+      'blur',
+      () => heading.removeAttribute('tabindex'),
+      { once: true }
+    );
     heading.focus({ preventScroll: true });
   }
 

--- a/src/app/documentation/doc-back-to-top/scroll-target.ts
+++ b/src/app/documentation/doc-back-to-top/scroll-target.ts
@@ -1,0 +1,15 @@
+/**
+ * When the "back to top" button is worth showing.
+ *
+ * Two screens down is far enough that the reader can no longer flick back with
+ * one gesture, and far enough that the button does not appear and vanish while
+ * someone is nudging around near the top of a page.
+ */
+const SCREENS_BEFORE_SHOWING = 2;
+
+export function shouldShowBackToTop(
+  scrollTop: number,
+  viewportHeight: number
+): boolean {
+  return scrollTop > viewportHeight * SCREENS_BEFORE_SHOWING;
+}

--- a/src/app/documentation/doc-toc/active-heading.spec.ts
+++ b/src/app/documentation/doc-toc/active-heading.spec.ts
@@ -1,124 +1,62 @@
-import { activeBandRootMargin, nextActiveHeading } from './active-heading';
+import { activeBandTopPx, activeHeadingAt } from './active-heading';
 
-describe('nextActiveHeading', () => {
-  const order = ['intro', 'setup', 'usage', 'troubleshooting'];
+describe('activeHeadingAt', () => {
+  const BAND = 128;
 
-  it('marks the heading that just entered the band', () => {
-    expect(
-      nextActiveHeading(null, [{ id: 'setup', isIntersecting: true }], order)
-    ).toBe('setup');
+  /** Headings laid out down the page, in document order. */
+  const at = (...tops: number[]) =>
+    tops.map((top, i) => ({ id: `h${i}`, top }));
+
+  it('marks the last heading the reader has scrolled under', () => {
+    // h0 and h1 are above the band line, h2 is still below it.
+    expect(activeHeadingAt(at(-500, 40, 600), BAND, false)).toBe('h1');
   });
 
-  it('prefers the topmost heading when several share the band', () => {
-    // A run of short subsections can put three headings in the band at once.
-    // The reader is under the first of them.
-    expect(
-      nextActiveHeading(
-        null,
-        [
-          { id: 'usage', isIntersecting: true },
-          { id: 'setup', isIntersecting: true },
-          { id: 'troubleshooting', isIntersecting: true },
-        ],
-        order
-      )
-    ).toBe('setup');
+  it('marks nothing above the first heading', () => {
+    // The page opens with prose, or with a title the outline does not list.
+    expect(activeHeadingAt(at(300, 900, 1500), BAND, false)).toBeNull();
   });
 
-  it('keeps the current heading while a long section fills the screen', () => {
-    // The section is taller than the band, so its own heading has scrolled out
-    // the top and nothing else has arrived yet. Blanking the rail here would
-    // lose the mark for the whole length of the section.
-    expect(
-      nextActiveHeading(
-        'setup',
-        [{ id: 'setup', isIntersecting: false }],
-        order
-      )
-    ).toBe('setup');
+  it('marks a heading that has landed exactly on the band line', () => {
+    // Where a deep link parks its target, via scroll-margin-top.
+    expect(activeHeadingAt(at(-200, BAND, 700), BAND, false)).toBe('h1');
   });
 
-  it('has no answer before the first heading is reached', () => {
-    expect(nextActiveHeading(null, [], order)).toBeNull();
+  it('keeps marking a long section whose heading has scrolled far away', () => {
+    expect(activeHeadingAt(at(-9000, 4000), BAND, false)).toBe('h0');
   });
 
-  it('ignores a heading that is not in the outline', () => {
-    // The page can contain anchored headings the outline does not list, e.g.
-    // one nested deeper than the outline records.
-    expect(
-      nextActiveHeading(
-        'setup',
-        [{ id: 'not-in-the-outline', isIntersecting: true }],
-        order
-      )
-    ).toBe('setup');
+  it('does not depend on which headings changed since the last reading', () => {
+    // The bug this replaced: an IntersectionObserver callback names only the
+    // targets whose state changed, so a reducer over one callback could pick a
+    // later heading while an earlier one was still in the band. Reading every
+    // position makes two headings above the line unambiguous.
+    expect(activeHeadingAt(at(-300, -100, 500), BAND, false)).toBe('h1');
+  });
+
+  it('marks the last heading at the bottom of the page', () => {
+    // A final section shorter than the viewport never brings its heading up to
+    // the band, so geometry alone would mark the section before it — and this
+    // drives aria-current, so that is a wrong answer given to a screen reader.
+    expect(activeHeadingAt(at(-2000, -900, 700), BAND, true)).toBe('h2');
+  });
+
+  it('has no answer for a page with no headings', () => {
+    expect(activeHeadingAt([], BAND, false)).toBeNull();
+    expect(activeHeadingAt([], BAND, true)).toBeNull();
   });
 });
 
-describe('activeBandRootMargin', () => {
-  it('converts the rem band to the pixels rootMargin requires', () => {
-    expect(activeBandRootMargin(16)).toBe('-128px 0px -55% 0px');
-    expect(activeBandRootMargin(20)).toBe('-160px 0px -55% 0px');
+describe('activeBandTopPx', () => {
+  it('scales the band with the root font size', () => {
+    expect(activeBandTopPx(16)).toBe(128);
+    expect(activeBandTopPx(20)).toBe(160);
   });
 
-  it('produces a value IntersectionObserver actually accepts', () => {
-    // The reason this function exists. rootMargin takes px and % only, so a
-    // rem value makes the constructor throw SyntaxError — and because the
-    // observer is built inside a render callback, that throw showed up as a
-    // console error and a rail that silently never highlighted anything,
-    // rather than as anything resembling a layout bug.
-    expect(
-      () =>
-        new IntersectionObserver(() => undefined, {
-          rootMargin: activeBandRootMargin(16),
-        })
-    ).not.toThrow();
-
-    expect(
-      () =>
-        new IntersectionObserver(() => undefined, {
-          rootMargin: '-8rem 0px -55% 0px',
-        })
-    ).toThrow();
-  });
-});
-
-describe('nextActiveHeading above the first heading', () => {
-  const order = ['intro', 'setup', 'usage'];
-
-  it('clears the mark when the reader is above the first heading', () => {
-    // Jumping to the top of the page — the Home key, or the back-to-top
-    // button — puts every observed heading below the band at once. Rule 2
-    // would keep marking whatever section was left behind.
-    expect(
-      nextActiveHeading(
-        'usage',
-        [{ id: 'usage', isIntersecting: false }],
-        order,
-        true
-      )
-    ).toBeNull();
-  });
-
-  it('still prefers a heading that is genuinely in the band', () => {
-    expect(
-      nextActiveHeading(
-        'usage',
-        [{ id: 'intro', isIntersecting: true }],
-        order,
-        true
-      )
-    ).toBe('intro');
-  });
-
-  it('keeps rule 2 intact once past the first heading', () => {
-    expect(
-      nextActiveHeading(
-        'setup',
-        [{ id: 'setup', isIntersecting: false }],
-        order,
-        false
-      )
-    ).toBe('setup');
+  it('reaches at least as far as a deep link parks its heading', () => {
+    // The band must cover scroll-margin-top (8rem in docs-typography.scss), or
+    // a heading arrived at by deep link would not read as the current one.
+    const scrollMarginTopRem = 8;
+    expect(activeBandTopPx(16)).toBeGreaterThanOrEqual(scrollMarginTopRem * 16);
   });
 });

--- a/src/app/documentation/doc-toc/active-heading.spec.ts
+++ b/src/app/documentation/doc-toc/active-heading.spec.ts
@@ -1,0 +1,124 @@
+import { activeBandRootMargin, nextActiveHeading } from './active-heading';
+
+describe('nextActiveHeading', () => {
+  const order = ['intro', 'setup', 'usage', 'troubleshooting'];
+
+  it('marks the heading that just entered the band', () => {
+    expect(
+      nextActiveHeading(null, [{ id: 'setup', isIntersecting: true }], order)
+    ).toBe('setup');
+  });
+
+  it('prefers the topmost heading when several share the band', () => {
+    // A run of short subsections can put three headings in the band at once.
+    // The reader is under the first of them.
+    expect(
+      nextActiveHeading(
+        null,
+        [
+          { id: 'usage', isIntersecting: true },
+          { id: 'setup', isIntersecting: true },
+          { id: 'troubleshooting', isIntersecting: true },
+        ],
+        order
+      )
+    ).toBe('setup');
+  });
+
+  it('keeps the current heading while a long section fills the screen', () => {
+    // The section is taller than the band, so its own heading has scrolled out
+    // the top and nothing else has arrived yet. Blanking the rail here would
+    // lose the mark for the whole length of the section.
+    expect(
+      nextActiveHeading(
+        'setup',
+        [{ id: 'setup', isIntersecting: false }],
+        order
+      )
+    ).toBe('setup');
+  });
+
+  it('has no answer before the first heading is reached', () => {
+    expect(nextActiveHeading(null, [], order)).toBeNull();
+  });
+
+  it('ignores a heading that is not in the outline', () => {
+    // The page can contain anchored headings the outline does not list, e.g.
+    // one nested deeper than the outline records.
+    expect(
+      nextActiveHeading(
+        'setup',
+        [{ id: 'not-in-the-outline', isIntersecting: true }],
+        order
+      )
+    ).toBe('setup');
+  });
+});
+
+describe('activeBandRootMargin', () => {
+  it('converts the rem band to the pixels rootMargin requires', () => {
+    expect(activeBandRootMargin(16)).toBe('-128px 0px -55% 0px');
+    expect(activeBandRootMargin(20)).toBe('-160px 0px -55% 0px');
+  });
+
+  it('produces a value IntersectionObserver actually accepts', () => {
+    // The reason this function exists. rootMargin takes px and % only, so a
+    // rem value makes the constructor throw SyntaxError — and because the
+    // observer is built inside a render callback, that throw showed up as a
+    // console error and a rail that silently never highlighted anything,
+    // rather than as anything resembling a layout bug.
+    expect(
+      () =>
+        new IntersectionObserver(() => undefined, {
+          rootMargin: activeBandRootMargin(16),
+        })
+    ).not.toThrow();
+
+    expect(
+      () =>
+        new IntersectionObserver(() => undefined, {
+          rootMargin: '-8rem 0px -55% 0px',
+        })
+    ).toThrow();
+  });
+});
+
+describe('nextActiveHeading above the first heading', () => {
+  const order = ['intro', 'setup', 'usage'];
+
+  it('clears the mark when the reader is above the first heading', () => {
+    // Jumping to the top of the page — the Home key, or the back-to-top
+    // button — puts every observed heading below the band at once. Rule 2
+    // would keep marking whatever section was left behind.
+    expect(
+      nextActiveHeading(
+        'usage',
+        [{ id: 'usage', isIntersecting: false }],
+        order,
+        true
+      )
+    ).toBeNull();
+  });
+
+  it('still prefers a heading that is genuinely in the band', () => {
+    expect(
+      nextActiveHeading(
+        'usage',
+        [{ id: 'intro', isIntersecting: true }],
+        order,
+        true
+      )
+    ).toBe('intro');
+  });
+
+  it('keeps rule 2 intact once past the first heading', () => {
+    expect(
+      nextActiveHeading(
+        'setup',
+        [{ id: 'setup', isIntersecting: false }],
+        order,
+        false
+      )
+    ).toBe('setup');
+  });
+});

--- a/src/app/documentation/doc-toc/active-heading.ts
+++ b/src/app/documentation/doc-toc/active-heading.ts
@@ -1,0 +1,102 @@
+/**
+ * Which entry the table of contents should mark as the one you are reading.
+ *
+ * Pulled out of the component because the interesting behavior is a decision
+ * about a set of intersection records, and testing that through a real
+ * `IntersectionObserver` means scrolling a real viewport and waiting on
+ * callbacks that fire on the browser's schedule, not the test's.
+ */
+
+/** One heading's visibility, as reported by the observer. */
+export interface HeadingVisibility {
+  readonly id: string;
+  readonly isIntersecting: boolean;
+}
+
+/**
+ * The next active heading, given what the observer just reported.
+ *
+ * Two rules, both of which exist because the observer only speaks about
+ * headings that CHANGED state:
+ *
+ * 1. When several headings sit in the band at once — a run of short
+ *    subsections — the topmost one wins, because that is the section heading
+ *    the reader has most recently passed under.
+ * 2. When nothing is in the band the previous answer stands. A section longer
+ *    than the band scrolls its own heading out the top, and clearing the mark
+ *    for the length of that section is worse than keeping it: the rail would
+ *    go blank exactly while the reader is deepest inside a section.
+ * 3. Except above the first heading, where `aboveFirstHeading` overrides rule 2
+ *    and the mark clears. The reader has not reached any section yet, and a
+ *    page can open with prose — or with a title the outline does not list —
+ *    between the top and the first entry, so "nothing in the band" there is not
+ *    the same situation as rule 2's. Without this, jumping to the top of the
+ *    page (the Home key, or the back-to-top button) leaves the rail marking
+ *    whatever section the reader jumped away from.
+ */
+export function nextActiveHeading(
+  current: string | null,
+  reported: readonly HeadingVisibility[],
+  order: readonly string[],
+  aboveFirstHeading = false
+): string | null {
+  let best: string | null = null;
+  let bestIndex = Number.POSITIVE_INFINITY;
+
+  for (const { id, isIntersecting } of reported) {
+    if (!isIntersecting) {
+      continue;
+    }
+    const index = order.indexOf(id);
+    if (index !== -1 && index < bestIndex) {
+      best = id;
+      bestIndex = index;
+    }
+  }
+
+  if (best !== null) {
+    return best;
+  }
+  return aboveFirstHeading ? null : current;
+}
+
+/**
+ * How far below the top of the viewport a heading counts as reached, in rem.
+ *
+ * Matches the rail's `top: 8rem` and the headings' `scroll-margin-top: 8rem`:
+ * a heading is "reached" once it clears the app navbar and the Documentation
+ * toolbar, which is exactly where a deep link parks it.
+ */
+const BAND_TOP_REM = 8;
+
+/**
+ * How much of the viewport below the band is excluded.
+ *
+ * Keeps the band near the top of the screen, so arriving at a section marks it
+ * rather than the section still filling most of the viewport.
+ */
+const BAND_BOTTOM = '-55%';
+
+/**
+ * The observer's `rootMargin` for a given root font size.
+ *
+ * Built rather than written as a constant because `rootMargin` accepts ONLY px
+ * and %: a `rem` value makes the IntersectionObserver constructor throw
+ * `SyntaxError`, and since the observer is constructed in a render callback
+ * that throw surfaces as a console error and a silently dead rail rather than
+ * as anything that looks like a layout bug. The rem-to-px conversion is done
+ * here so the band stays tied to the `8rem` in the stylesheets.
+ */
+export function activeBandRootMargin(rootFontSizePx: number): string {
+  return `-${activeBandTopPx(rootFontSizePx)}px 0px ${BAND_BOTTOM} 0px`;
+}
+
+/**
+ * Where the band starts, in px from the top of the viewport. Used to ask
+ * whether the reader is above the first heading, which the observer cannot say
+ * on its own: it only reports the headings it watches, and a page can open with
+ * prose or with a title that the outline does not list.
+ */
+export function activeBandTopPx(rootFontSizePx: number): number {
+  return BAND_TOP_REM * rootFontSizePx;
+}

--- a/src/app/documentation/doc-toc/active-heading.ts
+++ b/src/app/documentation/doc-toc/active-heading.ts
@@ -2,101 +2,80 @@
  * Which entry the table of contents should mark as the one you are reading.
  *
  * Pulled out of the component because the interesting behavior is a decision
- * about a set of intersection records, and testing that through a real
- * `IntersectionObserver` means scrolling a real viewport and waiting on
- * callbacks that fire on the browser's schedule, not the test's.
+ * about where the headings currently sit, and testing that through a real
+ * viewport means scrolling one and waiting on callbacks that fire on the
+ * browser's schedule, not the test's.
+ *
+ * This reads every heading's position on each sample rather than reacting to
+ * IntersectionObserver callbacks. An observer reports only the targets whose
+ * state CHANGED, so a callback is a delta, not a picture of the page: when a
+ * second heading enters the band while the first is still in it, the callback
+ * names only the second, and a reducer over that callback alone cannot know the
+ * first is still there. Deltas also mean no callback at all when nothing
+ * crosses a boundary — which is what a jump to the top or the bottom of a long
+ * page can look like, leaving a stale answer standing. Positions are always a
+ * complete, current picture, and rect reads on a throttled scroll cost less
+ * than the bugs the delta model brings.
  */
 
-/** One heading's visibility, as reported by the observer. */
-export interface HeadingVisibility {
+/** Where one heading sits, in px from the top of the viewport. */
+export interface HeadingPosition {
   readonly id: string;
-  readonly isIntersecting: boolean;
+  readonly top: number;
 }
 
 /**
- * The next active heading, given what the observer just reported.
+ * The heading the reader is currently under.
  *
- * Two rules, both of which exist because the observer only speaks about
- * headings that CHANGED state:
+ * `positions` must be in document order — the generated outline already is.
  *
- * 1. When several headings sit in the band at once — a run of short
- *    subsections — the topmost one wins, because that is the section heading
- *    the reader has most recently passed under.
- * 2. When nothing is in the band the previous answer stands. A section longer
- *    than the band scrolls its own heading out the top, and clearing the mark
- *    for the length of that section is worse than keeping it: the rail would
- *    go blank exactly while the reader is deepest inside a section.
- * 3. Except above the first heading, where `aboveFirstHeading` overrides rule 2
- *    and the mark clears. The reader has not reached any section yet, and a
- *    page can open with prose — or with a title the outline does not list —
- *    between the top and the first entry, so "nothing in the band" there is not
- *    the same situation as rule 2's. Without this, jumping to the top of the
- *    page (the Home key, or the back-to-top button) leaves the rail marking
- *    whatever section the reader jumped away from.
+ * - The answer is the LAST heading whose top has passed `bandTop`: the heading
+ *   the reader has most recently scrolled under.
+ * - Above the first heading the answer is null. The reader has not reached any
+ *   section yet, and a page can open with prose, or with a title the outline
+ *   does not list, before its first entry.
+ * - At the bottom of the page the answer is the last heading, whatever the
+ *   geometry says. A final section shorter than the remaining viewport can
+ *   never bring its own heading up to the band, so without this the rail marks
+ *   the second-to-last section while the reader looks at the last one. Since
+ *   this drives `aria-current`, that is a wrong answer handed to assistive
+ *   technology, not just a visual smudge.
  */
-export function nextActiveHeading(
-  current: string | null,
-  reported: readonly HeadingVisibility[],
-  order: readonly string[],
-  aboveFirstHeading = false
+export function activeHeadingAt(
+  positions: readonly HeadingPosition[],
+  bandTop: number,
+  atBottom: boolean
 ): string | null {
-  let best: string | null = null;
-  let bestIndex = Number.POSITIVE_INFINITY;
-
-  for (const { id, isIntersecting } of reported) {
-    if (!isIntersecting) {
-      continue;
-    }
-    const index = order.indexOf(id);
-    if (index !== -1 && index < bestIndex) {
-      best = id;
-      bestIndex = index;
-    }
+  if (positions.length === 0) {
+    return null;
   }
 
-  if (best !== null) {
-    return best;
+  if (atBottom) {
+    return positions[positions.length - 1].id;
   }
-  return aboveFirstHeading ? null : current;
+
+  let active: string | null = null;
+  for (const position of positions) {
+    if (position.top > bandTop) {
+      break;
+    }
+    active = position.id;
+  }
+  return active;
 }
 
 /**
  * How far below the top of the viewport a heading counts as reached, in rem.
  *
- * Matches the rail's `top: 8rem` and the headings' `scroll-margin-top: 8rem`:
- * a heading is "reached" once it clears the app navbar and the Documentation
- * toolbar, which is exactly where a deep link parks it.
+ * Tied to the headings' `scroll-margin-top` in docs-typography.scss, NOT to the
+ * rail's sticky offset, which is a different number for a different reason. A
+ * deep link parks its heading exactly `scroll-margin-top` below the top of the
+ * viewport, and the rail has to call that heading current when it lands — so
+ * the band has to reach at least that far down.
  */
 const BAND_TOP_REM = 8;
 
-/**
- * How much of the viewport below the band is excluded.
- *
- * Keeps the band near the top of the screen, so arriving at a section marks it
- * rather than the section still filling most of the viewport.
- */
-const BAND_BOTTOM = '-55%';
-
-/**
- * The observer's `rootMargin` for a given root font size.
- *
- * Built rather than written as a constant because `rootMargin` accepts ONLY px
- * and %: a `rem` value makes the IntersectionObserver constructor throw
- * `SyntaxError`, and since the observer is constructed in a render callback
- * that throw surfaces as a console error and a silently dead rail rather than
- * as anything that looks like a layout bug. The rem-to-px conversion is done
- * here so the band stays tied to the `8rem` in the stylesheets.
- */
-export function activeBandRootMargin(rootFontSizePx: number): string {
-  return `-${activeBandTopPx(rootFontSizePx)}px 0px ${BAND_BOTTOM} 0px`;
-}
-
-/**
- * Where the band starts, in px from the top of the viewport. Used to ask
- * whether the reader is above the first heading, which the observer cannot say
- * on its own: it only reports the headings it watches, and a page can open with
- * prose or with a title that the outline does not list.
- */
+/** Where the band starts, in px, for a given root font size. */
 export function activeBandTopPx(rootFontSizePx: number): number {
   return BAND_TOP_REM * rootFontSizePx;
 }

--- a/src/app/documentation/doc-toc/doc-toc.component.html
+++ b/src/app/documentation/doc-toc/doc-toc.component.html
@@ -6,10 +6,14 @@
         <li
           class="doc-toc__item"
           [class.doc-toc__item--nested]="heading.depth > 1"
+          [class.doc-toc__item--active]="heading.id === activeId()"
         >
-          <a [routerLink]="route()" [fragment]="heading.id">{{
-            heading.text
-          }}</a>
+          <a
+            [routerLink]="route()"
+            [fragment]="heading.id"
+            [attr.aria-current]="heading.id === activeId() ? 'true' : null"
+            >{{ heading.text }}</a
+          >
         </li>
       }
     </ul>

--- a/src/app/documentation/doc-toc/doc-toc.component.scss
+++ b/src/app/documentation/doc-toc/doc-toc.component.scss
@@ -23,16 +23,23 @@
 // Matches the rail breakpoint in documentation.component.scss.
 @media (min-width: 1200px) {
   .doc-toc {
-    // Clears the app navbar and the Documentation toolbar, the same two bars
-    // the headings' scroll-margin-top clears. This only has anywhere to travel
-    // because the grid item stretches to the row height — see the
-    // `align-self: stretch` note in documentation.component.scss.
+    // 5rem clears the ONE bar that is actually fixed — the 4rem app navbar —
+    // plus a 1rem breath. The Documentation toolbar below it is `static` and
+    // scrolls away with the page, so matching the headings' 8rem
+    // scroll-margin-top here would hold the rail 4rem below the only chrome it
+    // has to clear and cost that much of its height for nothing. The band the
+    // scroll-spy uses is still 8rem, and deliberately: that one is tied to
+    // where a deep link parks a heading, not to what is on screen.
+    //
+    // This only has anywhere to travel because the grid item stretches to the
+    // row height — see the `align-self: stretch` note in
+    // documentation.component.scss.
     position: sticky;
-    top: 8rem;
+    top: 5rem;
     padding: 0;
     border-radius: 0;
     background: none;
-    max-height: calc(100vh - 10rem);
+    max-height: calc(100vh - 7rem);
     // The rule down the left of the rail is drawn by the items rather than by
     // this box, so the active entry can light up its own segment of it.
     --doc-toc-gutter: 16px;
@@ -44,11 +51,11 @@
   }
 
   .doc-toc__item {
-    border-left: 2px solid var(--docs-rule);
+    border-inline-start: 2px solid var(--docs-rule);
   }
 
   .doc-toc__item--active {
-    border-left-color: var(--docs-link);
+    border-inline-start-color: var(--docs-link);
   }
 }
 
@@ -61,7 +68,7 @@
   color: var(--docs-text-muted);
   // The label sits on the rail's gutter so it lines up with the entries below
   // it rather than hanging off their left edge.
-  padding-left: var(--doc-toc-gutter, 0);
+  padding-inline-start: var(--doc-toc-gutter, 0);
 }
 
 .doc-toc__list {
@@ -78,7 +85,8 @@
   display: block;
   // The indent is on the anchor, not the item, so the item's left border can
   // stay flush with the rail while the text steps in from it.
-  padding: 4px 0 4px var(--doc-toc-gutter, 0);
+  padding-block: 4px;
+  padding-inline: var(--doc-toc-gutter, 0) 0;
   font-size: 14px;
   line-height: 20px;
   color: var(--docs-text-muted);
@@ -86,7 +94,7 @@
 }
 
 .doc-toc__item--nested a {
-  padding-left: calc(var(--doc-toc-gutter, 0px) + 14px);
+  padding-inline-start: calc(var(--doc-toc-gutter, 0px) + 14px);
 }
 
 .doc-toc__item--active a {

--- a/src/app/documentation/doc-toc/doc-toc.component.scss
+++ b/src/app/documentation/doc-toc/doc-toc.component.scss
@@ -24,14 +24,31 @@
 @media (min-width: 1200px) {
   .doc-toc {
     // Clears the app navbar and the Documentation toolbar, the same two bars
-    // the headings' scroll-margin-top clears.
+    // the headings' scroll-margin-top clears. This only has anywhere to travel
+    // because the grid item stretches to the row height — see the
+    // `align-self: stretch` note in documentation.component.scss.
     position: sticky;
     top: 8rem;
-    padding: 0 0 0 16px;
+    padding: 0;
     border-radius: 0;
     background: none;
-    border-left: 1px solid var(--docs-rule);
     max-height: calc(100vh - 10rem);
+    // The rule down the left of the rail is drawn by the items rather than by
+    // this box, so the active entry can light up its own segment of it.
+    --doc-toc-gutter: 16px;
+    // An outline long enough to scroll is scrolled with the pointer already
+    // over the rail; without this, reaching its end hands the wheel to the
+    // article underneath and the reader loses the list they were reading.
+    overscroll-behavior: contain;
+    scrollbar-width: thin;
+  }
+
+  .doc-toc__item {
+    border-left: 2px solid var(--docs-rule);
+  }
+
+  .doc-toc__item--active {
+    border-left-color: var(--docs-link);
   }
 }
 
@@ -42,6 +59,9 @@
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--docs-text-muted);
+  // The label sits on the rail's gutter so it lines up with the entries below
+  // it rather than hanging off their left edge.
+  padding-left: var(--doc-toc-gutter, 0);
 }
 
 .doc-toc__list {
@@ -54,17 +74,24 @@
   margin: 0;
 }
 
-.doc-toc__item--nested {
-  padding-left: 14px;
-}
-
 .doc-toc__item a {
   display: block;
-  padding: 4px 0;
+  // The indent is on the anchor, not the item, so the item's left border can
+  // stay flush with the rail while the text steps in from it.
+  padding: 4px 0 4px var(--doc-toc-gutter, 0);
   font-size: 14px;
   line-height: 20px;
   color: var(--docs-text-muted);
   text-decoration: none;
+}
+
+.doc-toc__item--nested a {
+  padding-left: calc(var(--doc-toc-gutter, 0px) + 14px);
+}
+
+.doc-toc__item--active a {
+  color: var(--docs-link);
+  font-weight: 600;
 }
 
 .doc-toc__item a:hover,

--- a/src/app/documentation/doc-toc/doc-toc.component.spec.ts
+++ b/src/app/documentation/doc-toc/doc-toc.component.spec.ts
@@ -77,6 +77,40 @@ describe('DocTocComponent', () => {
     );
   });
 
+  it('marks the section being read, for the eye and for a screen reader', async () => {
+    await render('docs/materials');
+    const second = DOC_OUTLINE['docs/materials'][1];
+
+    fixture.componentInstance.activeId.set(second.id);
+    fixture.detectChanges();
+
+    const rows = host().querySelectorAll('.doc-toc__item');
+    expect(rows[1].classList).toContain('doc-toc__item--active');
+    expect(rows[0].classList).not.toContain('doc-toc__item--active');
+    expect(items()[1].getAttribute('aria-current')).toBe('true');
+    expect(items()[0].getAttribute('aria-current')).toBeNull();
+  });
+
+  it('marks nothing before the reader reaches the first heading', async () => {
+    await render('docs/materials');
+
+    expect(host().querySelector('.doc-toc__item--active')).toBeNull();
+    expect(host().querySelector('[aria-current]')).toBeNull();
+  });
+
+  it('drops the mark when the reader navigates to another page', async () => {
+    // The component survives navigation, so a stale id from the previous page
+    // would leave an unrelated entry highlighted until the first scroll.
+    await render('docs/materials');
+    fixture.componentInstance.activeId.set(DOC_OUTLINE['docs/materials'][1].id);
+    fixture.detectChanges();
+
+    await render('docs/printers');
+
+    expect(fixture.componentInstance.activeId()).toBeNull();
+    expect(host().querySelector('.doc-toc__item--active')).toBeNull();
+  });
+
   it('names the navigation landmark so it is not just "navigation"', async () => {
     await render('docs/materials');
 

--- a/src/app/documentation/doc-toc/doc-toc.component.ts
+++ b/src/app/documentation/doc-toc/doc-toc.component.ts
@@ -1,9 +1,11 @@
+import { ScrollDispatcher } from '@angular/cdk/scrolling';
 import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import {
   afterNextRender,
   ChangeDetectionStrategy,
   Component,
   computed,
+  DestroyRef,
   effect,
   inject,
   Injector,
@@ -11,13 +13,11 @@ import {
   PLATFORM_ID,
   signal,
 } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
+import { resolveScrollContainer, scrolls } from '../docs-scroll-container';
 import { DOC_OUTLINE, DocHeading } from '../generated/docs-outline';
-import {
-  activeBandRootMargin,
-  activeBandTopPx,
-  nextActiveHeading,
-} from './active-heading';
+import { activeBandTopPx, activeHeadingAt } from './active-heading';
 
 /**
  * The fewest entries worth a table of contents.
@@ -27,13 +27,16 @@ import {
  */
 const MINIMUM_ENTRIES = 3;
 
+/** How often the reader's position is sampled, in ms. */
+const SPY_SAMPLE_MS = 100;
+
 /**
- * Known limit of the band built by `activeBandRootMargin`: a final section
- * shorter than the remaining viewport can never reach it, so the rail keeps the
- * previous heading marked at the very bottom of such a page. Closing that needs
- * scroll-position plumbing on top of the observer, which costs more than the
- * case is worth.
+ * How close to the end counts as the bottom of the page, in px. Absorbs the
+ * fractional pixel a zoomed or scaled layout can leave between the scroll
+ * position and the scroll height, which would otherwise make the last section
+ * unreachable at the moment the reader arrives at it.
  */
+const BOTTOM_SLACK = 2;
 
 /**
  * "On this page" — the per-page table of contents.
@@ -74,84 +77,80 @@ export class DocTocComponent {
   /**
    * The heading the reader is currently under, or null before they reach the
    * first one. Writable so a test can drive the rendering without scrolling a
-   * real viewport; the observer below is the only production writer.
+   * real viewport; `sample` is the only production writer.
    */
   readonly activeId = signal<string | null>(null);
 
   private readonly platformId = inject(PLATFORM_ID);
   private readonly document = inject(DOCUMENT);
   private readonly injector = inject(Injector);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly scrollDispatcher = inject(ScrollDispatcher);
 
   constructor() {
     effect((onCleanup) => {
       const headings = this.headings();
       this.activeId.set(null);
 
-      if (
-        !isPlatformBrowser(this.platformId) ||
-        headings.length === 0 ||
-        typeof IntersectionObserver === 'undefined'
-      ) {
+      if (!isPlatformBrowser(this.platformId) || headings.length === 0) {
         return;
       }
 
-      let observer: IntersectionObserver | undefined;
       // The headings belong to the routed page component, a sibling of this one
       // in the shell, so they are not in the DOM yet when this effect runs on a
-      // navigation. afterNextRender waits for the outlet to have swapped.
-      const pending = afterNextRender(
-        () => (observer = this.observeHeadings(headings)),
-        { injector: this.injector }
-      );
-
-      onCleanup(() => {
-        pending.destroy();
-        observer?.disconnect();
+      // navigation. afterNextRender waits for the outlet to have swapped, and
+      // this first reading places the mark before the reader scrolls at all.
+      const pending = afterNextRender(() => this.sample(), {
+        injector: this.injector,
       });
+      onCleanup(() => pending.destroy());
     });
+
+    if (isPlatformBrowser(this.platformId)) {
+      this.scrollDispatcher
+        .scrolled(SPY_SAMPLE_MS)
+        .pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe(() => this.sample());
+    }
   }
 
-  private observeHeadings(
-    headings: readonly DocHeading[]
-  ): IntersectionObserver | undefined {
-    const order = headings.map((heading) => heading.id);
-    const elements = order
-      .map((id) => this.document.getElementById(id))
-      .filter((element): element is HTMLElement => element !== null);
-
-    if (elements.length === 0) {
-      return undefined;
+  /**
+   * Takes one reading of where the headings are and marks the current one.
+   *
+   * Reads a position for every heading rather than tracking what changed, so
+   * the answer never depends on which sample happened to notice what — see the
+   * note at the top of active-heading.ts.
+   */
+  private sample(): void {
+    const headings = this.headings();
+    if (headings.length === 0) {
+      return;
     }
 
-    const rootFontSize = this.rootFontSize();
-    const bandTop = activeBandTopPx(rootFontSize);
-    const [first] = elements;
+    const positions = headings
+      .map((heading) => this.document.getElementById(heading.id))
+      .filter((element): element is HTMLElement => element !== null)
+      .map((element) => ({
+        id: element.id,
+        top: element.getBoundingClientRect().top,
+      }));
 
-    const observer = new IntersectionObserver(
-      (entries) =>
-        this.activeId.update((current) =>
-          nextActiveHeading(
-            current,
-            entries.map((entry) => ({
-              id: entry.target.id,
-              isIntersecting: entry.isIntersecting,
-            })),
-            order,
-            // Only read when nothing is in the band, which is the one case
-            // where the answer matters and the observer cannot supply it.
-            first.getBoundingClientRect().top > bandTop
-          )
-        ),
-      { rootMargin: activeBandRootMargin(rootFontSize) }
+    if (positions.length === 0) {
+      return;
+    }
+
+    const container = resolveScrollContainer(this.document);
+    const atBottom =
+      scrolls(container) &&
+      container.scrollTop + container.clientHeight >=
+        container.scrollHeight - BOTTOM_SLACK;
+
+    this.activeId.set(
+      activeHeadingAt(positions, activeBandTopPx(this.rootFontSize()), atBottom)
     );
-
-    for (const element of elements) {
-      observer.observe(element);
-    }
-    return observer;
   }
 
-  /** The px value of 1rem, which is what the band has to be expressed in. */
+  /** The px value of 1rem, which is what the band is measured in. */
   private rootFontSize(): number {
     const view = this.document.defaultView;
     const size = view

--- a/src/app/documentation/doc-toc/doc-toc.component.ts
+++ b/src/app/documentation/doc-toc/doc-toc.component.ts
@@ -1,11 +1,23 @@
+import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import {
+  afterNextRender,
   ChangeDetectionStrategy,
   Component,
   computed,
+  effect,
+  inject,
+  Injector,
   input,
+  PLATFORM_ID,
+  signal,
 } from '@angular/core';
 import { RouterLink } from '@angular/router';
 import { DOC_OUTLINE, DocHeading } from '../generated/docs-outline';
+import {
+  activeBandRootMargin,
+  activeBandTopPx,
+  nextActiveHeading,
+} from './active-heading';
 
 /**
  * The fewest entries worth a table of contents.
@@ -16,12 +28,22 @@ import { DOC_OUTLINE, DocHeading } from '../generated/docs-outline';
 const MINIMUM_ENTRIES = 3;
 
 /**
+ * Known limit of the band built by `activeBandRootMargin`: a final section
+ * shorter than the remaining viewport can never reach it, so the rail keeps the
+ * previous heading marked at the very bottom of such a page. Closing that needs
+ * scroll-position plumbing on top of the observer, which costs more than the
+ * case is worth.
+ */
+
+/**
  * "On this page" — the per-page table of contents.
  *
  * The headings come from `DOC_OUTLINE`, generated from the same Markdown the
- * page was compiled from. Nothing here reads the DOM: the docs are prerendered,
- * so a scraped TOC would be missing from the HTML a crawler and a cold-cache
- * reader receive, and would depend on the page component having mounted.
+ * page was compiled from. Nothing here reads the DOM to BUILD the list: the
+ * docs are prerendered, so a scraped TOC would be missing from the HTML a
+ * crawler and a cold-cache reader receive, and would depend on the page
+ * component having mounted. The DOM is only consulted to find where those
+ * known headings currently sit on screen.
  */
 @Component({
   selector: 'app-doc-toc',
@@ -48,4 +70,95 @@ export class DocTocComponent {
 
   /** The route to link to. Fragments are navigations, so they need the path. */
   readonly route = computed(() => `/${this.path()}`);
+
+  /**
+   * The heading the reader is currently under, or null before they reach the
+   * first one. Writable so a test can drive the rendering without scrolling a
+   * real viewport; the observer below is the only production writer.
+   */
+  readonly activeId = signal<string | null>(null);
+
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly document = inject(DOCUMENT);
+  private readonly injector = inject(Injector);
+
+  constructor() {
+    effect((onCleanup) => {
+      const headings = this.headings();
+      this.activeId.set(null);
+
+      if (
+        !isPlatformBrowser(this.platformId) ||
+        headings.length === 0 ||
+        typeof IntersectionObserver === 'undefined'
+      ) {
+        return;
+      }
+
+      let observer: IntersectionObserver | undefined;
+      // The headings belong to the routed page component, a sibling of this one
+      // in the shell, so they are not in the DOM yet when this effect runs on a
+      // navigation. afterNextRender waits for the outlet to have swapped.
+      const pending = afterNextRender(
+        () => (observer = this.observeHeadings(headings)),
+        { injector: this.injector }
+      );
+
+      onCleanup(() => {
+        pending.destroy();
+        observer?.disconnect();
+      });
+    });
+  }
+
+  private observeHeadings(
+    headings: readonly DocHeading[]
+  ): IntersectionObserver | undefined {
+    const order = headings.map((heading) => heading.id);
+    const elements = order
+      .map((id) => this.document.getElementById(id))
+      .filter((element): element is HTMLElement => element !== null);
+
+    if (elements.length === 0) {
+      return undefined;
+    }
+
+    const rootFontSize = this.rootFontSize();
+    const bandTop = activeBandTopPx(rootFontSize);
+    const [first] = elements;
+
+    const observer = new IntersectionObserver(
+      (entries) =>
+        this.activeId.update((current) =>
+          nextActiveHeading(
+            current,
+            entries.map((entry) => ({
+              id: entry.target.id,
+              isIntersecting: entry.isIntersecting,
+            })),
+            order,
+            // Only read when nothing is in the band, which is the one case
+            // where the answer matters and the observer cannot supply it.
+            first.getBoundingClientRect().top > bandTop
+          )
+        ),
+      { rootMargin: activeBandRootMargin(rootFontSize) }
+    );
+
+    for (const element of elements) {
+      observer.observe(element);
+    }
+    return observer;
+  }
+
+  /** The px value of 1rem, which is what the band has to be expressed in. */
+  private rootFontSize(): number {
+    const view = this.document.defaultView;
+    const size = view
+      ? parseFloat(
+          view.getComputedStyle(this.document.documentElement).fontSize
+        )
+      : NaN;
+    return Number.isFinite(size) && size > 0 ? size : 16;
+  }
 }

--- a/src/app/documentation/docs-scroll-container.spec.ts
+++ b/src/app/documentation/docs-scroll-container.spec.ts
@@ -1,0 +1,56 @@
+import { resolveScrollContainer, scrolls } from './docs-scroll-container';
+import { scrollPercentOf } from './docs-telemetry.service';
+
+describe('resolveScrollContainer', () => {
+  /**
+   * A stand-in for the shell's `mat-sidenav-content`. Only the three geometry
+   * properties the resolver reads are needed, and a real element cannot be made
+   * to report an arbitrary scrollHeight without laying out the whole shell.
+   */
+  const fakeDoc = (content: Partial<HTMLElement> | null): Document => {
+    const documentElement = { tagName: 'HTML' } as HTMLElement;
+    return {
+      documentElement,
+      querySelector: () => content,
+    } as unknown as Document;
+  };
+
+  it('uses the sidenav content when it is the element that scrolls', () => {
+    const content = { scrollHeight: 5000, clientHeight: 800 } as HTMLElement;
+
+    expect(resolveScrollContainer(fakeDoc(content))).toBe(content);
+  });
+
+  it('falls back to the document when the sidenav content does not scroll', () => {
+    // The desktop docs shell: the container is as tall as the article, so it
+    // has no scroll range of its own and the document is what moves.
+    const content = { scrollHeight: 8997, clientHeight: 8997 } as HTMLElement;
+    const doc = fakeDoc(content);
+
+    expect(resolveScrollContainer(doc)).toBe(doc.documentElement);
+  });
+
+  it('falls back to the document when there is no sidenav at all', () => {
+    const doc = fakeDoc(null);
+
+    expect(resolveScrollContainer(doc)).toBe(doc.documentElement);
+  });
+
+  it('does not treat a sub-pixel difference as a scroll range', () => {
+    const content = { scrollHeight: 800.5, clientHeight: 800 } as HTMLElement;
+
+    expect(scrolls(content)).toBeFalse();
+  });
+
+  it('keeps scroll depth from reading 100% on a container that cannot scroll', () => {
+    // Why the fallback matters rather than being tidier. scrollPercentOf reads
+    // "no scroll range" as fully read, which is right for a short page and
+    // wrong for the wrong element — picking a container that merely exists
+    // reported every desktop docs visit as 100% read.
+    const stuck = { scrollHeight: 8997, clientHeight: 8997, scrollTop: 0 };
+    expect(scrollPercentOf(stuck)).toBe(100);
+
+    const real = { scrollHeight: 9000, clientHeight: 900, scrollTop: 0 };
+    expect(scrollPercentOf(real)).toBe(0);
+  });
+});

--- a/src/app/documentation/docs-scroll-container.ts
+++ b/src/app/documentation/docs-scroll-container.ts
@@ -1,0 +1,31 @@
+/**
+ * Which element the docs shell actually scrolls.
+ *
+ * There is no single answer, which is why this is a function and not a
+ * selector. `mat-sidenav-content` scrolls only when the sidenav container is
+ * height-constrained; when it is not, the container is as tall as the article
+ * and the document scrolls instead. The shell has been through both shapes, so
+ * asking which element overflows is the only reading that stays true — an
+ * out-of-date assumption here is invisible, because both candidates exist in
+ * the DOM either way and neither one throws.
+ *
+ * That invisibility has already cost something. The scroll-depth telemetry
+ * assumed `mat-sidenav-content` and got an element whose `scrollHeight` equals
+ * its `clientHeight`, which `scrollPercentOf` reads as "nothing to scroll,
+ * therefore fully read" — so every desktop docs visit reported 100%.
+ */
+export function resolveScrollContainer(doc: Document): HTMLElement {
+  const content = doc.querySelector?.<HTMLElement>('mat-sidenav-content');
+  if (content && scrolls(content)) {
+    return content;
+  }
+  return doc.documentElement;
+}
+
+/**
+ * Whether an element has anywhere to scroll. The one-pixel slack absorbs the
+ * sub-pixel difference a fractional layout can leave between the two.
+ */
+export function scrolls(element: HTMLElement): boolean {
+  return element.scrollHeight > element.clientHeight + 1;
+}

--- a/src/app/documentation/docs-scroll-container.ts
+++ b/src/app/documentation/docs-scroll-container.ts
@@ -29,3 +29,24 @@ export function resolveScrollContainer(doc: Document): HTMLElement {
 export function scrolls(element: HTMLElement): boolean {
   return element.scrollHeight > element.clientHeight + 1;
 }
+
+/**
+ * Selector for the navigation drawer itself, as opposed to the content beside
+ * it. `mat-sidenav-content` is a SIBLING of `mat-sidenav`, not a descendant, so
+ * this cleanly separates the two.
+ */
+const DRAWER = 'mat-sidenav, mat-drawer';
+
+/**
+ * Whether a scroller belongs to the navigation drawer rather than the article.
+ *
+ * Material registers the drawer's own `.mat-drawer-inner-container` as a
+ * `cdkScrollable` (see sidenav.mjs), so the CDK's scroll dispatcher reports the
+ * SIDEBAR moving exactly as it reports the article moving. On a phone the
+ * drawer is `mode="over"` with a navigation list longer than the screen, so
+ * this is not hypothetical: without the distinction, scrolling the menu to its
+ * end files a "read the whole article" measurement.
+ */
+export function isDrawerScroller(element: HTMLElement): boolean {
+  return element.closest?.(DRAWER) != null;
+}

--- a/src/app/documentation/docs-theme.scss
+++ b/src/app/documentation/docs-theme.scss
@@ -8,8 +8,10 @@
 
 :root {
   // Body text at a comfortable reading size, and a measure that keeps a line
-  // in the 45-75 character band the eye tracks without losing its place.
-  --docs-measure: 70ch;
+  // inside the 45-85 character band the eye tracks without losing its place.
+  // Near the upper half of that band on purpose: these pages carry tables,
+  // code blocks and screenshots that a tighter measure squeezes.
+  --docs-measure: 78ch;
   --docs-text: rgba(0, 0, 0, 0.87);
   --docs-text-muted: rgba(0, 0, 0, 0.6);
   --docs-rule: rgba(0, 0, 0, 0.12);

--- a/src/app/documentation/docs-typography.scss
+++ b/src/app/documentation/docs-typography.scss
@@ -11,8 +11,8 @@
 
 .docs-markdown {
   min-height: 70vh;
-  // The measure. Somewhere near 70 characters a line is long enough to carry a
-  // clause and short enough that the eye finds the start of the next one.
+  // The measure. At this width a line is long enough to carry a clause and
+  // short enough that the eye finds the start of the next one.
   max-width: var(--docs-measure);
   margin-inline: auto;
   color: var(--docs-text);

--- a/src/app/documentation/documentation.component.html
+++ b/src/app/documentation/documentation.component.html
@@ -48,6 +48,10 @@
             <app-ad></app-ad>
           </div>
         </div>
+
+        <!-- Last in the DOM: it is a shortcut, not part of the reading order,
+             and it is fixed-positioned so its place here costs no layout. -->
+        <app-doc-back-to-top />
       </div>
     </mat-sidenav-content>
   </mat-sidenav-container>

--- a/src/app/documentation/documentation.component.scss
+++ b/src/app/documentation/documentation.component.scss
@@ -86,9 +86,18 @@ h1.example-app-name {
 }
 
 /**
- * 1200px, not a Material breakpoint: the rail only earns its space once the
- * article still has the full measure beside it. Below that the TOC sits above
- * the prose, capped so a 27-entry page does not push the article off screen.
+ * 1200px, not a Material breakpoint.
+ *
+ * The docked sidebar takes ~300px of this before the article sees any of it, so
+ * at the breakpoint itself the article track is around 550px — near 70ch, not
+ * the 78ch measure. That is a deliberate trade, not an oversight: 70ch is the
+ * measure these pages shipped with and reads perfectly well, and setting the
+ * breakpoint where 78ch survives instead would put it past 1400px and take the
+ * rail away from every 1280px laptop. The measure is a target the article
+ * reaches on a wide screen, not a floor the layout guarantees.
+ *
+ * Below the breakpoint the TOC sits above the prose, capped so a 27-entry page
+ * does not push the article off screen.
  */
 @media (min-width: 1200px) {
   .docs-layout {

--- a/src/app/documentation/documentation.component.scss
+++ b/src/app/documentation/documentation.component.scss
@@ -35,7 +35,11 @@ h1.example-app-name {
 }
 
 .content {
-  padding: 10px;
+  // The horizontal padding only does work below the layout's own max-width;
+  // past that the centring gutters are wider than any padding would be. It
+  // scales so the article is not against the viewport edge on the tablet
+  // widths just under the rail breakpoint.
+  padding: 10px clamp(10px, 3vw, 32px);
   background-color: white;
 
   :host-context(html.dark-theme) & {
@@ -65,6 +69,14 @@ h1.example-app-name {
   grid-template-columns: minmax(0, 1fr);
   gap: 32px;
   align-items: start;
+  // The measure plus the rail plus the gap, with a little room to spare. Without
+  // a cap the grid runs the full window, so on a wide monitor the article
+  // centers itself inside an enormous left track while the rail stays pinned to
+  // the far edge — the reader sees a narrow column of prose with a chasm on
+  // either side of it. Capping the grid puts the leftover width outside BOTH
+  // columns instead of between them.
+  max-width: 1320px;
+  margin-inline: auto;
 }
 
 /**
@@ -82,27 +94,39 @@ h1.example-app-name {
     grid-row: 1;
   }
 
+  /**
+   * Lets the table of contents rail below actually stick.
+   *
+   * `position: sticky` resolves its offsets against the nearest ancestor
+   * scrollport. Material gives `.mat-drawer-container` `overflow: hidden` and
+   * `.mat-drawer-content` `overflow: auto`, so BOTH are scrollports — and on
+   * this page neither one scrolls: they are as tall as the article, and the
+   * document is what the reader actually scrolls. A sticky element measured
+   * against a box that never moves never sticks, which is why the rail rode up
+   * the page no matter what was done to the rail itself. Both have to be opened
+   * up; removing either alone changes nothing, because the other still sits
+   * between the rail and the viewport.
+   *
+   * Confined to the rail breakpoint. Below it the sidenav is `mode="over"` and
+   * `fixedInViewport`, where the clipping is doing real work, and there is no
+   * sticky rail to rescue anyway.
+   */
+  .example-sidenav-container.mat-drawer-container,
+  .example-sidenav-container > .mat-drawer-content {
+    overflow: visible;
+  }
+
   .docs-layout__toc {
     grid-column: 2;
     grid-row: 1;
+    // Overrides the grid's `align-items: start`, which is what the single-column
+    // layout wants but which collapses this item to the height of the contents
+    // list. A sticky child can only travel inside its containing block, so with
+    // no spare height the rail has nowhere to stick and rides up the page with
+    // the article. Stretching the item to the row height is what makes the
+    // `position: sticky` in doc-toc.component.scss do anything at all.
+    align-self: stretch;
   }
-}
-
-/**
- * The page furniture under the article shares the prose measure.
- *
- *  centres itself inside the column, so a full-width block
- * beneath it starts at a different left edge and the page reads as two
- * documents. A page that opts out of the measure (docs-getting-started runs
- * full width) keeps its footer at the measure, which is the intent: these are
- * navigation, not part of that page's layout.
- */
-.docs-layout__main > app-doc-related,
-.docs-layout__main > app-doc-page-nav,
-.docs-layout__main > app-doc-feedback {
-  display: block;
-  max-width: var(--docs-measure);
-  margin-inline: auto;
 }
 
 /**

--- a/src/app/documentation/documentation.component.scss
+++ b/src/app/documentation/documentation.component.scss
@@ -23,8 +23,14 @@ h1.example-app-name {
 }
 
 .example-sidenav-container {
-  /* When the sidenav is not fixed, stretch the sidenav container to fill the available space. This
-       causes `<mat-sidenav-content>` to act as our scrolling element for desktop layouts. */
+  /* Stretches the sidenav container to fill the available space when the sidenav
+     is not fixed.
+
+     This does NOT make `<mat-sidenav-content>` the scrolling element, which an
+     earlier version of this comment claimed: nothing here constrains the
+     container's height, so it grows to the full height of the article and the
+     document is what scrolls. Anything that needs the real scrolling element
+     has to ask which one overflows — see `docs-scroll-container.ts`. */
   flex: 1;
 }
 

--- a/src/app/documentation/documentation.component.spec.ts
+++ b/src/app/documentation/documentation.component.spec.ts
@@ -122,15 +122,31 @@ describe('DocumentationComponent telemetry', () => {
   let fixture: ComponentFixture<DocumentationComponent>;
 
   /** A CdkScrollable stand-in whose element reports the given geometry. */
+  /**
+   * A scroller the CDK dispatcher might report.
+   *
+   * A real element, not a geometry object: the component has to tell the
+   * article's scroller from the navigation drawer's, and that distinction is a
+   * question about where the element sits in the DOM. A bare stub cannot answer
+   * it, so it would let the sidebar bug through unnoticed.
+   */
   function scrollableAt(
     scrollTop: number,
     clientHeight: number,
-    scrollHeight: number
+    scrollHeight: number,
+    host: 'content' | 'drawer' = 'content'
   ): CdkScrollable {
+    const element = document.createElement('div');
+    Object.defineProperties(element, {
+      scrollTop: { value: scrollTop },
+      clientHeight: { value: clientHeight },
+      scrollHeight: { value: scrollHeight },
+    });
+    if (host === 'drawer') {
+      document.createElement('mat-sidenav').appendChild(element);
+    }
     return {
-      getElementRef: () => ({
-        nativeElement: { scrollTop, clientHeight, scrollHeight },
-      }),
+      getElementRef: () => ({ nativeElement: element }),
     } as unknown as CdkScrollable;
   }
 
@@ -217,12 +233,28 @@ describe('DocumentationComponent telemetry', () => {
     expect(component.currentSlug()).toBe('materials');
   });
 
-  it('reports scroll depth from the sidenav content, which scrolls on desktop', async () => {
+  it('reports scroll depth from the scroller the dispatcher names', async () => {
     await setup('/docs/prints');
 
     scrolled.next(scrollableAt(1600, 800, 4000));
 
     expect(telemetry.trackScrollDepth).toHaveBeenCalledWith(50, 'prints');
+  });
+
+  it('does not report scrolling the navigation drawer as reading the article', async () => {
+    // Material registers the drawer's inner container as a cdkScrollable, so
+    // the dispatcher reports the sidebar exactly as it reports the article. On
+    // a phone that list is longer than the screen; scrolling it to the end
+    // would otherwise file a 100% "read the whole page" measurement.
+    await setup('/docs/prints');
+    telemetry.trackScrollDepth.calls.reset();
+
+    // Geometry chosen to read as 50%: the fallback container in this test DOM
+    // has no scroll range and so reports 100, and asserting against 100 would
+    // pass whether the drawer was rejected or not.
+    scrolled.next(scrollableAt(1200, 600, 3000, 'drawer'));
+
+    expect(telemetry.trackScrollDepth).not.toHaveBeenCalledWith(50, 'prints');
   });
 
   it('samples depth on arrival, not only on scroll', async () => {

--- a/src/app/documentation/documentation.component.ts
+++ b/src/app/documentation/documentation.component.ts
@@ -26,7 +26,10 @@ import {
   buildDocBreadcrumb,
 } from '../core/structured-data/doc-schema';
 import { getDocSeoTags } from './doc-seo.config';
-import { resolveScrollContainer, scrolls } from './docs-scroll-container';
+import {
+  isDrawerScroller,
+  resolveScrollContainer,
+} from './docs-scroll-container';
 import { DocsSearchOpener } from './docs-search/docs-search.opener';
 import {
   isApplePlatform,
@@ -173,7 +176,11 @@ export class DocumentationComponent
   /**
    * Depth is sampled through the CDK dispatcher rather than a window listener
    * because which element scrolls depends on the layout, and the dispatcher
-   * reports both. `resolveScrollContainer` settles which one to read.
+   * reports every registered scroller.
+   *
+   * Which is also why what it reports has to be filtered: Material registers
+   * the drawer's own scroller alongside the content's, so "something scrolled"
+   * is not the same question as "how far into the article are we".
    */
   private trackScrollDepth(): void {
     this.scrollDispatcher
@@ -185,30 +192,41 @@ export class DocumentationComponent
   }
 
   /**
-   * Takes one depth reading. Also called on arrival: a page that fits on screen
-   * can never fire a scroll event, and without this would be reported as 0%
-   * read rather than fully read.
+   * Takes one depth reading of the article, whatever else on the page moved.
    *
-   * The element the dispatcher hands us is only trusted when it has somewhere
-   * to scroll. `scrollPercentOf` reads an element with no scroll range as 100%
-   * — right for a short page, badly wrong for the wrong element — so reading a
-   * container that merely exists reports every visit as fully read.
+   * Also called on arrival: a page that fits on screen can never fire a scroll
+   * event, and without this would be reported as 0% read rather than fully
+   * read. That fallback is why the element has to be right — `scrollPercentOf`
+   * reads anything with no scroll range as 100%, so measuring a container that
+   * merely exists reports every visit as fully read.
    */
   private sampleScrollDepth(scrollable?: CdkScrollable): void {
     if (!isPlatformBrowser(this.platformId)) {
       return;
     }
-    const reported = scrollable?.getElementRef().nativeElement;
-    const element =
-      reported && scrolls(reported)
-        ? reported
-        : resolveScrollContainer(this.document);
+    const element = this.articleScroller(scrollable);
     if (element) {
       this.telemetry.trackScrollDepth(
         scrollPercentOf(element),
         this.currentSlug()
       );
     }
+  }
+
+  /**
+   * The element whose position answers "how much of the article was read".
+   *
+   * The dispatcher's own report is used when it is the article moving, because
+   * it is the most direct answer available. A drawer scroller is discarded —
+   * that is the sidebar, not the page — and so is a missing one, leaving
+   * `resolveScrollContainer` to work it out from the layout.
+   */
+  private articleScroller(scrollable?: CdkScrollable): HTMLElement {
+    const reported = scrollable?.getElementRef().nativeElement;
+    if (reported && !isDrawerScroller(reported)) {
+      return reported;
+    }
+    return resolveScrollContainer(this.document);
   }
 
   private applySeoForUrl(url: string): void {

--- a/src/app/documentation/documentation.component.ts
+++ b/src/app/documentation/documentation.component.ts
@@ -26,6 +26,7 @@ import {
   buildDocBreadcrumb,
 } from '../core/structured-data/doc-schema';
 import { getDocSeoTags } from './doc-seo.config';
+import { resolveScrollContainer, scrolls } from './docs-scroll-container';
 import { DocsSearchOpener } from './docs-search/docs-search.opener';
 import {
   isApplePlatform,
@@ -171,8 +172,8 @@ export class DocumentationComponent
 
   /**
    * Depth is sampled through the CDK dispatcher rather than a window listener
-   * because the scrolling element differs by layout: `mat-sidenav-content`
-   * scrolls on desktop, the document scrolls on mobile (see the component SCSS).
+   * because which element scrolls depends on the layout, and the dispatcher
+   * reports both. `resolveScrollContainer` settles which one to read.
    */
   private trackScrollDepth(): void {
     this.scrollDispatcher
@@ -187,25 +188,27 @@ export class DocumentationComponent
    * Takes one depth reading. Also called on arrival: a page that fits on screen
    * can never fire a scroll event, and without this would be reported as 0%
    * read rather than fully read.
+   *
+   * The element the dispatcher hands us is only trusted when it has somewhere
+   * to scroll. `scrollPercentOf` reads an element with no scroll range as 100%
+   * — right for a short page, badly wrong for the wrong element — so reading a
+   * container that merely exists reports every visit as fully read.
    */
   private sampleScrollDepth(scrollable?: CdkScrollable): void {
     if (!isPlatformBrowser(this.platformId)) {
       return;
     }
-    const element = scrollable
-      ? scrollable.getElementRef().nativeElement
-      : (this.scrollContainer() ?? this.document.documentElement);
+    const reported = scrollable?.getElementRef().nativeElement;
+    const element =
+      reported && scrolls(reported)
+        ? reported
+        : resolveScrollContainer(this.document);
     if (element) {
       this.telemetry.trackScrollDepth(
         scrollPercentOf(element),
         this.currentSlug()
       );
     }
-  }
-
-  /** The element that actually scrolls: sidenav content on desktop, document on mobile. */
-  private scrollContainer(): HTMLElement | null {
-    return this.document.querySelector?.('mat-sidenav-content') ?? null;
   }
 
   private applySeoForUrl(url: string): void {

--- a/src/app/documentation/documentation.module.ts
+++ b/src/app/documentation/documentation.module.ts
@@ -9,6 +9,7 @@ import { DocsGettingStartedComponent } from './docs/docs-getting-started/docs-ge
 import { DocsReleaseNotesComponent } from './docs/docs-release-notes/docs-release-notes.component';
 import { DocumentationRoutingModule } from './documentation-routing.module';
 import { DocFeedbackComponent } from './doc-feedback/doc-feedback.component';
+import { DocBackToTopComponent } from './doc-back-to-top/doc-back-to-top.component';
 import { DocPageNavComponent } from './doc-page-nav/doc-page-nav.component';
 import { DocRelatedComponent } from './doc-related/doc-related.component';
 import { DocTocComponent } from './doc-toc/doc-toc.component';
@@ -44,6 +45,7 @@ import { DOCS_PAGE_COMPONENTS } from './generated/docs-declarations';
     DocFeedbackComponent,
     DocTocComponent,
     DocPageNavComponent,
+    DocBackToTopComponent,
     DocRelatedComponent,
     // Standalone, and imported here rather than by each page: a generated page
     // is declared by this module, so this module is its template scope.


### PR DESCRIPTION
Three commits that were written on `feat/docs-capture-harness` after #162's
branch tip was pushed. They never left the machine, so #162 merged without
them and `main` has the broken rail. This lands them unchanged.

## The rail did not stick

`main` sets `position: sticky` on the table of contents, and it has never
worked. Two independent reasons:

- **It binds to an element that never scrolls.** `mat-sidenav-content` and
  `mat-sidenav-container` both ship an `overflow` value, which makes them the
  nearest scrollable ancestor. Neither actually scrolls here — this shell never
  constrains its height, so the container grows to the full content height and
  `<html>` is the real scroller (`scrollHeight === clientHeight` on both).
  Sticky does not care that they never move; it stuck to one of them faithfully
  and the rail scrolled off with the page.
- **It had nowhere to travel.** `align-items: start` on the grid sizes the TOC's
  grid item to its content, which is the TOC. Travel of zero.

Scoped to the rail breakpoint. The sidenav is only in `over` mode below 600px,
so at these widths the drawer is always open and side-docked and there is no
off-canvas transform for the container to clip.

## The rail now follows the reader

`active-heading.ts` highlights the section you are actually looking at, reading
the reader's position on scroll rather than reacting to intersection changes —
the intersection approach could not answer "which heading am I under" when no
heading was on screen, which is most of the time on a long page.

Also included: a back-to-top control, and `docs-scroll-container.ts`, which
gives the scroll-depth telemetry the element that actually scrolls rather than
the one the layout comment claimed.

## Not the rail

`scripts/test-brief.sh` now prints `RESULT: PASSED` / `RESULT: FAILED` as its
last line. The script is documented to be piped, and a pipeline reports the exit
status of its last command, so `npm run test:brief | tail` silently discarded
the verdict. A compile error was the bad case: Karma never reaches a `TOTAL:`
line, so the output ended in a blank summary that read as a clean run.

## Verification

- `npm run lint:brief` clean; `npm run test:brief` 1575 passing (`RESULT: PASSED`).
- Checked in Chrome at 1500px on `/docs/materials`: the rail pins at 80px and
  stays there through the page, and the active entry tracks the scroll position
  through "How Remaining Material is Calculated" to "Temperatures" to
  "Loaded Material".
- Below 1200px the TOC is still the static index card and the overflow
  overrides do not apply; no horizontal overflow at either width.