### PR TITLE
release: v1.50.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "print-log-ui",
-  "version": "1.49.1",
+  "version": "1.50.0",
   "scripts": {
     "ng": "ng",
     "start": "node scripts/build-docs.mjs --quiet --watch --then ng serve --ssl --host 0.0.0.0",

--- a/src/app/core/services/version-release-note-dialog.service.ts
+++ b/src/app/core/services/version-release-note-dialog.service.ts
@@ -28,6 +28,37 @@ export class VersionReleaseNoteDialogService {
   private readonly LOCAL_STORAGE_KEY = 'LastLoggedInVersion';
 
   private releaseNotes: ReleaseNoteHistory = {
+    '1.50.0': {
+      title: '1.50.0 - Project Dates & A New Look',
+      body: `<p>
+<strong>Project start and finish dates</strong> are here! Every project now shows when it started and when it wrapped up, based on the prints it contains, and you can pin either date by hand from the project edit form when the prints do not tell the whole story. This one came in as a user suggestion, so thank you for sending it in!
+</p>
+<p>
+The <strong>home page</strong> and the <strong>documentation</strong> have both been redesigned. Docs pages now have search, a contents rail that follows you as you scroll, and screenshots captured from the real app. Every old documentation link still works.
+</p>
+<p>
+Got an idea of your own? <a href="/feedback">Send in your feedback</a> and help shape what comes next.
+</p>
+<p>
+  <strong>Support development of 3D Print Log:</strong><br />
+  <a href="/subscription">Subscribe to Pro</a> for an ad-free experience and extra cloud storage,
+  buy me a coffee by <a
+    href="https://paypal.me/hoffmanengineering"
+    rel="noreferrer noopener"
+    target="_blank"
+    >donating via PayPal</a
+  >, or by becoming a
+  <a
+    href="https://www.patreon.com/HoffmanEngineering"
+    rel="noreferrer noopener"
+    target="_blank"
+  >
+    Patron of Hoffman Engineering</a
+  >
+  on Patreon.com
+  </p><p>Share <strong>3D Print Log</strong> with a friend, and Happy Printing!
+</p>`,
+    },
     '1.49.1': {
       redirect: '1.49.0',
     },

--- a/src/content/docs-anchors.json
+++ b/src/content/docs-anchors.json
@@ -56,6 +56,7 @@
   "docs/klipper": ["Setup"],
   "docs/slic3r-uploader": [],
   "docs/release-notes": [
+    "v1.50.0",
     "v1.49.1",
     "v1.49.0",
     "v1.48.1",

--- a/src/content/release-notes/1.50.0.md
+++ b/src/content/release-notes/1.50.0.md
@@ -1,0 +1,26 @@
+---
+version: 1.50.0
+date: 2026-09-03
+title: 'Project Dates & A New Look'
+---
+
+**Project start and finish dates** now appear on every project. The dates are derived from the prints in the project, so an existing project already has them without you touching anything, and the project edit form lets you pin either end by hand when the prints do not tell the whole story (a project you started designing weeks before the first test print, or one you consider finished even though you printed a spare part later). This one came in as a user suggestion, so thank you for sending it in. See [Projects](/docs/projects) for how the automatic dates are derived and when a manual date takes over.
+
+The **home page** has been rebuilt around the product itself. Real screenshots of the app are visible right away instead of a wall of text, the feature sections are laid out to be read rather than scanned, and the whole page now follows your light or dark theme properly.
+
+The **documentation** got the larger rebuild. Every page is now written in Markdown and rendered through a shared design system, with a contents rail that follows you as you scroll, previous and next links at the bottom of each page, and search across the whole site. Pages are grouped by what you are trying to do, the material documentation was split so the field reference lives on its own page, and there is a proper start-to-finish tutorial for logging your first print. Screenshots throughout are captured from the real app and can carry numbered callouts that point at what the text is describing. Every old documentation link still works.
+
+#### Full List of Changes:
+
+- **Project start and finish dates** - Projects now show a start and finish date, derived from the prints they contain. ([PR #137](https://github.com/HoffmanEngineering/3d-print-log-ui/pull/137), [API PR #106](https://github.com/HoffmanEngineering/3d-print-log-api/pull/106))
+- **Manual date overrides** - The project edit form lets you pin the start date, the finish date, or both, and an unrelated edit will not silently clear a date you pinned. ([PR #137](https://github.com/HoffmanEngineering/3d-print-log-ui/pull/137), [API PR #106](https://github.com/HoffmanEngineering/3d-print-log-api/pull/106))
+- **Dates are no longer shifted by your time zone** - A date you type is saved as the day you typed, rather than landing on the previous day for anyone west of UTC. ([PR #137](https://github.com/HoffmanEngineering/3d-print-log-ui/pull/137))
+- **Redesigned home page** - The print list, materials and analytics screens are shown above the fold, creating a free account is a single click, and the page is themed properly in both light and dark mode. ([PR #166](https://github.com/HoffmanEngineering/3d-print-log-ui/pull/166))
+- **Faster, lighter home page images** - The home page screenshots are now generated automatically from the real app, and weigh less than the old ones despite there being more of them. ([PR #65](https://github.com/HoffmanEngineering/3d-print-log-ui/pull/65), [PR #166](https://github.com/HoffmanEngineering/3d-print-log-ui/pull/166))
+- **Search across the documentation** - A search box on `/docs` finds pages and sections as you type. ([PR #160](https://github.com/HoffmanEngineering/3d-print-log-ui/pull/160))
+- **Redesigned documentation pages** - Docs pages share one visual design, with a per-page contents rail and previous/next links between related pages. ([PR #161](https://github.com/HoffmanEngineering/3d-print-log-ui/pull/161))
+- **The contents rail follows you** - The list of sections on a docs page stays on screen as you scroll and highlights the section you are reading. ([PR #167](https://github.com/HoffmanEngineering/3d-print-log-ui/pull/167))
+- **Documentation reorganized** - Pages are grouped by what you are trying to do, the material documentation is split into a guide and a field reference, and `/docs/log-your-first-print` walks you through logging a print from start to finish. Old links and bookmarks continue to work. ([PR #169](https://github.com/HoffmanEngineering/3d-print-log-ui/pull/169))
+- **Screenshots in the documentation** - Doc figures are captured from the real app, so they stay current, and can carry numbered callouts that point at the part of the screen the text is talking about. ([PR #162](https://github.com/HoffmanEngineering/3d-print-log-ui/pull/162), [PR #170](https://github.com/HoffmanEngineering/3d-print-log-ui/pull/170))
+- **Documentation written in Markdown** - Every docs page is now a Markdown file, which makes pages faster to write, correct and keep up to date. ([PR #150](https://github.com/HoffmanEngineering/3d-print-log-ui/pull/150), [PR #159](https://github.com/HoffmanEngineering/3d-print-log-ui/pull/159))
+- **Snappier print list search** - Typing in the print list search box no longer sends duplicate requests or leaves the loading bar spinning after the results have arrived. ([PR #171](https://github.com/HoffmanEngineering/3d-print-log-ui/pull/171))


### PR DESCRIPTION
Release **v1.50.0** — *Project Dates & A New Look*.

- Bumps `package.json` to 1.50.0
- Adds `src/content/release-notes/1.50.0.md` (publishes anchor `#v1.50.0`, registered in `docs-anchors.json`)
- Registers the version in `version-release-note-dialog.service.ts`

Rebased on latest `main`; the release note covers everything merged for this version, including [#171](https://github.com/HoffmanEngineering/3d-print-log-ui/pull/171).