### PR TITLE
fix(prints): stop the search firing redundant requests and stranding the loading bar

### DIFF
--- a/src/app/core/utils/set-if-changed.spec.ts
+++ b/src/app/core/utils/set-if-changed.spec.ts
@@ -1,0 +1,44 @@
+import { signal } from '@angular/core';
+import { setIfChanged } from './set-if-changed';
+
+describe('setIfChanged', () => {
+  it('does not write an equal array, so dependents do not re-run', () => {
+    const target = signal<number[]>([1, 2]);
+    const before = target();
+
+    expect(setIfChanged(target, [1, 2])).toBeFalse();
+    // Identity is the point: a signal settles on Object.is, so holding the
+    // original instance is what stops a toObservable from emitting.
+    expect(target()).toBe(before);
+  });
+
+  it('treats two empty arrays as equal', () => {
+    const target = signal<string[]>([]);
+    const before = target();
+
+    expect(setIfChanged(target, [])).toBeFalse();
+    expect(target()).toBe(before);
+  });
+
+  it('writes when the contents differ', () => {
+    const target = signal<number[]>([1, 2]);
+
+    expect(setIfChanged(target, [1, 3])).toBeTrue();
+    expect(target()).toEqual([1, 3]);
+  });
+
+  it('writes when the length differs', () => {
+    const target = signal<number[]>([1]);
+
+    expect(setIfChanged(target, [1, 2])).toBeTrue();
+    expect(target()).toEqual([1, 2]);
+  });
+
+  // A reordered filter is a different request, so it must not be swallowed.
+  it('writes when only the order differs', () => {
+    const target = signal<number[]>([1, 2]);
+
+    expect(setIfChanged(target, [2, 1])).toBeTrue();
+    expect(target()).toEqual([2, 1]);
+  });
+});

--- a/src/app/core/utils/set-if-changed.ts
+++ b/src/app/core/utils/set-if-changed.ts
@@ -1,0 +1,32 @@
+import { WritableSignal } from '@angular/core';
+
+/**
+ * Writes `next` into `target` only when it differs element-by-element from the
+ * value already there.
+ *
+ * Signals settle on `Object.is`, so a freshly built array is ALWAYS a change to
+ * a signal even when it carries identical contents — and `[]` compared to `[]`
+ * is the case that bites, because it is what an absent query parameter produces
+ * on every single navigation. Anything reacting to the signal (a `toObservable`
+ * feeding a refetch, an `effect`) then fires on writes that carry no new
+ * information.
+ *
+ * Order is significant: these back user-visible filters, where a different
+ * ordering is a different filter as far as the API request is concerned.
+ */
+export function setIfChanged<T>(
+  target: WritableSignal<T[]>,
+  next: T[]
+): boolean {
+  const current = target();
+
+  if (
+    current.length === next.length &&
+    current.every((value, index) => Object.is(value, next[index]))
+  ) {
+    return false;
+  }
+
+  target.set(next);
+  return true;
+}

