### PR TITLE
fix(parsers): calculate filament estimates for Nylon in slicer parsers

### DIFF
--- a/src/app/core/services/file-parsers/anycubic/anycubic-file-parser.service.spec.ts
+++ b/src/app/core/services/file-parsers/anycubic/anycubic-file-parser.service.spec.ts
@@ -46,6 +46,16 @@ describe('AnycubicFileParserService filament estimates', () => {
     service = TestBed.inject(AnycubicFileParserService);
   });
 
+  it('should compute the weight for Nylon using density 1.06', () => {
+    const testGcode = `; total filament used [g] = 0.0
+; filament_type = Nylon
+; filament_diameter = 1.75
+; filament used [mm] = 1000`;
+
+    const actual = service.estimateFilamentUsageInMg(testGcode);
+    expect(actual).toBe(2549);
+  });
+
   it('should return undefined when diameter or length is missing or zero', () => {
     const invalidInputs = [
       `; filament_type = PLA

--- a/src/app/core/services/file-parsers/anycubic/anycubic-file-parser.service.ts
+++ b/src/app/core/services/file-parsers/anycubic/anycubic-file-parser.service.ts
@@ -115,29 +115,23 @@ export class AnycubicFileParserService implements GcodeNewPrintParser {
       return undefined;
     }
 
-    if (filamentType.includes('PLA')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.PLA,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
-    } else if (filamentType.includes('ABS')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.ABS,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
-    } else if (filamentType.includes('PETG')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.PETG,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
+    const materials: Array<[string, number]> = [
+      ['PLA', MaterialDensities.materials.PLA],
+      ['ABS', MaterialDensities.materials.ABS],
+      ['PETG', MaterialDensities.materials.PETG],
+      ['Nylon', MaterialDensities.materials.Nylon],
+    ];
+
+    for (const [type, density] of materials) {
+      if (filamentType.includes(type)) {
+        return this.calculateWeightInMg(
+          density,
+          filamentUsageLengthInMM,
+          filamentDiameter
+        );
+      }
     }
 
-    // Only PLA, ABS and PETG are handled above, so anything else is unknown
-    // rather than zero. Note MaterialDensities also declares Nylon, which this
-    // chain never reaches -- see #100.
     return undefined;
   }
 

--- a/src/app/core/services/file-parsers/creality-print/creality-print-file-parser.service.spec.ts
+++ b/src/app/core/services/file-parsers/creality-print/creality-print-file-parser.service.spec.ts
@@ -59,6 +59,16 @@ Adaptive Layers:0`);
   });
 
   describe('estimateFilamentUsageInMg', () => {
+    it('should compute the weight for Nylon using density 1.06', () => {
+      const testGcode = `; total filament used [g] = 0.0
+; filament_type = Nylon
+; filament_diameter = 1.75
+; filament used [mm] = 1000`;
+
+      const actual = service.estimateFilamentUsageInMg(testGcode);
+      expect(actual).toBe(2549);
+    });
+
     it('should return undefined when diameter or length is missing or zero', () => {
       const invalidInputs = [
         `; filament_type = PLA

--- a/src/app/core/services/file-parsers/creality-print/creality-print-file-parser.service.ts
+++ b/src/app/core/services/file-parsers/creality-print/creality-print-file-parser.service.ts
@@ -115,29 +115,23 @@ export class CrealityPrintFileParserService implements GcodeNewPrintParser {
       return undefined;
     }
 
-    if (filamentType.includes('PLA')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.PLA,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
-    } else if (filamentType.includes('ABS')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.ABS,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
-    } else if (filamentType.includes('PETG')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.PETG,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
+    const materials: Array<[string, number]> = [
+      ['PLA', MaterialDensities.materials.PLA],
+      ['ABS', MaterialDensities.materials.ABS],
+      ['PETG', MaterialDensities.materials.PETG],
+      ['Nylon', MaterialDensities.materials.Nylon],
+    ];
+
+    for (const [type, density] of materials) {
+      if (filamentType.includes(type)) {
+        return this.calculateWeightInMg(
+          density,
+          filamentUsageLengthInMM,
+          filamentDiameter
+        );
+      }
     }
 
-    // Only PLA, ABS and PETG are handled above, so anything else is unknown
-    // rather than zero. Note MaterialDensities also declares Nylon, which this
-    // chain never reaches -- see #100.
     return undefined;
   }
 

--- a/src/app/core/services/file-parsers/orca/orca-file-parser.service.spec.ts
+++ b/src/app/core/services/file-parsers/orca/orca-file-parser.service.spec.ts
@@ -38,6 +38,16 @@ describe('OrcaFileParserService', () => {
   });
 
   describe('estimateFilamentUsageInMg', () => {
+    it('should compute the weight for Nylon using density 1.06', () => {
+      const testGcode = `; total filament used [g] = 0.0
+; filament_type = Nylon
+; filament_diameter = 1.75
+; filament used [mm] = 1000`;
+
+      const actual = service.estimateFilamentUsageInMg(testGcode);
+      expect(actual).toBe(2549);
+    });
+
     it('should return undefined when diameter or length is missing or zero', () => {
       const invalidInputs = [
         `; filament_type = PLA

--- a/src/app/core/services/file-parsers/orca/orca-file-parser.service.ts
+++ b/src/app/core/services/file-parsers/orca/orca-file-parser.service.ts
@@ -71,29 +71,23 @@ export class OrcaFileParserService implements GcodeNewPrintParser {
       return undefined;
     }
 
-    if (filamentType.includes('PLA')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.PLA,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
-    } else if (filamentType.includes('ABS')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.ABS,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
-    } else if (filamentType.includes('PETG')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.PETG,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
+    const materials: Array<[string, number]> = [
+      ['PLA', MaterialDensities.materials.PLA],
+      ['ABS', MaterialDensities.materials.ABS],
+      ['PETG', MaterialDensities.materials.PETG],
+      ['Nylon', MaterialDensities.materials.Nylon],
+    ];
+
+    for (const [type, density] of materials) {
+      if (filamentType.includes(type)) {
+        return this.calculateWeightInMg(
+          density,
+          filamentUsageLengthInMM,
+          filamentDiameter
+        );
+      }
     }
 
-    // Only PLA, ABS and PETG are handled above, so anything else is unknown
-    // rather than zero. Note MaterialDensities also declares Nylon, which this
-    // chain never reaches -- see #100.
     return undefined;
   }
 

--- a/src/app/core/services/file-parsers/prusa/prusa-slicer-file-parser.service.spec.ts
+++ b/src/app/core/services/file-parsers/prusa/prusa-slicer-file-parser.service.spec.ts
@@ -61,16 +61,14 @@ describe('PrusaSlicerFileParserService', () => {
       expect(service.estimateFilamentUsageInMg(testGcode)).toBeUndefined();
     });
 
-    // Characterizes existing behavior that is WRONG: a Nylon density is declared
-    // in MaterialDensities but the material chain never branches on it, so a
-    // valid Nylon file loses its estimate. Tracked in #100.
-    it('should currently return undefined for Nylon despite having its density', () => {
+    it('should compute the weight for Nylon using density 1.06', () => {
       const testGcode = `; total filament used [g] = 0.0
 ; filament_type = Nylon
 ; filament_diameter = 1.75
 ; filament used [mm] = 1000`;
 
-      expect(service.estimateFilamentUsageInMg(testGcode)).toBeUndefined();
+      const actual = service.estimateFilamentUsageInMg(testGcode);
+      expect(actual).toBe(2549);
     });
 
     it('should return undefined when the diameter is missing', () => {

--- a/src/app/core/services/file-parsers/prusa/prusa-slicer-file-parser.service.ts
+++ b/src/app/core/services/file-parsers/prusa/prusa-slicer-file-parser.service.ts
@@ -71,29 +71,23 @@ export class PrusaSlicerFileParserService implements GcodeNewPrintParser {
       return undefined;
     }
 
-    if (filamentType.includes('PLA')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.PLA,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
-    } else if (filamentType.includes('ABS')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.ABS,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
-    } else if (filamentType.includes('PETG')) {
-      return this.calculateWeightInMg(
-        MaterialDensities.materials.PETG,
-        filamentUsageLengthInMM,
-        filamentDiameter
-      );
+    const materials: Array<[string, number]> = [
+      ['PLA', MaterialDensities.materials.PLA],
+      ['ABS', MaterialDensities.materials.ABS],
+      ['PETG', MaterialDensities.materials.PETG],
+      ['Nylon', MaterialDensities.materials.Nylon],
+    ];
+
+    for (const [type, density] of materials) {
+      if (filamentType.includes(type)) {
+        return this.calculateWeightInMg(
+          density,
+          filamentUsageLengthInMM,
+          filamentDiameter
+        );
+      }
     }
 
-    // Only PLA, ABS and PETG are handled above, so anything else is unknown
-    // rather than zero. Note MaterialDensities also declares Nylon, which this
-    // chain never reaches -- see #100.
     return undefined;
   }
 


### PR DESCRIPTION
## Summary
Refactors the filament material estimation logic across all four slicer parsers (PrusaSlicer, OrcaSlicer, Creality Print, Anycubic) to evaluate `Nylon` (density 1.06 g/cm³) using a shared, cleanly ordered material lookup table.

## Problem
Although `MaterialDensities.materials` declares `Nylon: 1.06`, the `estimateFilamentUsageInMg` method in all four slicer parsers previously only checked `PLA`, `ABS`, and `PETG`. Consequently, gcode files sliced for Nylon with valid length and diameter metadata returned `undefined` for estimated filament usage.

## Solution
1. **Refactored Material Chain**: Unified duplicate `if/else` checks in `prusa-slicer-file-parser.service.ts`, `orca-file-parser.service.ts`, `creality-print-file-parser.service.ts`, and `anycubic-file-parser.service.ts` into a clean material lookup iteration supporting PLA, ABS, PETG, and Nylon.
2. **Maintained Substring Order**: Preserved `includes()` evaluation order (keeping `PETG` ahead of any future `PET` entries).
3. **Updated Unit Tests**:
   - `prusa-slicer-file-parser.service.spec.ts`: Replaced characterization test asserting `undefined` with positive test asserting weight estimate `2549` mg for 1000mm length at 1.75mm diameter.
   - `orca-file-parser.service.spec.ts`, `creality-print-file-parser.service.spec.ts`, `anycubic-file-parser.service.spec.ts`: Added Nylon estimation test cases.

## Testing & Validation
- `npm run typecheck:strict`: Clean (0 errors outside gate).
- `npm run test:scripts`: 415 passed in 877ms.
- `prettier`: Formatted and checked.

Closes #100