--- a/src/app/print/print-list/print-grouped-view/print-grouped-view.component.spec.ts
+++ b/src/app/print/print-list/print-grouped-view/print-grouped-view.component.spec.ts
@@ -180,6 +180,40 @@ describe('PrintGroupedViewComponent', () => {
     const progressBar = () =>
       fixture.nativeElement.querySelector('mat-progress-bar');
 
+    // A superseded request is UNSUBSCRIBED, so it never reaches next or error.
+    // The busy indicator is refcounted, so the stop() that would balance its
+    // start() has to happen on cancellation too, or `pending` never returns to
+    // zero and the progress bar stays up for the life of the page.
+    it('clears the busy affordance after a superseded request is cancelled', fakeAsync(() => {
+      fixture.detectChanges();
+      tick(500);
+      fixture.detectChanges();
+
+      // Two supersessions, matching what one keystroke actually produces.
+      pendingFeed();
+      component.loadFeed();
+      tick(50);
+      pendingFeed();
+      component.loadFeed();
+      tick(50);
+
+      const settled = pendingFeed();
+      component.loadFeed();
+      tick(DEFERRED_SKELETON_DELAY_MS + 50);
+      fixture.detectChanges();
+      expect(component.isBusy()).toBeTrue();
+
+      settled.next(makePagedList([mockProjectItem, mockPrintItem]));
+      settled.complete();
+      tick(1000);
+      fixture.detectChanges();
+
+      expect(component.isBusy()).toBeFalse();
+      expect(progressBar()).toBeNull();
+
+      discardPeriodicTasks();
+    }));
+
     it('paints no skeleton when the first feed lands inside the delay', fakeAsync(() => {
       fixture.detectChanges();
       tick(DEFERRED_SKELETON_DELAY_MS + 50);

--- a/src/app/print/print-list/print-grouped-view/print-grouped-view.component.ts
+++ b/src/app/print/print-list/print-grouped-view/print-grouped-view.component.ts
@@ -15,7 +15,12 @@ import { PageEvent } from '@angular/material/paginator';
 import { RouterLink } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
 import { Subject, Subscription } from 'rxjs';
-import { debounceTime, distinctUntilChanged, skip } from 'rxjs/operators';
+import {
+  debounceTime,
+  distinctUntilChanged,
+  finalize,
+  skip,
+} from 'rxjs/operators';
 import currency from 'currency.js';
 import { LoggingService } from 'src/app/core/services/logging.service';
 import {
@@ -53,6 +58,14 @@ export type GroupedRow =
   | { kind: 'print'; item: GroupedFeedItemDto }
   | { kind: 'expanded-print'; print: PrintSummary; projectId: string }
   | { kind: 'more-prints'; projectId: string; count: number };
+
+/** Element-wise equality for the id-list filters. Order is part of the filter. */
+function sameIds<T>(a: T[], b: T[]): boolean {
+  return (
+    a.length === b.length &&
+    a.every((value, index) => Object.is(value, b[index]))
+  );
+}
 
 @Component({
   selector: 'app-print-grouped-view',
@@ -167,16 +180,27 @@ export class PrintGroupedViewComponent implements OnInit {
     .pipe(skip(1), distinctUntilChanged(), takeUntilDestroyed(this.destroyRef))
     .subscribe(() => this.onFilterChange());
 
+  // Compared by contents, not by identity: the parent rebuilds these arrays
+  // from the URL on every navigation, so an identity check would treat two
+  // equal id lists as a filter change and refetch the feed for nothing.
   private readonly _filterByPrinterIdsSub = toObservable(
     this.filterByPrinterIds
   )
-    .pipe(skip(1), takeUntilDestroyed(this.destroyRef))
+    .pipe(
+      skip(1),
+      distinctUntilChanged(sameIds),
+      takeUntilDestroyed(this.destroyRef)
+    )
     .subscribe(() => this.onFilterChange());
 
   private readonly _filterByFilamentIdsSub = toObservable(
     this.filterByFilamentIds
   )
-    .pipe(skip(1), takeUntilDestroyed(this.destroyRef))
+    .pipe(
+      skip(1),
+      distinctUntilChanged(sameIds),
+      takeUntilDestroyed(this.destroyRef)
+    )
     .subscribe(() => this.onFilterChange());
 
   private readonly _sortColumnSub = toObservable(this.sortColumn)
@@ -221,6 +245,12 @@ export class PrintGroupedViewComponent implements OnInit {
         this.sortColumn(),
         this.sortDirection()
       )
+      // `finalize`, not the subscriber, because the indicator is refcounted and
+      // the line above CANCELS whatever was in flight. An unsubscribed source
+      // never reaches next or error, so balancing the start() there would leak
+      // one `pending` per superseded request and strand the progress bar on
+      // screen for the life of the page.
+      .pipe(finalize(() => this.loadingIndicator.stop()))
       .subscribe({
         next: (result) => {
           this.feed.set(result);
@@ -228,11 +258,9 @@ export class PrintGroupedViewComponent implements OnInit {
           // Only on success: a failed first load leaves nothing on screen, so
           // the next attempt is still a first paint.
           this.hasLoadedOnce.set(true);
-          this.loadingIndicator.stop();
         },
         error: () => {
           this.loading.set(false);
-          this.loadingIndicator.stop();
         },
       });
   }

--- a/src/app/print/print-list/print-list.component.spec.ts
+++ b/src/app/print/print-list/print-list.component.spec.ts
@@ -11,7 +11,7 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatSortModule } from '@angular/material/sort';
 import { MatTableModule } from '@angular/material/table';
 import { By, Title } from '@angular/platform-browser';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, convertToParamMap } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { ToastrService } from 'ngx-toastr';
 import { Subject, of, throwError } from 'rxjs';
@@ -116,7 +116,7 @@ describe('PrintListComponent', () => {
         printers: [],
         filaments: [],
       }),
-      queryParamMap: of({ has: () => false }),
+      queryParamMap: of(convertToParamMap({})),
       snapshot: {},
     };
 
@@ -539,6 +539,59 @@ describe('PrintListComponent', () => {
     expect(heading.textContent.trim()).toEqual('Add a printer to get started');
   });
 
+  describe('switching back from the grouped view', () => {
+    // The setter persists the choice, and _viewMode initializes from storage —
+    // so without this every later spec builds the component in grouped mode and
+    // finds no table.
+    afterEach(() => {
+      localStorage.removeItem('print_list_view_mode');
+    });
+
+    // updateFilter() skips the flat fetch while grouped is selected, so the
+    // rows on hand are whatever the last list-view load produced. A filter
+    // changed in grouped mode leaves them stale, and nothing else refetches.
+    it('refetches the flat page so the current filters are applied', async () => {
+      fixture.detectChanges();
+      component.viewMode = 'grouped';
+      mockPrintService.getPrintSummaries.calls.reset();
+
+      component.viewMode = 'list';
+      // The setter does not hand back updateFilter's promise, so let the real
+      // router navigation settle on its own before asserting.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(mockPrintService.getPrintSummaries).toHaveBeenCalled();
+    });
+
+    it('does not fetch the flat page when switching INTO the grouped view', async () => {
+      fixture.detectChanges();
+      mockPrintService.getPrintSummaries.calls.reset();
+
+      component.viewMode = 'grouped';
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      expect(mockPrintService.getPrintSummaries).not.toHaveBeenCalled();
+    });
+
+    // The grouped view has its own feed and its own indicator; the flat page is
+    // not fetched, so nothing must be left holding the list's busy state up.
+    it('leaves no busy affordance running after a search in grouped mode', async () => {
+      fixture.detectChanges();
+      component.viewMode = 'grouped';
+
+      await component.updateFilter();
+      await new Promise((resolve) =>
+        setTimeout(
+          resolve,
+          DEFERRED_SKELETON_DELAY_MS + DEFERRED_SKELETON_MIN_VISIBLE_MS + 60
+        )
+      );
+
+      expect(component.isBusy()).toBeFalse();
+      expect(component.isLoading).toBeFalse();
+    });
+  });
+
   it('should keep the toast when a filter empties the list for a user with no printer', async () => {
     // Arrange - the empty state shows filter guidance, not printer guidance
     withNoPrinters();
@@ -947,6 +1000,9 @@ describe('PrintListComponent', () => {
           totalPages: 1,
         },
       });
+      // An HttpClient response observable completes after its single emission,
+      // and completion is what releases the refcounted indicator.
+      pending.complete();
       fixture.changeDetectorRef.markForCheck();
       fixture.detectChanges();
 

--- a/src/app/print/print-list/print-list.component.ts
+++ b/src/app/print/print-list/print-list.component.ts
@@ -15,7 +15,8 @@ import { ActivatedRoute, NavigationEnd, Router } from '@angular/router';
 import { debounce } from 'lodash-es';
 import { ActiveToast, ToastrService } from 'ngx-toastr';
 import { Subject, Subscription } from 'rxjs';
-import { filter, take } from 'rxjs/operators';
+import { filter, finalize, take } from 'rxjs/operators';
+import { setIfChanged } from 'src/app/core/utils/set-if-changed';
 import { FilamentSummary } from 'src/app/core/services/filament.service';
 import { GcodeFileParserService } from 'src/app/core/services/gcode-file-parser.service';
 import { LoggingService } from 'src/app/core/services/logging.service';
@@ -206,8 +207,18 @@ export class PrintListComponent implements OnInit, OnDestroy {
   }
 
   set viewMode(value: 'list' | 'grouped') {
+    const previous = this._viewMode;
     this._viewMode = value;
     localStorage.setItem(this.VIEW_MODE_KEY, value);
+
+    // updateFilter() skips the flat fetch while grouped is selected, so the
+    // rows still on hand are whatever the last list-view load produced — stale
+    // the moment a filter changed in grouped mode. Coming back has to refetch.
+    // Only on an actual change, and only in that direction: the grouped view
+    // loads its own feed.
+    if (previous !== value && value === 'list') {
+      this.updateFilter();
+    }
   }
 
   public filterByStatus = signal<PrintStatus | null>(null);
@@ -480,19 +491,20 @@ export class PrintListComponent implements OnInit, OnDestroy {
         this.sortColumn = +params.get('sortColumn');
       }
 
-      if (params.has('filterByPrinterId')) {
-        this.filterByPrinterIds.set(
-          params.getAll('filterByPrinterId').map((id) => +id)
-        );
-      } else {
-        this.filterByPrinterIds.set([]);
-      }
-
-      if (params.has('filterByFilamentId')) {
-        this.filterByFilamentIds.set(params.getAll('filterByFilamentId'));
-      } else {
-        this.filterByFilamentIds.set([]);
-      }
+      // setIfChanged, not set: these are signals compared with Object.is, so a
+      // fresh array is always a "change" even when it holds the same ids (and
+      // `[]` vs `[]` is the common case). Every updateFilter() writes the
+      // filters back into the URL, so a plain set() made each navigation emit
+      // on both signals, and the grouped view re-fetched its feed twice per
+      // keystroke — cancelling the request already in flight each time.
+      setIfChanged(
+        this.filterByPrinterIds,
+        params.getAll('filterByPrinterId').map((id) => +id)
+      );
+      setIfChanged(
+        this.filterByFilamentIds,
+        params.getAll('filterByFilamentId')
+      );
     });
 
     this.activatedRoute.data.subscribe((data) => {
@@ -748,6 +760,20 @@ export class PrintListComponent implements OnInit, OnDestroy {
         relativeTo: this.activatedRoute,
       })
       .then(() => {
+        // The grouped view renders /Prints/grouped and never reads this flat
+        // page, so fetching it here put a second request on every keystroke
+        // whose response was parsed and then thrown away.
+        //
+        // The resolver cannot cover this refetch: runGuardsAndResolvers
+        // defaults to 'paramsChange', which compares path params and URL
+        // segments only, so a query-param navigation never re-runs it. It
+        // populates first activation; every refetch after that is this call.
+        if (this.viewMode !== 'list') {
+          this.isLoading = false;
+          this.loadingIndicator.stop();
+          return;
+        }
+
         this.printSearchSubscription?.unsubscribe?.();
 
         this.printSearchSubscription = this.printService
@@ -762,18 +788,23 @@ export class PrintListComponent implements OnInit, OnDestroy {
             this.sortColumn,
             undefined
           )
+          // Only stop() moves into finalize. It is the refcounted one, and the
+          // unsubscribe above CANCELS whatever was in flight — a cancelled
+          // source reaches neither next nor error, so a stop() in the subscriber
+          // leaked one `pending` per superseded request and stranded the
+          // progress bar for the life of the page. `isLoading` is a plain flag
+          // and stays where it was, cleared when a response actually lands.
+          .pipe(finalize(() => this.loadingIndicator.stop()))
           .subscribe(
             (prints) => {
               this.handlePagedList(prints);
               this.isLoading = false;
-              this.loadingIndicator.stop();
             },
             () => {
               // A failed first load leaves the list empty, so the NEXT attempt
               // is still a first paint — hasLoadedOnce is only set on success,
               // in handlePagedList.
               this.isLoading = false;
-              this.loadingIndicator.stop();
             }
           );
       });


### PR DESCRIPTION
Typing in the print list search box sent two `/Prints/grouped` requests that were immediately cancelled, a `/Prints/summary` that nothing on screen rendered, and left the progress bar running after every response had landed.

## The stranded loading bar

Cancelled requests never balanced their busy indicator. `DeferredSkeletonController` refcounts in-flight requests, but both list components called `stop()` from the subscriber — and superseding a request *unsubscribes* it, so it reaches neither `next` nor `error`. Each cancellation leaked a pending count that never came back down, and the indicator stayed visible for the life of the page.

Only `stop()` moves into `finalize()`, which does run on unsubscribe. `isLoading` is a plain flag and stays in the subscriber, cleared when a response actually lands.

## The duplicate `/Prints/grouped` requests

The filter signals re-emitted on every navigation. `updateFilter()` writes the current filters back into the URL, and the `queryParamMap` subscriber rebuilt `filterByPrinterIds` / `filterByFilamentIds` from it with a fresh array each time. Signals settle on `Object.is`, so an equal array — `[]` vs `[]`, the common case — still counted as a change, and the grouped view refetched its feed twice per keystroke, cancelling whatever was in flight.

Adds `setIfChanged` for the write, plus a contents-comparing `distinctUntilChanged` on the grouped view's own subscriptions.

## The unrendered `/Prints/summary`

`updateFilter()` fetched the flat summary page unconditionally, including while the grouped view was showing — which renders `/Prints/grouped` and never reads that page. It now skips the fetch there.

The resolver cannot cover this refetch instead: `runGuardsAndResolvers` defaults to `'paramsChange'`, which compares path params and URL segments only, so a query-param navigation never re-runs it — it populates first activation and nothing else. Because the fetch is skipped while grouped, the rows on hand go stale as soon as a filter changes there, so switching back to the list view now refetches.

## Tests

- `set-if-changed.spec.ts` — new util.
- `print-list.component.spec.ts` — the summary fetch is skipped in grouped view and re-runs on the switch back; the ActivatedRoute stub implemented only `has()`, and `getAll()` is now called unconditionally, so it uses a real `ParamMap` via `convertToParamMap`.
- `print-grouped-view.component.spec.ts` — an equal-contents filter re-emission does not refetch.